### PR TITLE
feat(recovery): analytics dashboard from Google Health API data

### DIFF
--- a/supabase/migrations/003_add_vitals_columns.sql
+++ b/supabase/migrations/003_add_vitals_columns.sql
@@ -1,0 +1,9 @@
+-- 003_add_vitals_columns.sql
+-- Additive columns missing from the initial schema.
+-- Both are ADD COLUMN IF NOT EXISTS — idempotent and safe to re-run.
+
+-- source: used by both vitals-import and vitals-import-api RPCs to record the ingestion path.
+ALTER TABLE vitals ADD COLUMN IF NOT EXISTS source text;
+
+-- sleep_score: referenced in app code; remains null until a data source provides it.
+ALTER TABLE vitals ADD COLUMN IF NOT EXISTS sleep_score numeric;

--- a/web/src/hooks/useVitals.js
+++ b/web/src/hooks/useVitals.js
@@ -1,24 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
-
-const RHR_BASELINE = 57;
-const HRV_BASELINE = 30;
-
-function computeReadiness(latest) {
-  if (!latest) return { readinessScore: 0, readinessLabel: 'FATIGUED' };
-  let score = 100;
-  score -= Math.max(0, latest.rhr - RHR_BASELINE) * 4;
-  score -= Math.max(0, HRV_BASELINE - latest.hrv) * 1.5;
-  score -= latest.sleep < 7 ? (7 - latest.sleep) * 8 : 0;
-  const readinessScore = Math.round(Math.min(100, Math.max(0, score)));
-  const readinessLabel =
-    readinessScore >= 80
-      ? 'READY'
-      : readinessScore >= 60
-        ? 'CAUTION'
-        : 'FATIGUED';
-  return { readinessScore, readinessLabel };
-}
+import {
+  computeReadiness,
+  computePersonalBaselines,
+  computeReadinessHistory,
+} from '../utils/recoveryAnalytics.js';
 
 export function useVitals() {
   const query = useQuery({
@@ -26,7 +12,7 @@ export function useVitals() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('vitals')
-        .select('date, rhr, hrv, sleep, sleep_score')
+        .select('date, rhr, hrv, sleep, sleep_score, bodyweight')
         .order('date', { ascending: false })
         .limit(30);
       if (error) throw error;
@@ -35,13 +21,25 @@ export function useVitals() {
     staleTime: 60_000,
   });
 
-  const latest = query.data?.[0] ?? null;
-  const { readinessScore, readinessLabel } = computeReadiness(latest);
+  const rows = query.data ?? [];
+  const latest = rows[0] ?? null;
+  const personalBaselines = computePersonalBaselines(rows);
+  const { readinessScore, readinessLabel } = computeReadiness(
+    latest,
+    personalBaselines
+  );
+  const vitalsHistory = rows.slice().reverse();
+  const history = computeReadinessHistory(rows, personalBaselines);
+  const hasPersonalBaselines = rows.length >= 14;
 
   return {
     ...query,
     latest,
     readinessScore,
     readinessLabel,
+    personalBaselines,
+    vitalsHistory,
+    history,
+    hasPersonalBaselines,
   };
 }

--- a/web/src/utils/__tests__/recoveryAnalytics.test.js
+++ b/web/src/utils/__tests__/recoveryAnalytics.test.js
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computePersonalBaselines,
+  computeReadiness,
+  computeReadinessHistory,
+  joinVitalsTsb,
+} from '../recoveryAnalytics.js';
+
+const RHR_DEFAULT = 57;
+const HRV_DEFAULT = 30;
+const SLEEP_TARGET = 7;
+
+function makeRows(n, overrides = {}) {
+  return Array.from({ length: n }, (_, i) => ({
+    date: `2026-06-${String(20 - i).padStart(2, '0')}`,
+    rhr: 55,
+    hrv: 32,
+    sleep: 7.5,
+    ...overrides,
+  }));
+}
+
+describe('computePersonalBaselines', () => {
+  it('returns defaults when rows is null', () => {
+    expect(computePersonalBaselines(null)).toEqual({
+      rhrBaseline: RHR_DEFAULT,
+      hrvBaseline: HRV_DEFAULT,
+      sleepTarget: SLEEP_TARGET,
+    });
+  });
+
+  it('returns defaults when fewer than minSamples rows', () => {
+    const r = computePersonalBaselines(makeRows(13));
+    expect(r.rhrBaseline).toBe(RHR_DEFAULT);
+    expect(r.hrvBaseline).toBe(HRV_DEFAULT);
+  });
+
+  it('returns computed baseline when minSamples rows present', () => {
+    const r = computePersonalBaselines(makeRows(14, { rhr: 55, hrv: 35 }));
+    expect(r.rhrBaseline).toBe(55);
+    expect(r.hrvBaseline).toBe(35);
+  });
+
+  it('sleepTarget is always the fixed 7h health target', () => {
+    const r = computePersonalBaselines(makeRows(14, { sleep: 9 }));
+    expect(r.sleepTarget).toBe(SLEEP_TARGET);
+  });
+
+  it('trims outliers — single extreme RHR does not skew the mean', () => {
+    const rows = [
+      ...makeRows(27, { rhr: 55 }),
+      { date: '2026-05-24', rhr: 120, hrv: 32, sleep: 7.5 },
+    ];
+    const r = computePersonalBaselines(rows);
+    expect(r.rhrBaseline).toBeLessThan(60);
+  });
+});
+
+describe('computeReadiness', () => {
+  it('returns FATIGUED with score 0 when latest is null', () => {
+    expect(computeReadiness(null)).toEqual({
+      readinessScore: 0,
+      readinessLabel: 'FATIGUED',
+    });
+  });
+
+  it('returns score 100 READY when all metrics are at baseline', () => {
+    const r = computeReadiness({
+      rhr: RHR_DEFAULT,
+      hrv: HRV_DEFAULT,
+      sleep: SLEEP_TARGET,
+    });
+    expect(r.readinessScore).toBe(100);
+    expect(r.readinessLabel).toBe('READY');
+  });
+
+  it('deducts 4 points per bpm above RHR baseline', () => {
+    const r = computeReadiness({
+      rhr: 62,
+      hrv: HRV_DEFAULT,
+      sleep: SLEEP_TARGET,
+    });
+    expect(r.readinessScore).toBe(80);
+  });
+
+  it('deducts 1.5 points per ms below HRV baseline', () => {
+    const r = computeReadiness({
+      rhr: RHR_DEFAULT,
+      hrv: 20,
+      sleep: SLEEP_TARGET,
+    });
+    expect(r.readinessScore).toBe(85);
+  });
+
+  it('uses personalized baselines when provided', () => {
+    const baselines = { rhrBaseline: 60, hrvBaseline: 35, sleepTarget: 7 };
+    const r = computeReadiness({ rhr: 60, hrv: 35, sleep: 7 }, baselines);
+    expect(r.readinessScore).toBe(100);
+  });
+
+  it('handles null metric fields without crashing', () => {
+    expect(() =>
+      computeReadiness({ rhr: null, hrv: null, sleep: null })
+    ).not.toThrow();
+    const r = computeReadiness({ rhr: null, hrv: null, sleep: null });
+    expect(r.readinessScore).toBe(100);
+  });
+
+  it('clamps score to 0 minimum', () => {
+    const r = computeReadiness({ rhr: 100, hrv: 5, sleep: 3 });
+    expect(r.readinessScore).toBe(0);
+  });
+});
+
+describe('computeReadinessHistory', () => {
+  it('returns empty array when rows is empty', () => {
+    expect(computeReadinessHistory([])).toEqual([]);
+  });
+
+  it('returns correct length for 7 rows', () => {
+    const rows = makeRows(7);
+    expect(computeReadinessHistory(rows)).toHaveLength(7);
+  });
+
+  it('caps at 14 entries even when more rows provided', () => {
+    const rows = makeRows(20);
+    expect(computeReadinessHistory(rows)).toHaveLength(14);
+  });
+
+  it('returns rows in ascending date order', () => {
+    const rows = [
+      { date: '2026-06-20', rhr: 57, hrv: 30, sleep: 7 },
+      { date: '2026-06-19', rhr: 57, hrv: 30, sleep: 7 },
+    ];
+    const result = computeReadinessHistory(rows);
+    expect(result[0].date).toBe('06/19');
+    expect(result[1].date).toBe('06/20');
+  });
+
+  it('each entry has date and readinessScore', () => {
+    const [entry] = computeReadinessHistory(makeRows(1));
+    expect(entry).toMatchObject({
+      date: expect.any(String),
+      readinessScore: expect.any(Number),
+    });
+  });
+});
+
+describe('joinVitalsTsb', () => {
+  it('returns empty array when vitals is empty', () => {
+    expect(joinVitalsTsb([], [{ date: '06/20', tsb: 5 }])).toEqual([]);
+  });
+
+  it('returns empty array when loadData is empty', () => {
+    expect(joinVitalsTsb([{ date: '2026-06-20', hrv: 30 }], [])).toEqual([]);
+  });
+
+  it('joins correctly despite YYYY-MM-DD vs MM/DD date format difference', () => {
+    const vitals = [{ date: '2026-06-20', hrv: 32 }];
+    const load = [{ date: '06/20', tsb: 5 }];
+    const result = joinVitalsTsb(vitals, load);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ date: '06/20', hrv: 32, tsb: 5 });
+  });
+
+  it('excludes rows where HRV is null', () => {
+    const vitals = [
+      { date: '2026-06-20', hrv: null },
+      { date: '2026-06-19', hrv: 30 },
+    ];
+    const load = [
+      { date: '06/20', tsb: 5 },
+      { date: '06/19', tsb: 3 },
+    ];
+    const result = joinVitalsTsb(vitals, load);
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toBe('06/19');
+  });
+
+  it('excludes rows where no TSB match found', () => {
+    const vitals = [{ date: '2026-06-20', hrv: 30 }];
+    const load = [{ date: '06/15', tsb: 5 }];
+    const result = joinVitalsTsb(vitals, load);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/web/src/utils/recoveryAnalytics.js
+++ b/web/src/utils/recoveryAnalytics.js
@@ -1,0 +1,77 @@
+const RHR_DEFAULT = 57;
+const HRV_DEFAULT = 30;
+const SLEEP_TARGET = 7;
+
+function trimmedMean(values, fraction = 0.1) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = Math.max(1, Math.floor(sorted.length * fraction));
+  const trimmed = sorted.slice(n, sorted.length - n);
+  const source = trimmed.length ? trimmed : sorted;
+  return source.reduce((s, v) => s + v, 0) / source.length;
+}
+
+export function computePersonalBaselines(rows, minSamples = 14) {
+  const recent = (rows ?? []).slice(0, 28);
+  const rhrVals = recent.filter((r) => r.rhr != null).map((r) => Number(r.rhr));
+  const hrvVals = recent.filter((r) => r.hrv != null).map((r) => Number(r.hrv));
+  return {
+    rhrBaseline:
+      rhrVals.length >= minSamples
+        ? Math.round(trimmedMean(rhrVals) * 10) / 10
+        : RHR_DEFAULT,
+    hrvBaseline:
+      hrvVals.length >= minSamples
+        ? Math.round(trimmedMean(hrvVals) * 10) / 10
+        : HRV_DEFAULT,
+    sleepTarget: SLEEP_TARGET,
+  };
+}
+
+export function computeReadiness(latest, baselines = {}) {
+  const rhrBaseline = baselines.rhrBaseline ?? RHR_DEFAULT;
+  const hrvBaseline = baselines.hrvBaseline ?? HRV_DEFAULT;
+  const sleepTarget = baselines.sleepTarget ?? SLEEP_TARGET;
+  if (!latest) return { readinessScore: 0, readinessLabel: 'FATIGUED' };
+  let score = 100;
+  if (latest.rhr != null) score -= Math.max(0, latest.rhr - rhrBaseline) * 4;
+  if (latest.hrv != null) score -= Math.max(0, hrvBaseline - latest.hrv) * 1.5;
+  if (latest.sleep != null)
+    score -= latest.sleep < sleepTarget ? (sleepTarget - latest.sleep) * 8 : 0;
+  const readinessScore = Math.round(Math.min(100, Math.max(0, score)));
+  const readinessLabel =
+    readinessScore >= 80
+      ? 'READY'
+      : readinessScore >= 60
+        ? 'CAUTION'
+        : 'FATIGUED';
+  return { readinessScore, readinessLabel };
+}
+
+export function computeReadinessHistory(rows, baselines = {}) {
+  return (rows ?? [])
+    .slice(0, 14)
+    .reverse()
+    .map((row) => ({
+      date: row.date ? row.date.slice(5).replace('-', '/') : '',
+      readinessScore: computeReadiness(row, baselines).readinessScore,
+    }));
+}
+
+export function joinVitalsTsb(vitalsRows, loadData) {
+  const tsbByDate = {};
+  (loadData ?? []).forEach((d) => {
+    tsbByDate[d.date] = d.tsb;
+  });
+  return (vitalsRows ?? [])
+    .slice(0, 28)
+    .reverse()
+    .map((row) => {
+      const chartDate = row.date ? row.date.slice(5).replace('-', '/') : '';
+      return {
+        date: chartDate,
+        hrv: row.hrv ?? null,
+        tsb: tsbByDate[chartDate] ?? null,
+      };
+    })
+    .filter((d) => d.hrv != null && d.tsb != null);
+}

--- a/web/src/views/mobile/MobileRecovery.jsx
+++ b/web/src/views/mobile/MobileRecovery.jsx
@@ -1,4 +1,13 @@
 import React, { useMemo } from 'react';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  ResponsiveContainer,
+  ReferenceLine,
+  XAxis,
+} from 'recharts';
 import { useVitals } from '../../hooks/useVitals.js';
 import { useTSSHistory } from '../../hooks/useTSSHistory.js';
 import { calcTrainingLoad } from '../../utils/trainingLoad.js';
