### PR TITLE
feat(coach): add Claude fitness coach chat tab

### DIFF
--- a/supabase/functions/coach-chat/index.ts
+++ b/supabase/functions/coach-chat/index.ts
@@ -1,0 +1,114 @@
+// coach-chat — streaming Anthropic API proxy for the fitness coach tab.
+//
+// Required secrets (set via Supabase Dashboard → Edge Functions → Secrets):
+//   ANTHROPIC_API_KEY  — Anthropic API key
+//
+// Deployed with JWT verification ON (default). The caller must send
+// Authorization: Bearer <supabase-session-token>.
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const MODEL_MAP: Record<string, string> = {
+  haiku: 'claude-haiku-4-5-20251001',
+  sonnet: 'claude-sonnet-4-6',
+};
+
+const COACH_SYSTEM_PROMPT = `You are Scott's personal rowing and strength coach. Scott is a 50+ recreational athlete in Perth, WA.
+
+ATHLETE PROFILE
+- Sport: indoor rowing (erg), strength, cycling
+- Season goal: compete at a rowing regatta, working toward Worlds Feb 2027
+- Current phase: Base (Jun–Aug 2026) — aerobic foundation only
+- Intensity rules: UT2 (<119bpm) and UT1 (119–136bpm) ONLY until Build 1 (Sep 2026). No threshold or VO2max intervals yet.
+- CP estimate: ~190W (untested; CP test scheduled 1 Jul 2026)
+- HR ceiling: 170bpm (MHR for training)
+- Drag factor: 125 standard
+- Polarised TID: 80% easy (Z2), 20% hard — but hard sessions deferred to Build 1
+
+STRENGTH
+- Compound-first: Back Squat, RDL, Bench Press, Barbell Row
+- Progressive overload weekly; concurrent aerobic+strength
+- Lower strength on Wed (two-a-day); Upper on separate days
+
+NUTRITION
+- TDEE ~3,140 kcal | protein floor 188g | fasted erg for Z2 base fat adaptation
+
+RESPONSE STYLE
+- Brief, direct, evidence-based. No filler phrases.
+- Use numbers: quote watts, HR, sRPE, TSB where relevant.
+- Numbered lists for multi-point answers.
+- If you're uncertain, say so — don't fabricate.
+- Stay within current phase. Don't prescribe intensity workouts until Build 1.`;
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: CORS_HEADERS });
+  }
+
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: 'ANTHROPIC_API_KEY not configured' }), {
+      status: 500,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { messages: Array<{ role: string; content: string }>; context?: string; model?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid JSON body' }), {
+      status: 400,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { messages, context = '', model = 'sonnet' } = body;
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return new Response(JSON.stringify({ error: 'messages array required' }), {
+      status: 400,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const resolvedModel = MODEL_MAP[model] ?? MODEL_MAP.sonnet;
+  const systemPrompt = context
+    ? `${COACH_SYSTEM_PROMPT}\n\nCURRENT TRAINING DATA:\n${context}`
+    : COACH_SYSTEM_PROMPT;
+
+  const upstream = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: resolvedModel,
+      max_tokens: 1024,
+      stream: true,
+      system: systemPrompt,
+      messages: messages.slice(-10).map((m) => ({ role: m.role, content: m.content })),
+    }),
+  });
+
+  if (!upstream.ok) {
+    const errorText = await upstream.text();
+    return new Response(errorText, {
+      status: upstream.status,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(upstream.body, {
+    headers: {
+      ...CORS_HEADERS,
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+    },
+    status: 200,
+  });
+});

--- a/supabase/migrations/002_coach_messages.sql
+++ b/supabase/migrations/002_coach_messages.sql
@@ -1,0 +1,23 @@
+-- 002_coach_messages.sql
+-- Chat history table for the Claude fitness coach feature.
+-- Messages are owner-only via RLS; no shared/public access.
+
+CREATE TABLE IF NOT EXISTS coach_messages (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid references auth.users not null default auth.uid(),
+  role        text not null check (role in ('user', 'assistant')),
+  content     text not null,
+  model       text,
+  created_at  timestamptz default now()
+);
+
+ALTER TABLE coach_messages ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS coach_messages_owner ON coach_messages;
+CREATE POLICY coach_messages_owner
+  ON coach_messages FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS coach_messages_user_created
+  ON coach_messages (user_id, created_at DESC);

--- a/web/src/erg-dashboard.jsx
+++ b/web/src/erg-dashboard.jsx
@@ -12,6 +12,7 @@ import { std, mean } from 'mathjs';
 import { supabase } from './supabaseClient.js';
 import StrengthLogger from './StrengthLogger.jsx';
 import ErgLiveView from './views/ErgLiveView.jsx';
+import CoachView from './views/CoachView.jsx';
 import WorkoutItem from './components/WorkoutItem.jsx';
 import LogSessionForm from './components/LogSessionForm.jsx';
 import LogEntry from './components/LogEntry.jsx';
@@ -2247,6 +2248,7 @@ export default function App() {
             ['recovery', 'Recovery'],
             ['log', 'Log'],
             ['journal', 'Journal'],
+            ['coach', 'Coach'],
           ].map(([v, label]) => (
             <button
               key={v}
@@ -9705,6 +9707,8 @@ export default function App() {
               </div>
             </>
           )}
+          {/* ── COACH VIEW (Claude fitness coach chat) ── */}
+          {view === 'coach' && <CoachView />}
         </ErrorBoundary>
 
         <div

--- a/web/src/hooks/__tests__/useCoach.test.js
+++ b/web/src/hooks/__tests__/useCoach.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock supabaseClient so the import of useCoach.js doesn't fail at module load time
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: vi.fn(),
+    auth: { getSession: vi.fn(), getUser: vi.fn() },
+  },
+}));
+
+// Mock @tanstack/react-query to provide useQueryClient
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: [] }),
+  useQueryClient: () => ({ setQueryData: vi.fn(), getQueryData: () => [] }),
+}));
+
+// Mock child hooks so useCoach.js can be imported without a QueryClient
+vi.mock('../useTSSHistory.js', () => ({ useTSSHistory: () => ({ data: [] }) }));
+vi.mock('../useVitals.js', () => ({
+  useVitals: () => ({
+    latest: null,
+    readinessScore: 0,
+    readinessLabel: 'FATIGUED',
+  }),
+}));
+vi.mock('../useSessions.js', () => ({ useSessions: () => ({ data: [] }) }));
+
+import { buildTrainingContext } from '../useCoach.js';
+
+// buildTrainingContext is a pure exported function — no mocking needed
+describe('buildTrainingContext', () => {
+  it('includes today date header', () => {
+    const result = buildTrainingContext(null, null, 0, 'FATIGUED', [], null);
+    expect(result).toMatch(/CURRENT TRAINING DATA \(as of \d{4}-\d{2}-\d{2}\)/);
+  });
+
+  it('includes TSB, CTL, ATL when load data present', () => {
+    const load = { tsb: -8.2, ctl: 34.1, atl: 42.3 };
+    const result = buildTrainingContext(load, null, 0, 'FATIGUED', [], null);
+    expect(result).toContain('TSB: -8.2');
+    expect(result).toContain('CTL: 34.1');
+    expect(result).toContain('ATL: 42.3');
+  });
+
+  it('labels TSB signal correctly', () => {
+    expect(
+      buildTrainingContext(
+        { tsb: 10, ctl: 30, atl: 20 },
+        null,
+        0,
+        'READY',
+        [],
+        null
+      )
+    ).toContain('GREEN');
+    expect(
+      buildTrainingContext(
+        { tsb: -5, ctl: 30, atl: 35 },
+        null,
+        0,
+        'CAUTION',
+        [],
+        null
+      )
+    ).toContain('AMBER');
+    expect(
+      buildTrainingContext(
+        { tsb: -15, ctl: 25, atl: 40 },
+        null,
+        0,
+        'FATIGUED',
+        [],
+        null
+      )
+    ).toContain('RED');
+  });
+
+  it('includes readiness and vitals when present', () => {
+    const vitals = { rhr: 58, hrv: 27, sleep: 6.8 };
+    const result = buildTrainingContext(null, vitals, 68, 'CAUTION', [], null);
+    expect(result).toContain('Readiness: 68/100 CAUTION');
+    expect(result).toContain('RHR: 58');
+    expect(result).toContain('HRV: 27ms');
+    expect(result).toContain('Sleep: 6.8h');
+  });
+
+  it('uses em dashes for missing vitals fields', () => {
+    const vitals = { rhr: null, hrv: null, sleep: null };
+    const result = buildTrainingContext(null, vitals, 0, 'FATIGUED', [], null);
+    expect(result).toContain('RHR: —');
+    expect(result).toContain('HRV: —ms');
+    expect(result).toContain('Sleep: —h');
+  });
+
+  it('includes today planned session when provided', () => {
+    const planned = { type: 'Z2 Aerobic', label: '60min easy' };
+    const result = buildTrainingContext(null, null, 0, 'READY', [], planned);
+    expect(result).toContain("Today's session: Z2 Aerobic — 60min easy");
+  });
+
+  it('includes today planned session without label when label absent', () => {
+    const planned = { type: 'Lower Strength' };
+    const result = buildTrainingContext(null, null, 0, 'READY', [], planned);
+    expect(result).toContain("Today's session: Lower Strength");
+    expect(result).not.toContain('undefined');
+  });
+
+  it('includes recent sessions list', () => {
+    const sessions = [
+      { date: '2026-06-24', type: 'Z2 Aerobic', duration: '60', srpe: 4 },
+      { date: '2026-06-23', type: 'Upper Strength', duration: '45', srpe: 6 },
+    ];
+    const result = buildTrainingContext(null, null, 0, 'READY', sessions, null);
+    expect(result).toContain('Recent sessions (newest first):');
+    expect(result).toContain('2026-06-24: Z2 Aerobic 60min sRPE 4');
+    expect(result).toContain('2026-06-23: Upper Strength 45min sRPE 6');
+  });
+
+  it('omits duration and sRPE when absent', () => {
+    const sessions = [{ date: '2026-06-24', type: 'Rest' }];
+    const result = buildTrainingContext(null, null, 0, 'READY', sessions, null);
+    expect(result).toContain('2026-06-24: Rest');
+    expect(result).not.toContain('undefined');
+    expect(result).not.toContain('NaN');
+  });
+
+  it('omits sections entirely when data absent', () => {
+    const result = buildTrainingContext(null, null, 0, 'READY', [], null);
+    expect(result).not.toContain('TSB:');
+    expect(result).not.toContain('Readiness:');
+    expect(result).not.toContain("Today's session:");
+    expect(result).not.toContain('Recent sessions');
+  });
+});

