### PR TITLE
fix(mobile): live TSS aggregation, live recent-sessions list, mobile-view tests

### DIFF
--- a/web/src/hooks/__tests__/useTSSHistory.test.js
+++ b/web/src/hooks/__tests__/useTSSHistory.test.js
@@ -86,4 +86,29 @@ describe('useTSSHistory', () => {
     });
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
+
+  it('sums TSS for multiple sessions on the same day', async () => {
+    mockQuery([
+      { date: '2026-06-20', duration: 60, srpe: 6 }, // 6
+      { date: '2026-06-20', duration: 30, srpe: 8 }, // 4
+    ]);
+    const { result } = renderHook(() => useTSSHistory(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ date: '2026-06-20', tss: 10 }]);
+  });
+
+  it('rounds the per-day sum, not each session', async () => {
+    mockQuery([
+      { date: '2026-06-20', duration: 45, srpe: 6 }, // 4.5
+      { date: '2026-06-20', duration: 45, srpe: 6 }, // 4.5
+    ]);
+    const { result } = renderHook(() => useTSSHistory(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // 4.5 + 4.5 = 9.0 → 9, not round(4.5)+round(4.5) = 10
+    expect(result.current.data[0].tss).toBe(9);
+  });
 });

--- a/web/src/hooks/useTSSHistory.js
+++ b/web/src/hooks/useTSSHistory.js
@@ -13,10 +13,17 @@ export function useTSSHistory() {
         .gt('duration', 0)
         .order('date', { ascending: true });
       if (error) throw error;
-      return (data ?? []).map((s) => ({
-        date: s.date,
-        tss: Math.round((s.duration * s.srpe) / 60),
-      }));
+      // Sum TSS per day: multiple logged sessions on the same date must be
+      // combined. calcTrainingLoad keys its daily map by date, so emitting one
+      // row per session would let a later session overwrite an earlier one and
+      // silently drop that day's load. Sum raw, then round once.
+      const byDate = {};
+      for (const s of data ?? []) {
+        byDate[s.date] = (byDate[s.date] ?? 0) + (s.duration * s.srpe) / 60;
+      }
+      return Object.entries(byDate)
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+        .map(([date, tss]) => ({ date, tss: Math.round(tss) }));
     },
     staleTime: 300_000,
   });

--- a/web/src/test-setup.js
+++ b/web/src/test-setup.js
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom';
+
+// jsdom has no ResizeObserver, which recharts' ResponsiveContainer relies on.
+// Stub it so chart-bearing components can be rendered in tests.
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/web/src/views/mobile/MobileAnalytics.jsx
+++ b/web/src/views/mobile/MobileAnalytics.jsx
@@ -51,6 +51,28 @@ export default function MobileAnalytics() {
     month: 'short',
   });
 
