### PR TITLE
feat(security): RLS policies, user_id stamping, CSP headers

### DIFF
--- a/supabase/migrations/000_initial_schema.sql
+++ b/supabase/migrations/000_initial_schema.sql
@@ -1,0 +1,53 @@
+-- 000_initial_schema.sql
+-- Initial schema for erg-dashboard. Additive and idempotent.
+-- Reflects the columns the app already inserts at real insert sites.
+
+-- sessions: all workouts (erg, strength, cycling, rest)
+CREATE TABLE IF NOT EXISTS sessions (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid references auth.users(id),
+  date        date not null,
+  type        text not null,
+  label       text,
+  -- duration is kept as text on purpose: the app inserts an integer (minutes)
+  -- in some places and a trimmed text string (or null) in others. Using text
+  -- avoids silently dropping non-numeric values on insert.
+  duration    text,
+  srpe        numeric,
+  exercises   jsonb default '[]'::jsonb,
+  watts       numeric,
+  hr          numeric,
+  distance    numeric,
+  status      text default 'logged',
+  source      text,
+  -- prs: StrengthLogger sends a value here (currently a count integer); typed
+  -- as jsonb per the approved spec so it can hold structured PR data later.
+  prs         jsonb,
+  created_at  timestamptz default now()
+);
+
+-- vitals: daily health metrics
+CREATE TABLE IF NOT EXISTS vitals (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid references auth.users(id),
+  date        date not null,
+  rhr         numeric,
+  hrv         numeric,
+  sleep       numeric,
+  bodyweight  numeric,
+  created_at  timestamptz default now()
+);
+
+-- exercises: shared reference table for exercise definitions (no user_id)
+CREATE TABLE IF NOT EXISTS exercises (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null,
+  category    text,
+  created_at  timestamptz default now()
+);
+
+-- Defensive additive columns, in case the tables somehow pre-exist without them.
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS user_id uuid references auth.users(id);
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS prs jsonb;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS source text;
+ALTER TABLE vitals   ADD COLUMN IF NOT EXISTS user_id uuid references auth.users(id);

--- a/supabase/migrations/001_enable_rls.sql
+++ b/supabase/migrations/001_enable_rls.sql
@@ -1,0 +1,76 @@
+-- 001_enable_rls.sql
+-- Enable Row Level Security and add owner policies. Re-runnable.
+--
+-- The "8 policies" referenced in the spec are the owner policies on
+-- sessions + vitals (4 each). The exercises table is a shared reference
+-- table; it gets RLS enabled plus a single authenticated-read policy so it
+-- remains readable (without it, RLS would make the table unreadable).
+
+-- 1. Backfill user_id on existing rows BEFORE enabling RLS so no data is
+--    orphaned. Single-user app: assign to the earliest (only) auth user.
+UPDATE sessions
+  SET user_id = (SELECT id FROM auth.users ORDER BY created_at LIMIT 1)
+  WHERE user_id IS NULL;
+
+UPDATE vitals
+  SET user_id = (SELECT id FROM auth.users ORDER BY created_at LIMIT 1)
+  WHERE user_id IS NULL;
+
+-- 2. Enable RLS on all three tables.
+ALTER TABLE sessions  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vitals    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE exercises ENABLE ROW LEVEL SECURITY;
+
+-- 3. Owner policies (8 total: 4 sessions + 4 vitals).
+
+-- sessions ---------------------------------------------------------------
+DROP POLICY IF EXISTS sessions_select_own ON sessions;
+CREATE POLICY sessions_select_own ON sessions
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS sessions_insert_own ON sessions;
+CREATE POLICY sessions_insert_own ON sessions
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS sessions_update_own ON sessions;
+CREATE POLICY sessions_update_own ON sessions
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS sessions_delete_own ON sessions;
+CREATE POLICY sessions_delete_own ON sessions
+  FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- vitals -----------------------------------------------------------------
+DROP POLICY IF EXISTS vitals_select_own ON vitals;
+CREATE POLICY vitals_select_own ON vitals
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS vitals_insert_own ON vitals;
+CREATE POLICY vitals_insert_own ON vitals
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS vitals_update_own ON vitals;
+CREATE POLICY vitals_update_own ON vitals
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS vitals_delete_own ON vitals;
+CREATE POLICY vitals_delete_own ON vitals
+  FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- exercises (shared reference table): authenticated read only.
+-- Not counted in the 8 owner policies above.
+DROP POLICY IF EXISTS exercises_select_authenticated ON exercises;
+CREATE POLICY exercises_select_authenticated ON exercises
+  FOR SELECT
+  TO authenticated
+  USING (true);

--- a/web/src/erg-dashboard.jsx
+++ b/web/src/erg-dashboard.jsx
@@ -2777,6 +2777,9 @@ function LogSessionForm({ onSaved }) {
 
     setSaving(true);
     setMsg(null);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     const prs = filledRows.filter((r) => r.pr).length;
     const exercises = filledRows.map((r) => ({
       name: r.name.trim(),
@@ -2793,6 +2796,7 @@ function LogSessionForm({ onSaved }) {
       srpe,
       prs,
       exercises,
+      user_id: user?.id,
     });
     setSaving(false);
     if (error) {

--- a/web/src/hooks/useOfflineQueue.js
+++ b/web/src/hooks/useOfflineQueue.js
@@ -24,9 +24,13 @@ export function enqueueSession(session) {
 async function drainQueue() {
   const q = readQueue();
   if (q.length === 0) return;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   const failed = [];
   for (const session of q) {
-    const { _queuedAt, ...row } = session;
+    const { _queuedAt, ...rest } = session;
+    const row = { ...rest, user_id: rest.user_id ?? user?.id };
     const { error } = await supabase.from('sessions').insert(row);
     if (error) failed.push(session);
   }

--- a/web/src/views/ErgLiveView.jsx
+++ b/web/src/views/ErgLiveView.jsx
@@ -475,6 +475,9 @@ export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
 
   async function saveSession({ srpe, notes, date }) {
     setSaving(true);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     const row = {
       date,
       type: 'erg',
@@ -486,6 +489,7 @@ export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
       status: 'logged',
       source: 'bluetooth',
       exercises: notes ? [{ name: 'Notes', notes }] : [],
+      user_id: user?.id,
     };
 
     if (navigator.onLine) {

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -2,5 +2,32 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite",
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "geolocation=(), microphone=(), camera=()"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Cowork session work — three related security improvements shipped together:

- **RLS migration** (`supabase/migrations/001_enable_rls.sql`): backfills `user_id` on existing rows, enables Row Level Security on `sessions`/`vitals`/`exercises`, adds 8 owner policies + authenticated-read on the reference table
- **user_id stamping**: `LogSessionForm`, `ErgLiveView`, and `useOfflineQueue` now call `supabase.auth.getUser()` and attach `user_id` on every session insert — required for the RLS INSERT policy (`auth.uid() = user_id`) to pass
- **Security headers** (`web/vercel.json`): CSP, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`

## Before merging

- [ ] Apply `001_enable_rls.sql` to the Supabase project (run in SQL editor or via `supabase db push`)
- [ ] Verify existing sessions/vitals rows have `user_id` populated after backfill

## Test plan

- [ ] CI green
- [ ] Log a session — confirm it saves without RLS violation error
- [ ] Check Supabase dashboard — session rows should have `user_id` matching your auth UID

🤖 Generated with [Claude Code](https://claude.com/claude-code)