@@ -13,8 +22,19 @@ const C = {
   err: '#ff2d55',
 };
 
+const tickStyle = { fontSize: 9, fill: C.muted };
+
 export default function MobileRecovery() {
-  const { isLoading, latest, readinessScore, readinessLabel } = useVitals();
+  const {
+    isLoading,
+    latest,
+    readinessScore,
+    readinessLabel,
+    personalBaselines,
+    vitalsHistory,
+    history,
+    hasPersonalBaselines,
+  } = useVitals();
   const { data: tssHistory } = useTSSHistory();
   const tssSource = tssHistory?.length ? tssHistory : DAILY_TSS;
   const loadData = useMemo(() => calcTrainingLoad(tssSource), [tssSource]);
@@ -39,6 +59,35 @@ export default function MobileRecovery() {
       : readinessLabel === 'CAUTION'
         ? 'Train but monitor closely'
         : 'Prioritise recovery today';
+
+  const baselineLabel = hasPersonalBaselines ? 'your avg' : 'baseline';
+
+  const trend14 = useMemo(
+    () =>
+      vitalsHistory.slice(-14).map((r) => ({
+        ...r,
+        date: r.date ? r.date.slice(5).replace('-', '/') : '',
+      })),
+    [vitalsHistory]
+  );
+
+  const weightData = useMemo(() => {
+    const withWeight = vitalsHistory.filter((r) => r.bodyweight != null);
+    if (withWeight.length < 5) return null;
+    const slice = withWeight.slice(-14);
+    return slice.map((r, i, arr) => {
+      const window = arr.slice(Math.max(0, i - 6), i + 1);
+      const sma7 =
+        Math.round(
+          (window.reduce((s, w) => s + w.bodyweight, 0) / window.length) * 10
+        ) / 10;
+      return {
+        ...r,
+        date: r.date ? r.date.slice(5).replace('-', '/') : '',
+        sma7,
+      };
+    });
+  }, [vitalsHistory]);
 
   return (
     <div
@@ -88,13 +137,14 @@ export default function MobileRecovery() {
             No vitals recorded yet
           </div>
           <div style={{ fontSize: 11, color: C.muted, marginTop: 8 }}>
-            Connect Garmin or Fitbit to populate this view
+            Connect Google Health to populate this view
           </div>
         </div>
       )}
 
       {!isLoading && latest && (
         <>
+          {/* Readiness hero */}
           <div
             style={{
               background: C.panel,
@@ -136,6 +186,7 @@ export default function MobileRecovery() {
             </div>
           </div>
 
+          {/* Metric tiles */}
           <div
             style={{
               display: 'grid',
@@ -145,7 +196,10 @@ export default function MobileRecovery() {
             }}
           >
             {(() => {
-              const rhrDelta = (latest.rhr ?? 0) - 57;
+              const rhrDelta =
+                Math.round(
+                  ((latest.rhr ?? 0) - personalBaselines.rhrBaseline) * 10
+                ) / 10;
               const rhrColor =
                 rhrDelta > 5 ? '#ff2d55' : rhrDelta > 2 ? '#ffd700' : '#34d399';
               return (
@@ -167,11 +221,7 @@ export default function MobileRecovery() {
                     RESTING HR
                   </div>
                   <div
-                    style={{
-                      fontSize: 24,
-                      fontWeight: 700,
-                      color: rhrColor,
-                    }}
+                    style={{ fontSize: 24, fontWeight: 700, color: rhrColor }}
                   >
                     {latest.rhr ?? '—'} bpm
                   </div>
@@ -181,14 +231,17 @@ export default function MobileRecovery() {
                       : rhrDelta < 0
                         ? '↓ ' + rhrDelta
                         : '='}{' '}
-                    vs baseline
+                    vs {baselineLabel}
                   </div>
                 </div>
               );
             })()}
 
             {(() => {
-              const deficit = 30 - (latest.hrv ?? 0);
+              const deficit =
+                Math.round(
+                  (personalBaselines.hrvBaseline - (latest.hrv ?? 0)) * 10
+                ) / 10;
               const hrvColor =
                 deficit < 3 ? '#34d399' : deficit < 8 ? '#ffd700' : '#ff2d55';
               return (
@@ -210,19 +263,20 @@ export default function MobileRecovery() {
                     HRV
                   </div>
                   <div
-                    style={{
-                      fontSize: 24,
-                      fontWeight: 700,
-                      color: hrvColor,
-                    }}
+                    style={{ fontSize: 24, fontWeight: 700, color: hrvColor }}
                   >
                     {latest.hrv ?? '—'} ms
                   </div>
                   <div style={{ fontSize: 10, color: C.muted, marginTop: 4 }}>
-                    {latest.hrv >= 30
-                      ? '↑ +' + (latest.hrv - 30)
-                      : '↓ ' + (30 - latest.hrv)}{' '}
-                    vs baseline
+                    {(latest.hrv ?? 0) >= personalBaselines.hrvBaseline
+                      ? '↑ +' +
+                        Math.round(
+                          ((latest.hrv ?? 0) - personalBaselines.hrvBaseline) *
+                            10
+                        ) /
+                          10
+                      : '↓ ' + deficit}{' '}
+                    vs {baselineLabel}
                   </div>
                 </div>
               );
@@ -254,11 +308,7 @@ export default function MobileRecovery() {
                     SLEEP
                   </div>
                   <div
-                    style={{
-                      fontSize: 24,
-                      fontWeight: 700,
-                      color: sleepColor,
-                    }}
+                    style={{ fontSize: 24, fontWeight: 700, color: sleepColor }}
                   >
                     {latest.sleep ?? '—'}h
                   </div>
@@ -337,6 +387,220 @@ export default function MobileRecovery() {
               </div>
             )}
           </div>
+
+          {/* HRV 14-day trend */}
+          <div
+            style={{
+              background: C.panel,
+              borderRadius: 10,
+              padding: '14px',
+              marginBottom: 10,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 9,
+                letterSpacing: 2,
+                color: C.muted,
+                marginBottom: 6,
+              }}
+            >
+              HRV TREND — 14 DAYS
+            </div>
+            <ResponsiveContainer width="100%" height={110}>
+              <LineChart data={trend14}>
+                <XAxis
+                  dataKey="date"
+                  tick={tickStyle}
+                  axisLine={false}
+                  tickLine={false}
+                  interval="preserveStartEnd"
+                />
+                <ReferenceLine
+                  y={personalBaselines.hrvBaseline}
+                  stroke="#ff6b35"
+                  strokeDasharray="3 3"
+                />
+                <Line
+                  type="monotone"
+                  dataKey="hrv"
+                  stroke="#00d4ff"
+                  dot={false}
+                  strokeWidth={2}
+                  isAnimationActive={false}
+                  connectNulls
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          {/* RHR 14-day trend */}
+          <div
+            style={{
+              background: C.panel,
+              borderRadius: 10,
+              padding: '14px',
+              marginBottom: 10,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 9,
+                letterSpacing: 2,
+                color: C.muted,
+                marginBottom: 6,
+              }}
+            >
+              RESTING HR TREND — 14 DAYS
+            </div>
+            <ResponsiveContainer width="100%" height={110}>
+              <LineChart data={trend14}>
+                <XAxis
+                  dataKey="date"
+                  tick={tickStyle}
+                  axisLine={false}
+                  tickLine={false}
+                  interval="preserveStartEnd"
+                />
+                <ReferenceLine
+                  y={personalBaselines.rhrBaseline}
+                  stroke="#00d4ff"
+                  strokeDasharray="3 3"
+                />
+                <Line
+                  type="monotone"
+                  dataKey="rhr"
+                  stroke="#ff6b35"
+                  dot={false}
+                  strokeWidth={2}
+                  isAnimationActive={false}
+                  connectNulls
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          {/* Sleep 14-day bar chart */}
+          <div
+            style={{
+              background: C.panel,
+              borderRadius: 10,
+              padding: '14px',
+              marginBottom: 10,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 9,
+                letterSpacing: 2,
+                color: C.muted,
+                marginBottom: 6,
+              }}
+            >
+              SLEEP — 14 DAYS
+            </div>
+            <ResponsiveContainer width="100%" height={80}>
+              <BarChart data={trend14} barCategoryGap="20%">
+                <ReferenceLine y={7} stroke="#34d399" strokeDasharray="3 3" />
+                <Bar
+                  dataKey="sleep"
+                  fill="#a78bfa"
+                  radius={[3, 3, 0, 0]}
+                  isAnimationActive={false}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+
+          {/* 7-day readiness history */}
+          {history.length > 0 && (
+            <div
+              style={{
+                background: C.panel,
+                borderRadius: 10,
+                padding: '14px',
+                marginBottom: 10,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 9,
+                  letterSpacing: 2,
+                  color: C.muted,
+                  marginBottom: 6,
+                }}
+              >
+                READINESS — 7 DAYS
+              </div>
+              <ResponsiveContainer width="100%" height={80}>
+                <LineChart data={history.slice(-7)}>
+                  <ReferenceLine
+                    y={80}
+                    stroke="#34d399"
+                    strokeDasharray="3 3"
+                  />
+                  <ReferenceLine
+                    y={60}
+                    stroke="#ffd700"
+                    strokeDasharray="3 3"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="readinessScore"
+                    stroke={readinessColor}
+                    dot={false}
+                    strokeWidth={2}
+                    isAnimationActive={false}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {/* Bodyweight trend (only when ≥5 data points) */}
+          {weightData && (
+            <div
+              style={{
+                background: C.panel,
+                borderRadius: 10,
+                padding: '14px',
+                marginBottom: 10,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 9,
+                  letterSpacing: 2,
+                  color: C.muted,
+                  marginBottom: 6,
+                }}
+              >
+                BODYWEIGHT — 14 DAYS (kg)
+              </div>
+              <ResponsiveContainer width="100%" height={80}>
+                <LineChart data={weightData}>
+                  <Line
+                    type="monotone"
+                    dataKey="bodyweight"
+                    stroke="#ffd700"
+                    dot={false}
+                    strokeWidth={2}
+                    isAnimationActive={false}
+                    connectNulls
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="sma7"
+                    stroke="#ffd70088"
+                    strokeDasharray="4 4"
+                    dot={false}
+                    strokeWidth={1}
+                    isAnimationActive={false}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
Add 14-day trend charts, personalized baselines, and bodyweight tracking
to the Recovery tab, using the 30 days of vitals already fetched but
previously unused for trend analysis.

- schema: 003_add_vitals_columns.sql adds missing `source` and `sleep_score`
  columns referenced by app code and the upsert_vital RPC
- utils: recoveryAnalytics.js — pure functions for personalized baselines
  (trimmed mean of last 28 days for RHR/HRV), readiness history, and
  HRV/TSB join; 22 unit tests covering null safety, fallbacks, outlier
  trimming, and date format normalization
- hook: useVitals now fetches bodyweight, computes personalBaselines and
  readinessHistory, and returns vitalsHistory (ascending) and
  hasPersonalBaselines alongside existing fields
- view: MobileRecovery adds HRV trend, RHR trend, sleep bar, 7-day
  readiness history, and bodyweight (when ≥5 readings) as Recharts panels;
  metric tiles switch from hardcoded baselines to "your avg" once 14 days
  of data have accumulated

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019DbqVhSCgD4p3PGExQPpCH