+  // Recent sessions list: live logged sessions (newest first), falling back to
+  // the DAILY_TSS seed when the DB is empty (new install / offline).
+  const recentItems = useMemo(() => {
+    const live = (sessionsData ?? [])
+      .filter((s) => s.status !== 'planned')
+      .slice(0, 5)
+      .map((s) => ({
+        key: s.id,
+        label: s.label || s.type || 'Session',
+        date: s.date,
+        tss:
+          s.duration > 0 && s.srpe > 0
+            ? Math.round((s.duration * s.srpe) / 60)
+            : null,
+      }));
+    if (live.length) return live;
+    return DAILY_TSS.slice()
+      .reverse()
+      .slice(0, 5)
+      .map((s) => ({ key: s.date, label: s.note, date: s.date, tss: s.tss }));
+  }, [sessionsData]);
+
   return (
     <div style={{ padding: '16px 16px 24px', background: '#0a0a0f' }}>
       <div
@@ -276,30 +298,29 @@ export default function MobileAnalytics() {
         >
           RECENT SESSIONS
         </div>
-        {DAILY_TSS.slice()
-          .reverse()
-          .slice(0, 5)
-          .map((s) => (
-            <div
-              key={s.date}
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                padding: '10px 0',
-                borderBottom: '1px solid #4a4a6833',
-              }}
-            >
-              <span style={{ fontSize: 12, color: '#e8e8f0' }}>{s.note}</span>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: 10, color: '#7e7e9a' }}>{s.date}</div>
+        {recentItems.map((s) => (
+          <div
+            key={s.key}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              padding: '10px 0',
+              borderBottom: '1px solid #4a4a6833',
+            }}
+          >
+            <span style={{ fontSize: 12, color: '#e8e8f0' }}>{s.label}</span>
+            <div style={{ textAlign: 'right' }}>
+              <div style={{ fontSize: 10, color: '#7e7e9a' }}>{s.date}</div>
+              {s.tss != null && (
                 <div
                   style={{ fontSize: 12, fontWeight: 700, color: '#34d399' }}
                 >
                   {s.tss} TSS
                 </div>
-              </div>
+              )}
             </div>
-          ))}
+          </div>
+        ))}
       </div>
 
       {(() => {

--- a/web/src/views/mobile/__tests__/MobileAnalytics.test.jsx
+++ b/web/src/views/mobile/__tests__/MobileAnalytics.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const useSessionsMock = vi.fn();
+const useTSSHistoryMock = vi.fn();
+vi.mock('../../../hooks/useSessions.js', () => ({
+  useSessions: () => useSessionsMock(),
+}));
+vi.mock('../../../hooks/useTSSHistory.js', () => ({
+  useTSSHistory: () => useTSSHistoryMock(),
+}));
+
+import MobileAnalytics from '../MobileAnalytics.jsx';
+
+beforeEach(() => {
+  useSessionsMock.mockReset();
+  useTSSHistoryMock.mockReset();
+  useTSSHistoryMock.mockReturnValue({ data: [] });
+});
+
+describe('MobileAnalytics recent sessions', () => {
+  it('shows live logged sessions when available', () => {
+    useSessionsMock.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          date: '2026-06-24',
+          type: 'Erg',
+          label: 'Live row',
+          duration: 90,
+          srpe: 6,
+          status: 'logged',
+        },
+      ],
+    });
+    render(<MobileAnalytics />);
+    expect(screen.getByText('Live row')).toBeInTheDocument();
+    // 90 * 6 / 60 = 9
+    expect(screen.getByText('9 TSS')).toBeInTheDocument();
+    // the seed list should not be used when live data exists
+    expect(screen.queryByText('5k erg')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the DAILY_TSS seed when no live sessions exist', () => {
+    useSessionsMock.mockReturnValue({ data: [] });
+    render(<MobileAnalytics />);
+    expect(
+      screen.getByText('60min UT1 long row (sRPE 6 — first full hour)')
+    ).toBeInTheDocument();
+  });
+
+  it('excludes planned sessions from the recent list', () => {
+    useSessionsMock.mockReturnValue({
+      data: [
+        {
+          id: 2,
+          date: '2026-06-26',
+          type: 'Erg',
+          label: 'Planned row',
+          duration: 60,
+          srpe: 5,
+          status: 'planned',
+        },
+      ],
+    });
+    render(<MobileAnalytics />);
+    // A planned-only list yields no recent logged sessions, so the recent
+    // list falls back to the seed (the planned row surfaces under UPCOMING).
+    expect(
+      screen.getByText('60min UT1 long row (sRPE 6 — first full hour)')
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/views/mobile/__tests__/MobileRecovery.test.jsx
+++ b/web/src/views/mobile/__tests__/MobileRecovery.test.jsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const useVitalsMock = vi.fn();
+const useTSSHistoryMock = vi.fn();
+vi.mock('../../../hooks/useVitals.js', () => ({
+  useVitals: () => useVitalsMock(),
+}));
+vi.mock('../../../hooks/useTSSHistory.js', () => ({
+  useTSSHistory: () => useTSSHistoryMock(),
+}));
+
+import MobileRecovery from '../MobileRecovery.jsx';
+
+beforeEach(() => {
+  useVitalsMock.mockReset();
+  useTSSHistoryMock.mockReset();
+  useTSSHistoryMock.mockReturnValue({ data: [] });
+});
+
+describe('MobileRecovery', () => {
+  it('renders the loading state', () => {
+    useVitalsMock.mockReturnValue({
+      isLoading: true,
+      latest: null,
+      readinessScore: 0,
+      readinessLabel: 'READY',
+    });
+    render(<MobileRecovery />);
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  it('renders the no-vitals state', () => {
+    useVitalsMock.mockReturnValue({
+      isLoading: false,
+      latest: null,
+      readinessScore: 0,
+      readinessLabel: 'READY',
+    });
+    render(<MobileRecovery />);
+    expect(screen.getByText('No vitals recorded yet')).toBeInTheDocument();
+  });
+
+  it('renders readiness and metric cards including sleep score', () => {
+    useVitalsMock.mockReturnValue({
+      isLoading: false,
+      latest: { rhr: 55, hrv: 35, sleep: 7.5, sleep_score: 85 },
+      readinessScore: 88,
+      readinessLabel: 'READY',
+    });
+    render(<MobileRecovery />);
+    expect(screen.getByText('88')).toBeInTheDocument();
+    expect(screen.getByText('Train as planned')).toBeInTheDocument();
+    expect(screen.getByText('RESTING HR')).toBeInTheDocument();
+    expect(screen.getByText('SLEEP SCORE')).toBeInTheDocument();
+    expect(screen.getByText('85')).toBeInTheDocument();
+  });
+
+  it('falls back to the TSB card when sleep score is absent', () => {
+    useVitalsMock.mockReturnValue({
+      isLoading: false,
+      latest: { rhr: 55, hrv: 35, sleep: 7.5, sleep_score: null },
+      readinessScore: 70,
+      readinessLabel: 'CAUTION',
+    });
+    render(<MobileRecovery />);
+    expect(screen.getByText('FORM / TSB')).toBeInTheDocument();
+    expect(screen.queryByText('SLEEP SCORE')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/views/mobile/__tests__/MobileSessionLog.test.jsx
+++ b/web/src/views/mobile/__tests__/MobileSessionLog.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const useSessionsMock = vi.fn();
+vi.mock('../../../hooks/useSessions.js', () => ({
+  useSessions: () => useSessionsMock(),
+}));
+
+import MobileSessionLog from '../MobileSessionLog.jsx';
+
+beforeEach(() => useSessionsMock.mockReset());
+
+describe('MobileSessionLog', () => {
+  it('renders the loading state', () => {
+    useSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    render(<MobileSessionLog />);
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    useSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    });
+    render(<MobileSessionLog />);
+    expect(screen.getByText('Failed to load sessions')).toBeInTheDocument();
+  });
+
+  it('renders the empty state', () => {
+    useSessionsMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(<MobileSessionLog />);
+    expect(screen.getByText('No sessions found')).toBeInTheDocument();
+  });
+
+  it('lists sessions and filters by type', () => {
+    useSessionsMock.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          date: '2026-06-20',
+          type: 'Erg',
+          label: 'Morning row',
+          duration: 60,
+          srpe: 6,
+          avg_watts: 200,
+        },
+        {
+          id: 2,
+          date: '2026-06-19',
+          type: 'Strength',
+          label: 'Lower body',
+          duration: 45,
+          srpe: 7,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(<MobileSessionLog />);
+    expect(screen.getByText('Morning row')).toBeInTheDocument();
+    expect(screen.getByText('Lower body')).toBeInTheDocument();
+    expect(screen.getByText('2 logged')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Strength'));
+    expect(screen.queryByText('Morning row')).not.toBeInTheDocument();
+    expect(screen.getByText('Lower body')).toBeInTheDocument();
+  });
+});

--- a/web/src/views/mobile/__tests__/MobileStrength.test.jsx
+++ b/web/src/views/mobile/__tests__/MobileStrength.test.jsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const useStrengthPRsMock = vi.fn();
+vi.mock('../../../hooks/useStrengthPRs.js', () => ({
+  useStrengthPRs: () => useStrengthPRsMock(),
+}));
+vi.mock('../../../StrengthLogger.jsx', () => ({
+  default: () => <div>STRENGTH LOGGER VIEW</div>,
+}));
+
+import MobileStrength from '../MobileStrength.jsx';
+
+beforeEach(() => useStrengthPRsMock.mockReset());
+
+describe('MobileStrength', () => {
+  it('renders the loading state', () => {
+    useStrengthPRsMock.mockReturnValue({ data: undefined, isLoading: true });
+    render(<MobileStrength />);
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  it('renders the empty state', () => {
+    useStrengthPRsMock.mockReturnValue({ data: [], isLoading: false });
+    render(<MobileStrength />);
+    expect(
+      screen.getByText('No strength PRs yet — log your first session')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the PR grid', () => {
+    useStrengthPRsMock.mockReturnValue({
+      data: [
+        {
+          exercise_name: 'Back Squat',
+          best_e1rm_kg: 142.5,
+          heaviest_kg: 130,
+          logged_sets: 12,
+        },
+      ],
+      isLoading: false,
+    });
+    render(<MobileStrength />);
+    expect(screen.getByText('Back Squat')).toBeInTheDocument();
+    expect(screen.getByText('142.5kg')).toBeInTheDocument();
+    expect(screen.getByText('Heaviest: 130kg')).toBeInTheDocument();
+  });
+
+  it('opens the strength logger', () => {
+    useStrengthPRsMock.mockReturnValue({ data: [], isLoading: false });
+    render(<MobileStrength />);
+    fireEvent.click(screen.getByText('OPEN STRENGTH LOGGER'));
+    expect(screen.getByText('STRENGTH LOGGER VIEW')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes the two residual gaps in P2 (live-data analytics) that landed in `main` via PR #25, plus the missing mobile-view test coverage the cloud handover flagged.

## Changes
- **Gap A — TSS per-day aggregation (`useTSSHistory`)**: previously emitted one `{date, tss}` row per session. `calcTrainingLoad` keys its daily map by date, so two logged sessions on the same day silently dropped one. Now sums `duration*srpe/60` per date (raw, then rounds once) so same-day sessions combine correctly.
- **Gap B — live "recent sessions" list (`MobileAnalytics`)**: the RECENT SESSIONS list rendered the hardcoded `DAILY_TSS` seed. Now driven by live `useSessions` (`status !== 'planned'`, newest 5), falling back to the seed when the DB is empty (new install / offline).
- **Tests**: RTL tests for `MobileSessionLog`, `MobileStrength`, `MobileRecovery` (loading / empty / populated / interaction paths) and the `MobileAnalytics` recent-sessions live-vs-seed logic. Added a `ResizeObserver` stub to `test-setup.js` so recharts' `ResponsiveContainer` renders under jsdom.

## Verification
- `npm run lint` — 0 errors (2 pre-existing `usePM5.js` warnings, unrelated)
- `npm test` — **101 passing** (was 84; +2 aggregation, +15 mobile-view)
- `npm run build` — exits 0

No changes to `erg-dashboard.jsx` (desktop monolith) — deferred to avoid conflict with the parallel strangler-fig refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)