--- a/web/src/hooks/useCoach.js
+++ b/web/src/hooks/useCoach.js
@@ -1,0 +1,258 @@
+import { useState, useRef } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '../supabaseClient.js';
+import { useTSSHistory } from './useTSSHistory.js';
+import { useVitals } from './useVitals.js';
+import { useSessions } from './useSessions.js';
+import { calcTrainingLoad } from '../utils/trainingLoad.js';
+
+export function buildTrainingContext(
+  latestLoad,
+  latestVitals,
+  readinessScore,
+  readinessLabel,
+  recentSessions,
+  todayPlanned
+) {
+  const today = new Date().toISOString().split('T')[0];
+  const lines = [`CURRENT TRAINING DATA (as of ${today}):`];
+
+  if (latestLoad) {
+    const tsbSignal =
+      latestLoad.tsb > 5 ? 'GREEN' : latestLoad.tsb > -10 ? 'AMBER' : 'RED';
+    lines.push(
+      `TSB: ${latestLoad.tsb} (${tsbSignal}) | CTL: ${latestLoad.ctl} | ATL: ${latestLoad.atl}`
+    );
+  }
+
+  if (latestVitals) {
+    const rhr = latestVitals.rhr != null ? latestVitals.rhr : '—';
+    const hrv = latestVitals.hrv != null ? latestVitals.hrv : '—';
+    const sleep = latestVitals.sleep != null ? latestVitals.sleep : '—';
+    lines.push(
+      `Readiness: ${readinessScore}/100 ${readinessLabel} | RHR: ${rhr} | HRV: ${hrv}ms | Sleep: ${sleep}h`
+    );
+  }
+
+  if (todayPlanned) {
+    const label = todayPlanned.label ? ` — ${todayPlanned.label}` : '';
+    lines.push(`Today's session: ${todayPlanned.type}${label}`);
+  }
+
+  if (recentSessions?.length) {
+    lines.push('Recent sessions (newest first):');
+    recentSessions.forEach((s) => {
+      const dur = s.duration ? ` ${s.duration}min` : '';
+      const rpe = s.srpe ? ` sRPE ${s.srpe}` : '';
+      lines.push(`  ${s.date}: ${s.type}${dur}${rpe}`);
+    });
+  }
+
+  return lines.join('\n');
+}
+
+export function useCoach() {
+  const queryClient = useQueryClient();
+  const [streamingContent, setStreamingContent] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState(null);
+  const [model, setModelState] = useState(
+    () => localStorage.getItem('coach_model_pref') || 'sonnet'
+  );
+
+  const streamingRef = useRef('');
+
+  const { data: messages = [] } = useQuery({
+    queryKey: ['coach_messages'],
+    queryFn: async () => {
+      const { data, error: err } = await supabase
+        .from('coach_messages')
+        .select('role, content, model, created_at')
+        .order('created_at', { ascending: true })
+        .limit(100);
+      if (err) throw err;
+      return data ?? [];
+    },
+    staleTime: 300_000,
+    retry: 2,
+  });
+
+  const tssQuery = useTSSHistory();
+  const vitals = useVitals();
+  const sessions = useSessions();
+
+  const setModel = (m) => {
+    setModelState(m);
+    localStorage.setItem('coach_model_pref', m);
+  };
+
+  const sendMessage = async (userText) => {
+    if (!userText.trim() || isStreaming) return;
+
+    const userMsg = {
+      role: 'user',
+      content: userText,
+      model,
+      created_at: new Date().toISOString(),
+    };
+    queryClient.setQueryData(['coach_messages'], (old) => [
+      ...(old ?? []),
+      userMsg,
+    ]);
+
+    setIsStreaming(true);
+    setStreamingContent('');
+    streamingRef.current = '';
+    setError(null);
+
+    try {
+      await supabase
+        .from('coach_messages')
+        .insert({ role: 'user', content: userText, model });
+
+      const tssData = tssQuery.data ?? [];
+      const loadData = tssData.length ? calcTrainingLoad(tssData) : [];
+      const latestLoad = loadData[loadData.length - 1] ?? null;
+
+      const allSessions = sessions.data ?? [];
+      const today = new Date().toISOString().split('T')[0];
+      const recentLogged = allSessions
+        .filter((s) => s.status === 'logged')
+        .slice(0, 5);
+      const todayPlanned =
+        allSessions.find((s) => s.status === 'planned' && s.date === today) ??
+        null;
+
+      const context = buildTrainingContext(
+        latestLoad,
+        vitals.latest,
+        vitals.readinessScore,
+        vitals.readinessLabel,
+        recentLogged,
+        todayPlanned
+      );
+
+      const currentMessages =
+        queryClient.getQueryData(['coach_messages']) ?? [];
+      const apiMessages = currentMessages
+        .slice(-10)
+        .map((m) => ({ role: m.role, content: m.content }));
+
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+
+      const res = await fetch(`${supabaseUrl}/functions/v1/coach-chat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ messages: apiMessages, context, model }),
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`Coach error ${res.status}: ${errText}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let finalised = false;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop();
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const jsonStr = line.slice(6).trim();
+          if (!jsonStr || jsonStr === '[DONE]') continue;
+          try {
+            const parsed = JSON.parse(jsonStr);
+            if (
+              parsed.type === 'content_block_delta' &&
+              parsed.delta?.type === 'text_delta'
+            ) {
+              streamingRef.current += parsed.delta.text;
+              setStreamingContent(streamingRef.current);
+            } else if (parsed.type === 'message_stop') {
+              finalised = true;
+              const finalContent = streamingRef.current;
+              const assistantMsg = {
+                role: 'assistant',
+                content: finalContent,
+                model,
+                created_at: new Date().toISOString(),
+              };
+              await supabase
+                .from('coach_messages')
+                .insert({ role: 'assistant', content: finalContent, model });
+              queryClient.setQueryData(['coach_messages'], (old) => [
+                ...(old ?? []),
+                assistantMsg,
+              ]);
+              setStreamingContent('');
+              streamingRef.current = '';
+              setIsStreaming(false);
+            }
+          } catch {
+            // ignore malformed SSE lines
+          }
+        }
+      }
+
+      if (!finalised && streamingRef.current) {
+        const finalContent = streamingRef.current;
+        const assistantMsg = {
+          role: 'assistant',
+          content: finalContent,
+          model,
+          created_at: new Date().toISOString(),
+        };
+        await supabase
+          .from('coach_messages')
+          .insert({ role: 'assistant', content: finalContent, model });
+        queryClient.setQueryData(['coach_messages'], (old) => [
+          ...(old ?? []),
+          assistantMsg,
+        ]);
+        setStreamingContent('');
+        streamingRef.current = '';
+        setIsStreaming(false);
+      }
+    } catch (err) {
+      setError(err.message || 'Failed to get a response');
+      setIsStreaming(false);
+      setStreamingContent('');
+      streamingRef.current = '';
+    }
+  };
+
+  const clearHistory = async () => {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+    await supabase.from('coach_messages').delete().eq('user_id', user.id);
+    queryClient.setQueryData(['coach_messages'], []);
+  };
+
+  return {
+    messages,
+    streamingContent,
+    isStreaming,
+    error,
+    model,
+    setModel,
+    sendMessage,
+    clearHistory,
+    vitals,
+    tssQuery,
+  };
+}

