### PR TITLE
housekeeping: Capacitor WebView post-merge handover doc

### DIFF
--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -61,3 +61,15 @@ Publishing as HTML (pubhtml) and publishing as CSV are separate actions. Each ta
 2. Complete Step 3 (test fixtures JSON) onward per the handover notes.
 3. Two manual actions: Vercel root dir + .env copy.
 4. WO-002 (Slack) can be threaded in any time — quick win.
+
+---
+
+## Session 2026-06-26 (continued)
+
+Native Kotlin/Compose Android app replaced with Capacitor 7.6.7 WebView shell (PR #32,
+merged to main). Android project is now at `web/android/`; CI pipeline rewritten to
+build web assets first, then `cap sync`, then Gradle.
+
+See `coach/WO-006-capacitor-webview-handover.md` for the six post-merge follow-up items
+(on-device verification, secret names, local dev setup, icons, test-fixtures note,
+safe-area insets).

--- a/coach/WO-006-capacitor-webview-handover.md
+++ b/coach/WO-006-capacitor-webview-handover.md
@@ -1,0 +1,112 @@
+# WO-006 — Capacitor WebView: Post-Merge Handover
+
+**Date:** 2026-06-26  
+**Status:** Open — follow-up items after PR #32 merged to main  
+**Context:** The native Kotlin/Compose Android app was replaced with a Capacitor 7.6.7
+WebView shell (`web/android/`). The migration is live on `main`. These are the remaining
+items in priority order.
+
+---
+
+## 1. On-device APK verification ⚠️ Highest priority
+
+CI builds pass (`ci-android.yml` → `build-apk` job produces the APK artifact) but no
+runtime verification has been done yet.
+
+**What to verify on a physical or emulated Android device (API 26+):**
+- APK installs without error
+- WebView loads — app opens to the login screen (React UI, not a blank page)
+- Supabase email/password auth works end-to-end (login → dashboard)
+- All five mobile tabs render and are interactive: Analytics, Erg, Log, Strength, Recovery
+- Back navigation and tab switching behave correctly
+
+**How to get the APK:**
+Download the `erg-dashboard-debug` artifact from the latest `ci-android.yml` run on `main`.
+
+---
+
+## 2. GitHub secret names — confirm before relying on CI
+
+`ci-android.yml` maps existing repo secrets into Vite env vars at web build time:
+
+```yaml
+env:
+  VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+```
+
+If `SUPABASE_URL` or `SUPABASE_ANON_KEY` don't exist in GitHub → Settings → Secrets and
+variables → Actions, the web build will succeed but the built app will have empty Supabase
+credentials and silently fail to connect at runtime.
+
+**Action:** Confirm both secrets exist in the repo's Actions secrets. They are already used
+by the web CI (`ci-web.yml`) and any Vercel deploy, so they should be present.
+
+---
+
+## 3. Local dev prerequisite — Android Studio
+
+The web assets in `web/android/app/src/main/assets/public/` are **gitignored** (generated
+at build time). Opening `web/android/` in Android Studio without syncing will result in an
+empty WebView.
+
+**Required before opening in Android Studio:**
+
+```bash
+cd web
+npm run build          # compile React → web/dist/
+npx cap sync android   # copy assets + regenerate capacitor.settings.gradle
+```
+
+This is documented in `web/android/CLAUDE.md`.
+
+---
+
+## 4. App icons — replace generic Capacitor defaults
+
+The scaffold ships generic Capacitor launcher icons. The app currently shows the default
+Capacitor icon on the Android home screen.
+
+**Files to replace** (drop in brand-appropriate PNGs of the correct size):
+```
+web/android/app/src/main/res/mipmap-mdpi/ic_launcher.png        (48×48)
+web/android/app/src/main/res/mipmap-hdpi/ic_launcher.png        (72×72)
+web/android/app/src/main/res/mipmap-xhdpi/ic_launcher.png       (96×96)
+web/android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png      (144×144)
+web/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png     (192×192)
+```
+Round variants (`ic_launcher_round.png`) at the same sizes.
+After replacing, run `npx cap sync android` and rebuild.
+
+---
+
+## 5. `test-fixtures/` — now web-only
+
+`test-fixtures/training-load/fixtures.json` was previously validated by both:
+- Kotlin `GetTrainingLoadUseCaseTest` (deleted with the native Android app)
+- Vitest `web/src/utils/__tests__/trainingLoad.test.js`
+
+**Vitest is now the sole consumer.** No action needed — the fixtures and the Vitest suite
+are unchanged. This is noted so a future session agent doesn't assume the Kotlin test still
+exists.
+
+---
+
+## 6. Safe-area insets on Android — monitor, don't fix yet
+
+`MobileApp.jsx` uses `env(safe-area-inset-bottom)` for bottom tab bar padding. This was
+written for PWA/iOS behaviour. Capacitor on Android with gesture navigation may render the
+bottom bar flush against the system navigation area.
+
+**Status:** Out of scope for the migration. Monitor during on-device testing (item 1).
+If padding looks wrong, a follow-on spec in `web/src/views/mobile/MobileApp.jsx` is the
+right fix.
+
+---
+
+## References
+
+- PR #32 — the migration commit
+- `web/android/CLAUDE.md` — Android WebView architecture docs
+- `web/capacitor.config.json` — Capacitor config (`appId`, `webDir`, `androidScheme`)
+- `.github/workflows/ci-android.yml` — two-job CI pipeline


### PR DESCRIPTION
## Summary

- Adds `coach/WO-006-capacitor-webview-handover.md` — six post-merge follow-up items from the Capacitor WebView migration (PR #32), in priority order: on-device APK verification, GitHub secret names, local dev prerequisites, app icons, test-fixtures coverage, safe-area insets
- Appends `LEARNING_LOG.md` with a Session 2026-06-26 (continued) entry referencing the handover doc

## Test plan

- [ ] CI passes (no web/android code changes — only docs)
- [ ] `coach/WO-006-capacitor-webview-handover.md` visible on `main` for future session agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019d4aqxUaEoeoscGezE7gYQ

---
_Generated by [Claude Code](https://claude.ai/code/session_019d4aqxUaEoeoscGezE7gYQ)_