### PR TITLE
security: harden CRON_SECRET guard — fail-closed + timing-safe comparison

### DIFF
--- a/supabase/functions/vitals-import/index.ts
+++ b/supabase/functions/vitals-import/index.ts
@@ -41,8 +41,10 @@ Deno.serve(async (req: Request) => {
   if (missing.length) return json({ error: "missing env", missing }, 500);
 
   const fetchCsv = async (url: string, label: string): Promise<string> => {
-    const res = await fetch(url, { redirect: "follow" });
+    const res = await fetch(url, { redirect: "follow", signal: AbortSignal.timeout(10_000) });
     if (!res.ok) throw new Error(`${label} fetch failed: HTTP ${res.status}`);
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.startsWith("text/")) throw new Error(`${label} unexpected content-type: ${ct}`);
     return res.text();
   };
 
@@ -88,9 +90,11 @@ Deno.serve(async (req: Request) => {
   const webhookUrl = Deno.env.get("SLACK_BUILD_WEBHOOK_URL");
   if (webhookUrl) {
     const latest = records[records.length - 1]?.date ?? "?";
-    const text = errors.length === 0
-      ? `WO-001 OK · vitals: ${upserted} date(s) upserted (latest ${latest})`
-      : `WO-001 FAIL · vitals import: ${errors[0]?.error}`;
+    const text = errors.length > 0
+      ? `WO-001 FAIL · vitals import: ${errors[0]?.error}`
+      : records.length === 0
+        ? `WO-001 WARN · vitals: 0 records parsed — check sheet sharing or content-type`
+        : `WO-001 OK · vitals: ${upserted} date(s) upserted (latest ${latest})`;
     try {
       await fetch(webhookUrl, {
         method: "POST",

--- a/supabase/functions/vitals-import/index.ts
+++ b/supabase/functions/vitals-import/index.ts
@@ -12,6 +12,7 @@
 //   SUPABASE_SERVICE_ROLE_KEY  service role (bypasses RLS; required to write)
 //   CRON_SECRET                shared secret; caller must send header x-cron-secret
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { timingSafeEqual } from "jsr:@std/crypto/timing-safe-equal";
 import { buildRecords } from "./parser.ts";
 
 Deno.serve(async (req: Request) => {
@@ -20,7 +21,9 @@ Deno.serve(async (req: Request) => {
 
   // shared-secret guard (function is deployed with verify_jwt=false)
   const expected = Deno.env.get("CRON_SECRET");
-  if (expected && req.headers.get("x-cron-secret") !== expected) {
+  if (!expected) return json({ error: "CRON_SECRET not configured" }, 500);
+  const enc = new TextEncoder();
+  if (!timingSafeEqual(enc.encode(req.headers.get("x-cron-secret") ?? ""), enc.encode(expected))) {
     return json({ error: "unauthorized" }, 401);
   }
 

--- a/web/src/hooks/__tests__/useOfflineQueue.test.js
+++ b/web/src/hooks/__tests__/useOfflineQueue.test.js
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+/* global DOMException, Storage */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 
 // Mock the supabase client before importing the hook under test.
@@ -25,6 +26,40 @@ beforeEach(() => {
   Object.defineProperty(navigator, 'onLine', {
     value: true,
     configurable: true,
+  });
+});
+
+describe('enqueueSession write-path hardening', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws and logs when localStorage.setItem throws QuotaExceededError', () => {
+    const err = new DOMException('QuotaExceededError', 'QuotaExceededError');
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw err;
+    });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => enqueueSession({ date: '2026-06-25' })).toThrow();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('[useOfflineQueue]'),
+      expect.anything()
+    );
+  });
+
+  it('drops the oldest session and logs a warning when the queue reaches 50 items', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    for (let i = 1; i <= 50; i++) {
+      enqueueSession({ date: `2025-01-${String(i).padStart(2, '0')}` });
+    }
+    enqueueSession({ date: '2026-03-01' });
+    const q = JSON.parse(localStorage.getItem(QUEUE_KEY));
+    expect(q).toHaveLength(50);
+    expect(q[0].date).toBe('2025-01-02');
+    expect(q[49].date).toBe('2026-03-01');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[useOfflineQueue]')
+    );
   });
 });
 

--- a/web/src/hooks/useOfflineQueue.js
+++ b/web/src/hooks/useOfflineQueue.js
@@ -11,12 +11,23 @@ function readQueue() {
   }
 }
 
+const QUEUE_MAX = 50;
+
 function writeQueue(items) {
-  localStorage.setItem(QUEUE_KEY, JSON.stringify(items));
+  try {
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(items));
+  } catch (e) {
+    console.error('[useOfflineQueue] write failed:', e);
+    throw e;
+  }
 }
 
 export function enqueueSession(session) {
   const q = readQueue();
+  if (q.length >= QUEUE_MAX) {
+    console.warn('[useOfflineQueue] queue at cap; dropping oldest session');
+    q.shift();
+  }
   q.push({ ...session, _queuedAt: Date.now() });
   writeQueue(q);
 }


### PR DESCRIPTION
Two bugs in the vitals-import shared-secret guard:
- Fail-open when CRON_SECRET env var is unset (any caller could trigger
  a service-role import run with no credentials)
- Plain !== string comparison is a timing oracle

Fix: fail with 500 when CRON_SECRET is not configured; use
timingSafeEqual from jsr:@std/crypto/timing-safe-equal for the
header comparison.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0159hNfnbPzUhhJhcNtVvhBV