--- a/web/src/views/CoachView.jsx
+++ b/web/src/views/CoachView.jsx
@@ -1,0 +1,348 @@
+import { useState, useEffect, useRef } from 'react';
+import { useCoach } from '../hooks/useCoach.js';
+import { calcTrainingLoad } from '../utils/trainingLoad.js';
+
+const C = {
+  bg: '#08080d',
+  panel: '#1a1a2e',
+  border: '#4a4a68',
+  cyan: '#00d4ff',
+  text: '#e8e8f0',
+  muted: '#7e7e9a',
+  err: '#ff2d55',
+  userBubble: '#2a2a48',
+  userBubbleBorder: '#4a4a68',
+  assistantBorder: '#00d4ff',
+};
+
+const STARTER_PROMPTS = [
+  "How's my training load looking?",
+  'What should I focus on this week?',
+  'Is it safe to add intensity today?',
+];
+
+function MessageBubble({ msg }) {
+  const isUser = msg.role === 'user';
+  return (
+    <div
+      style={{
+        alignSelf: isUser ? 'flex-end' : 'flex-start',
+        maxWidth: '80%',
+        background: isUser ? C.userBubble : C.panel,
+        border: isUser ? `1px solid ${C.userBubbleBorder}` : 'none',
+        borderLeft: isUser ? undefined : `3px solid ${C.assistantBorder}`,
+        borderRadius: 8,
+        padding: '10px 14px',
+        fontSize: 13,
+        color: C.text,
+        lineHeight: 1.6,
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+      }}
+    >
+      {msg.content}
+    </div>
+  );
+}
+
+export default function CoachView() {
+  const {
+    messages,
+    streamingContent,
+    isStreaming,
+    error,
+    model,
+    setModel,
+    sendMessage,
+    clearHistory,
+    vitals,
+    tssQuery,
+  } = useCoach();
+  const [input, setInput] = useState('');
+  const bottomRef = useRef(null);
+  const textareaRef = useRef(null);
+
+  const tssData = tssQuery.data ?? [];
+  const loadData = tssData.length ? calcTrainingLoad(tssData) : [];
+  const latestLoad = loadData[loadData.length - 1] ?? null;
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, streamingContent]);
+
+  const handleSend = () => {
+    const text = input.trim();
+    if (!text || isStreaming) return;
+    setInput('');
+    if (textareaRef.current) textareaRef.current.style.height = 'auto';
+    sendMessage(text);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const handleInput = (e) => {
+    setInput(e.target.value);
+    e.target.style.height = 'auto';
+    e.target.style.height = `${Math.min(e.target.scrollHeight, 120)}px`;
+  };
+
+  const tsbLabel = latestLoad
+    ? `TSB ${latestLoad.tsb} · CTL ${latestLoad.ctl} · ATL ${latestLoad.atl}`
+    : null;
+  const readinessLabel =
+    vitals.latest && vitals.readinessScore != null
+      ? `Readiness ${vitals.readinessScore} ${vitals.readinessLabel}`
+      : null;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: 'calc(100vh - 180px)',
+        minHeight: 400,
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 6,
+          flexWrap: 'wrap',
+          gap: 8,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <div
+            style={{
+              fontSize: 9,
+              letterSpacing: 3,
+              color: C.cyan,
+              fontFamily: "'DM Mono', monospace",
+            }}
+          >
+            COACH
+          </div>
+          <div style={{ display: 'flex', gap: 4 }}>
+            {[
+              { key: 'haiku', label: 'QUICK' },
+              { key: 'sonnet', label: 'COACHING' },
+            ].map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setModel(key)}
+                style={{
+                  background: model === key ? C.panel : 'transparent',
+                  border: `1px solid ${model === key ? C.cyan : C.border}`,
+                  color: model === key ? C.cyan : C.muted,
+                  borderRadius: 4,
+                  padding: '3px 8px',
+                  fontSize: 9,
+                  letterSpacing: 0.5,
+                  cursor: 'pointer',
+                  fontFamily: "'DM Mono', monospace",
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <button
+          onClick={() => {
+            if (window.confirm('Clear all coaching history?')) clearHistory();
+          }}
+          style={{
+            background: 'transparent',
+            border: `1px solid ${C.border}`,
+            color: C.muted,
+            borderRadius: 4,
+            padding: '3px 8px',
+            fontSize: 9,
+            letterSpacing: 0.5,
+            cursor: 'pointer',
+            fontFamily: "'DM Mono', monospace",
+          }}
+        >
+          CLEAR
+        </button>
+      </div>
+
+      {/* Status badge */}
+      {(tsbLabel || readinessLabel) && (
+        <div
+          style={{
+            fontSize: 10,
+            color: C.muted,
+            marginBottom: 10,
+            fontFamily: "'DM Mono', monospace",
+          }}
+        >
+          {[tsbLabel, readinessLabel].filter(Boolean).join(' · ')}
+        </div>
+      )}
+
+      {/* Message list */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+          padding: '4px 0',
+        }}
+      >
+        {messages.length === 0 && !isStreaming && (
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 8,
+              padding: '24px 0',
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                color: C.muted,
+                marginBottom: 8,
+                fontFamily: "'DM Mono', monospace",
+                letterSpacing: 1,
+              }}
+            >
+              ASK YOUR COACH
+            </div>
+            {STARTER_PROMPTS.map((prompt) => (
+              <button
+                key={prompt}
+                onClick={() => sendMessage(prompt)}
+                style={{
+                  background: C.panel,
+                  border: `1px solid ${C.border}`,
+                  borderRadius: 6,
+                  padding: '10px 14px',
+                  color: C.text,
+                  fontSize: 13,
+                  textAlign: 'left',
+                  cursor: 'pointer',
+                  fontFamily: "'DM Mono', monospace",
+                  lineHeight: 1.4,
+                }}
+              >
+                {prompt}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {messages.map((msg, i) => (
+          <MessageBubble key={i} msg={msg} />
+        ))}
+
+        {streamingContent && (
+          <div
+            style={{
+              alignSelf: 'flex-start',
+              maxWidth: '80%',
+              background: C.panel,
+              borderLeft: `3px solid ${C.assistantBorder}`,
+              borderRadius: 8,
+              padding: '10px 14px',
+              fontSize: 13,
+              color: C.text,
+              lineHeight: 1.6,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}
+          >
+            {streamingContent}
+            <span style={{ opacity: 0.7 }}>▌</span>
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          style={{
+            color: C.err,
+            fontSize: 11,
+            padding: '6px 0',
+            fontFamily: "'DM Mono', monospace",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Input row */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 8,
+          paddingTop: 12,
+          borderTop: `1px solid ${C.border}`,
+          alignItems: 'flex-end',
+        }}
+      >
+        <textarea
+          ref={textareaRef}
+          value={input}
+          onChange={handleInput}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask your coach… (Enter to send, Shift+Enter for newline)"
+          disabled={isStreaming}
+          rows={1}
+          style={{
+            flex: 1,
+            background: C.panel,
+            border: `1px solid ${C.border}`,
+            borderRadius: 6,
+            padding: '10px 12px',
+            color: C.text,
+            fontSize: 13,
+            fontFamily: "'DM Mono', monospace",
+            resize: 'none',
+            minHeight: 44,
+            maxHeight: 120,
+            opacity: isStreaming ? 0.5 : 1,
+            outline: 'none',
+            overflowY: 'auto',
+            lineHeight: 1.5,
+          }}
+        />
+        <button
+          onClick={handleSend}
+          disabled={isStreaming || !input.trim()}
+          style={{
+            background: C.cyan,
+            color: C.bg,
+            border: 'none',
+            borderRadius: 6,
+            padding: '0 16px',
+            height: 44,
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 1,
+            cursor: isStreaming || !input.trim() ? 'not-allowed' : 'pointer',
+            opacity: isStreaming || !input.trim() ? 0.4 : 1,
+            fontFamily: "'DM Mono', monospace",
+            flexShrink: 0,
+          }}
+        >
+          SEND
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/views/__tests__/CoachView.test.jsx
+++ b/web/src/views/__tests__/CoachView.test.jsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+// jsdom doesn't implement scrollIntoView — mock it globally
+beforeEach(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+// Mock the useCoach hook so CoachView is testable in isolation
+const mockSendMessage = vi.fn();
+const mockSetModel = vi.fn();
+const mockClearHistory = vi.fn();
+
+const mockCoachState = {
+  messages: [],
+  streamingContent: '',
+  isStreaming: false,
+  error: null,
+  model: 'sonnet',
+  setModel: mockSetModel,
+  sendMessage: mockSendMessage,
+  clearHistory: mockClearHistory,
+  vitals: { latest: null, readinessScore: 0, readinessLabel: 'FATIGUED' },
+  tssQuery: { data: [] },
+};
+
+vi.mock('../../hooks/useCoach.js', () => ({
+  useCoach: () => mockCoachState,
+}));
+
+vi.mock('../../utils/trainingLoad.js', () => ({
+  calcTrainingLoad: () => [],
+}));
+
+import CoachView from '../CoachView.jsx';
+
+function resetCoachState(overrides = {}) {
+  Object.assign(
+    mockCoachState,
+    {
+      messages: [],
+      streamingContent: '',
+      isStreaming: false,
+      error: null,
+      model: 'sonnet',
+    },
+    overrides
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetCoachState();
+});
+
+describe('CoachView', () => {
+  it('renders starter prompt chips when messages is empty', () => {
+    render(<CoachView />);
+    expect(screen.getByText("How's my training load looking?")).toBeTruthy();
+    expect(screen.getByText('What should I focus on this week?')).toBeTruthy();
+    expect(screen.getByText('Is it safe to add intensity today?')).toBeTruthy();
+  });
+
+  it('calls sendMessage when a starter chip is clicked', () => {
+    render(<CoachView />);
+    fireEvent.click(screen.getByText("How's my training load looking?"));
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      "How's my training load looking?"
+    );
+  });
+
+  it('does not show starter chips when messages exist', () => {
+    resetCoachState({
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+    render(<CoachView />);
+    expect(screen.queryByText("How's my training load looking?")).toBeNull();
+  });
+
+  it('renders user message bubbles', () => {
+    resetCoachState({
+      messages: [{ role: 'user', content: 'What is my TSB?' }],
+    });
+    render(<CoachView />);
+    expect(screen.getByText('What is my TSB?')).toBeTruthy();
+  });
+
+  it('renders assistant message bubbles', () => {
+    resetCoachState({
+      messages: [{ role: 'assistant', content: 'Your TSB is -8.' }],
+    });
+    render(<CoachView />);
+    expect(screen.getByText('Your TSB is -8.')).toBeTruthy();
+  });
+
+  it('shows streaming content with cursor while isStreaming', () => {
+    resetCoachState({
+      streamingContent: 'Your training load is',
+      isStreaming: true,
+    });
+    render(<CoachView />);
+    expect(screen.getByText('Your training load is')).toBeTruthy();
+    expect(screen.getByText('▌')).toBeTruthy();
+  });
+
+  it('does not show cursor when not streaming', () => {
+    resetCoachState({ streamingContent: '', isStreaming: false });
+    render(<CoachView />);
+    expect(screen.queryByText('▌')).toBeNull();
+  });
+
+  it('disables send button while isStreaming', () => {
+    resetCoachState({ isStreaming: true });
+    render(<CoachView />);
+    const sendBtn = screen.getByRole('button', { name: 'SEND' });
+    expect(sendBtn.disabled).toBe(true);
+  });
+
+  it('calls sendMessage when form is submitted via send button', () => {
+    render(<CoachView />);
+    const textarea = screen.getByPlaceholderText(/Ask your coach/);
+    fireEvent.change(textarea, { target: { value: 'How do I improve CTL?' } });
+    fireEvent.click(screen.getByRole('button', { name: 'SEND' }));
+    expect(mockSendMessage).toHaveBeenCalledWith('How do I improve CTL?');
+  });
+
+  it('calls sendMessage when Enter pressed without Shift', () => {
+    render(<CoachView />);
+    const textarea = screen.getByPlaceholderText(/Ask your coach/);
+    fireEvent.change(textarea, { target: { value: 'Quick question' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+    expect(mockSendMessage).toHaveBeenCalledWith('Quick question');
+  });
+
+  it('does not call sendMessage on Shift+Enter', () => {
+    render(<CoachView />);
+    const textarea = screen.getByPlaceholderText(/Ask your coach/);
+    fireEvent.change(textarea, { target: { value: 'Multi-line' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows error banner when error is set', () => {
+    resetCoachState({ error: 'Failed to connect' });
+    render(<CoachView />);
+    expect(screen.getByText('Failed to connect')).toBeTruthy();
+  });
+
+  it('calls setModel when model toggle clicked', () => {
+    render(<CoachView />);
+    fireEvent.click(screen.getByRole('button', { name: 'QUICK' }));
+    expect(mockSetModel).toHaveBeenCalledWith('haiku');
+  });
+
+  it('calls clearHistory with confirm guard', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<CoachView />);
+    fireEvent.click(screen.getByRole('button', { name: 'CLEAR' }));
+    expect(mockClearHistory).toHaveBeenCalled();
+  });
+
+  it('does not call clearHistory when confirm is cancelled', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<CoachView />);
+    fireEvent.click(screen.getByRole('button', { name: 'CLEAR' }));
+    expect(mockClearHistory).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a full AI coaching experience backed by a Supabase Edge Function
that proxies streaming requests to the Anthropic API.

- New Coach tab (13th nav item) with streaming chat UI
- Dual-model toggle: Quick (Haiku) for everyday Q&A, Coaching (Sonnet)
  for training/nutrition/wellness advice
- Training context injected per message: TSB/CTL/ATL, readiness score,
  recent sessions, vitals, today's planned session
- Conversation history persisted to Supabase coach_messages table
- Edge function (supabase/functions/coach-chat/index.ts) handles
  Anthropic API key securely; no CSP changes needed
- DB migration 002_coach_messages.sql with owner-only RLS policy
- 25 new tests across buildTrainingContext (pure function) and CoachView

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PhDgxMbACXRXQ29sVnVqDh