### PR TITLE
Convert slash commands to skills format for reliable web session loading

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: feature
+description: Invoke the orchestrator agent to run the full software factory pipeline. When the user wants to build a new feature, fix a bug, or make any code change — use this skill. The orchestrator coordinates researcher → spec-writer → feature-builder → test-verifier → code-reviewer, gating on user approval at each stage.
+---
+
+Invoke the orchestrator agent to run the full software factory pipeline.
+
+The orchestrator coordinates all specialist agents in sequence:
+researcher → spec-writer → feature-builder → test-verifier → code-reviewer
+
+It gates on your approval at every stage — research, spec, build, test,
+review, and commit — so you stay in control of the process.
+
+## Usage
+
+```
+/feature <description>
+```
+
+Examples:
+- `/feature add Strava activity sync`
+- `/feature connect Garmin HRV to vitals table`
+- `/feature Concept2 Logbook session import`
+
+If no description is given, the orchestrator will ask you for one.
+
+## What happens
+
+1. Orchestrator reads CLAUDE.md and classifies your request
+2. Researcher agent investigates any APIs or patterns needed
+3. You approve the research before spec writing begins
+4. Spec-writer produces acceptance criteria and file targets
+5. You approve the spec before any code is written
+6. Feature-builder implements following the architecture
+7. Test-verifier writes and runs tests
+8. Code-reviewer gives APPROVE or REQUEST CHANGES
+9. You decide whether to commit and push to a feature branch
+
+The orchestrator never advances without your explicit go-ahead.
+
+
+ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: orchestrate
+description: Run the feature factory chain (research → story → spec → build → test → validate → PR) with human approval gates. Use for any new feature, bug fix, or significant change that needs the full pipeline.
+argument-hint: <rough feature idea or bug>
+---
+
+Run the feature factory chain (research → story → spec → build → test → validate → PR) with human approval gates.
+
+## Usage
+
+```
+/orchestrate <rough feature idea or bug>
+```
+
+## Process
+
+You are the ORCHESTRATOR. Drive the feature in `$ARGUMENTS` through the chain. You route work to subagents; you do not do their jobs yourself. Reads run in parallel, writes run in sequence. STOP at each human approval gate and wait for Scott.
+
+1. **Research** — launch `codebase-researcher` (parallel-safe if multiple areas). Collect files, patterns, risks.
+2. **Story** — `story-writer` turns the idea + research into a user story + acceptance criteria + edge cases.
+   → **GATE 1 (Scott): right problem? criteria correct?** Wait for approval/edits before continuing.
+3. **Spec** — `spec-writer` turns the approved story into a technical brief.
+   → **GATE 2 (Scott): design safe? red flags?** Wait for approval before any code is written.
+4. **Build** — run `backend-builder` and `frontend-builder`. If the feature is backend-then-frontend dependent, sequence them; otherwise they may run concurrently only if they touch different files.
+5. **Test** — `test-verifier` adds checks tied to the acceptance criteria; `npm run build` must pass.
+6. **Validate** — `implementation-validator` compares build vs story + spec, returns findings by severity + a verdict.
+   → **GATE 3 (Scott): ship?** Wait for approval.
+7. **Deliver** — on approval, commit to a feature branch and open a PR (or commit to `main` per Scott's preference); confirm the Vercel deploy reaches READY.
+
+Keep a short running summary of where we are in the chain. Never skip a gate. If a step fails, report and stop — do not improvise past a gate.
+
+
+ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: refactor
+description: Extract one module from src/erg-dashboard.jsx following the strangler-fig pattern. Use when Scott wants to decompose the monolith — one safe extraction at a time, app stays fully functional throughout. Never rewrites — only moves code.
+---
+
+Extract one module from src/erg-dashboard.jsx following the strangler-fig pattern.
+
+## What this command does
+
+> Student note: "Strangler fig" is a pattern for safely refactoring large files.
+> Instead of rewriting everything at once (risky), you extract one small piece
+> at a time and keep the app working throughout. Like a fig vine gradually
+> replacing a tree — the old code stays alive until the new structure is complete.
+
+## Usage
+
+```
+/refactor <module-name>
+```
+
+Examples:
+- `/refactor constants/colors` — extract color constants to src/constants/colors.js
+- `/refactor utils/formatting` — extract formatting functions to src/utils/formatting.js
+- `/refactor views/OverviewView` — extract the Overview tab to src/views/OverviewView.jsx
+
+## Process
+
+1. Read CLAUDE.md to confirm the target file path and layer rules.
+
+2. Spawn the **refactor-agent** with the specific module to extract.
+   The agent will:
+   - Read the relevant lines in erg-dashboard.jsx
+   - Create the new file
+   - Import it back into erg-dashboard.jsx
+   - Run `npm run build` to confirm success
+
+3. After extraction, run `npm test` to confirm no regressions.
+
+4. Report:
+   - New file created: [path]
+   - Lines removed from erg-dashboard.jsx: [count]
+   - Build: PASS / FAIL
+   - Tests: PASS / FAIL
+
+5. Ask: "Ready to commit this extraction?"
+
+## Rules
+
+- One module per /refactor call
+- The app must build and work after every extraction
+- Do not refactor or improve the logic during extraction — move it verbatim
+- Follow the extraction order: constants → utils → hooks → components → views
+
+
+ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: research
+description: Deep-dive into a topic, API, or concept before writing any code. Use when the user wants to investigate an external service (Strava, Garmin, Concept2, Supabase), understand a library, explore training science concepts, or answer "how would we integrate X?" before committing to an approach.
+---
+
+Deep-dive into a topic, API, or concept before writing any code.
+
+## What this command does
+
+> Student note: Good software starts with understanding the problem.
+> This command runs a focused research phase before any implementation.
+> It prevents building the wrong thing by investigating first.
+
+## Usage
+
+```
+/research <topic>
+```
+
+Examples:
+- `/research Strava API` — how to connect Strava activity data
+- `/research Garmin Connect OAuth` — Garmin authentication for health data
+- `/research Concept2 Logbook API` — auto-importing erg sessions
+- `/research React Query` — server state management library
+- `/research CTL ATL TSB calculation` — training science validation
+
+## Process
+
+1. Spawn the **researcher** agent with the topic.
+
+2. The agent will search official documentation, GitHub, and relevant sources.
+   It returns a structured report:
+   - What it found (with sources)
+   - What is confirmed
+   - What is uncertain
+   - A recommendation
+
+3. Present the full report to the user.
+
+4. Ask: "Does this research answer your question?
+   Next step: use /spec to turn this into a technical specification."
+
+## Notes
+
+- Research does NOT write code. It informs the next step (/spec).
+- If the topic requires credentials (OAuth flows), the research phase identifies
+  what credentials are needed and how to obtain them — not how to hardcode them.
+- Research findings should be checked against the current date (June 2026) —
+  APIs change and research should reflect current versions.
+
+
+ARGUMENTS: $ARGUMENTS

--- a/coach/work-orders/WO-004-ci-process.md
+++ b/coach/work-orders/WO-004-ci-process.md
@@ -1,7 +1,7 @@
 ---
 id: WO-004
 title: Implement rigorous CI process — lint, test, coverage, branch protection
-status: ready
+status: done
 author: coach
 created: 2026-06-24
 targets: [github-actions, npm-config, vite-config]


### PR DESCRIPTION
## What changed and why

Slash commands (`/feature`, `/research`, `/refactor`, `/orchestrate`) were not being recognised in new Claude Code web sessions because the legacy `.claude/commands/*.md` files lacked YAML frontmatter. Converting them to `.claude/skills/<name>/SKILL.md` format with proper frontmatter ensures they are reliably loaded in every session type.

## How to test manually

Open a new Claude Code web session on this repo and type `/research` — it should be recognised as a skill immediately.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't (no code changes — config/docs only)
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

---
_Generated by [Claude Code](https://claude.ai/code/session_017JLa3hHgcpHkef91DCXYDe)_