### PR TITLE
Add package-lock.json for reproducible installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "erg-dashboard",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "husky": "^9.1.7"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Claude-Session: https://claude.ai/code/session_01YWGSG2aEmWWJP4wk6p7cEn

## What changed and why

<!-- One sentence. What does this PR do and why is it needed? -->

## How to test manually

<!-- Only needed if the change isn't covered by CI tests. Delete if not applicable. -->

## Checklist

- [ ] CI is green (lint, test, build)
- [ ] Tests cover the change, or I've noted why they don't
- [ ] `npm run build` passes locally
- [ ] No unexpected console errors in the browser
