### PR TITLE
feat(android): install Capacitor plugins for PM5 BLE, network, lifecycle, notifications (WO-006)

### DIFF
--- a/web/android/app/src/main/AndroidManifest.xml
+++ b/web/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"
@@ -38,4 +39,23 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- BLE — PM5 ergometer (Android 12+) -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
+
+    <!-- Network status (@capacitor/network) -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!-- Vibration (navigator.vibrate) -->
+    <uses-permission android:name="android.permission.VIBRATE" />
+
+    <!-- Local notifications (Android 13+, runtime permission requested in JS) -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <!-- Exact alarms required for predictable notification delivery (Android 12+) -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 </manifest>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,8 +9,12 @@
       "version": "1.3.0",
       "dependencies": {
         "@capacitor/android": "^8.4.1",
+        "@capacitor/app": "^8.0.0",
         "@capacitor/cli": "^8.4.1",
         "@capacitor/core": "^8.4.1",
+        "@capacitor/local-notifications": "^8.0.0",
+        "@capacitor/network": "^8.0.0",
+        "@capgo/capacitor-bluetooth-low-energy": "^8.1.0",
         "@supabase/supabase-js": "^2.108.2",
         "@tanstack/react-query": "^5.101.1",
         "mathjs": "^15.2.0",
@@ -1645,6 +1649,15 @@
         "@capacitor/core": "^8.4.0"
       }
     },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
+      "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/cli": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.4.1.tgz",
@@ -1684,6 +1697,33 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/local-notifications": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.2.0.tgz",
+      "integrity": "sha512-fvLY0w2w4MiX+DD4+Wv4DOwOLdzKZsMDwAcRv/Juudd+QbKbn69s6cM3xVqPwAiDqfnqsY4/S8xtQD6M73wY2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/network": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/network/-/network-8.0.1.tgz",
+      "integrity": "sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capgo/capacitor-bluetooth-low-energy": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capgo/capacitor-bluetooth-low-energy/-/capacitor-bluetooth-low-energy-8.2.0.tgz",
+      "integrity": "sha512-Ql0d1SalNUOBDCq075HNc5V9GNKwYdVxTodNV03uX4YKdtzbzsfdkwp3XTwZtTb+dkzweXbdQC9MkNIUDEs2AA==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {

--- a/web/package.json
+++ b/web/package.json
@@ -20,9 +20,13 @@
     ]
   },
   "dependencies": {
+    "@capgo/capacitor-bluetooth-low-energy": "^8.1.0",
     "@capacitor/android": "^8.4.1",
+    "@capacitor/app": "^8.0.0",
     "@capacitor/cli": "^8.4.1",
     "@capacitor/core": "^8.4.1",
+    "@capacitor/local-notifications": "^8.0.0",
+    "@capacitor/network": "^8.0.0",
     "@supabase/supabase-js": "^2.108.2",
     "@tanstack/react-query": "^5.101.1",
     "mathjs": "^15.2.0",

--- a/web/src/hooks/useOfflineQueue.js
+++ b/web/src/hooks/useOfflineQueue.js
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react';
+import { Capacitor } from '@capacitor/core';
+import { Network } from '@capacitor/network';
 import { supabase } from '../supabaseClient';
 
 const QUEUE_KEY = 'erg_pending_sessions';
@@ -42,15 +44,30 @@ export function useOfflineQueue() {
   const [pending, setPending] = useState(readQueue().length);
 
   useEffect(() => {
-    const sync = async () => {
-      if (navigator.onLine) {
+    const sync = async (connected) => {
+      if (connected) {
         const synced = await drainQueue();
         if (synced > 0) setPending(readQueue().length);
       }
     };
-    window.addEventListener('online', sync);
-    sync();
-    return () => window.removeEventListener('online', sync);
+
+    if (Capacitor.isNativePlatform()) {
+      let networkHandle;
+      Network.addListener('networkStatusChange', ({ connected }) =>
+        sync(connected)
+      ).then((h) => {
+        networkHandle = h;
+      });
+      Network.getStatus().then(({ connected }) => sync(connected));
+      return () => {
+        networkHandle?.remove();
+      };
+    } else {
+      const webSync = () => sync(navigator.onLine);
+      window.addEventListener('online', webSync);
+      webSync();
+      return () => window.removeEventListener('online', webSync);
+    }
   }, []);
 
   function addToQueue(session) {

--- a/web/src/hooks/usePM5.js
+++ b/web/src/hooks/usePM5.js
@@ -1,4 +1,6 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { Capacitor } from '@capacitor/core';
+import { App } from '@capacitor/app';
 import {
   connectToPM5,
   subscribeToRowingStatus,
@@ -17,6 +19,21 @@ export function usePM5() {
   const deviceRef = useRef(null);
   // Track peak metrics for end-of-session summary
   const peakMetrics = useRef({ maxWatts: 0, strokeCount: 0, samples: [] });
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+    const handle = App.addListener('pause', () => {
+      if (deviceRef.current?.gatt?.connected) {
+        disconnectPM5(deviceRef.current);
+        deviceRef.current = null;
+        setStatus('idle');
+        setMetrics(null);
+      }
+    });
+    return () => {
+      handle.then((h) => h.remove());
+    };
+  }, []);
 
   const connect = useCallback(async () => {
     setStatus('connecting');

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,11 +1,19 @@
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Capacitor } from '@capacitor/core';
+import { BluetoothLowEnergy } from '@capgo/capacitor-bluetooth-low-energy';
 import App from './erg-dashboard.jsx';
 import { supabase } from './supabaseClient.js';
 import { usePWAInstall } from './hooks/usePWAInstall.js';
 import { useIsMobile } from './hooks/useIsMobile.js';
 import MobileApp from './views/mobile/MobileApp.jsx';
+import { createNotificationChannels } from './utils/notifications.js';
+
+if (Capacitor.isNativePlatform()) {
+  BluetoothLowEnergy.shimWebBluetooth();
+  createNotificationChannels();
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/web/src/utils/notifications.js
+++ b/web/src/utils/notifications.js
@@ -1,0 +1,51 @@
+import { Capacitor } from '@capacitor/core';
+import { LocalNotifications } from '@capacitor/local-notifications';
+
+export async function createNotificationChannels() {
+  if (!Capacitor.isNativePlatform()) return;
+  await LocalNotifications.createChannel({
+    id: 'readiness',
+    name: 'Readiness Alerts',
+    importance: 3,
+    sound: 'default',
+  });
+}
+
+export async function requestNotificationPermission() {
+  if (!Capacitor.isNativePlatform()) return 'granted';
+  const { display } = await LocalNotifications.checkPermissions();
+  if (display === 'granted') return 'granted';
+  const { display: result } = await LocalNotifications.requestPermissions();
+  return result;
+}
+
+export async function scheduleReadinessAlert() {
+  const permission = await requestNotificationPermission();
+  if (permission !== 'granted') return;
+  await LocalNotifications.schedule({
+    notifications: [
+      {
+        id: 1001,
+        title: 'Readiness check',
+        body: "Check your TSB and plan today's session.",
+        schedule: { every: 'day', allowWhileIdle: true },
+        channelId: 'readiness',
+      },
+    ],
+  });
+}
+
+export async function scheduleSessionReminder(sessionLabel, atDate) {
+  const permission = await requestNotificationPermission();
+  if (permission !== 'granted') return;
+  await LocalNotifications.schedule({
+    notifications: [
+      {
+        id: Date.now() % 2147483647,
+        title: 'Session reminder',
+        body: sessionLabel,
+        schedule: { at: atDate, allowWhileIdle: true },
+      },
+    ],
+  });
+}

--- a/web/src/views/mobile/MobileApp.jsx
+++ b/web/src/views/mobile/MobileApp.jsx
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { Capacitor } from '@capacitor/core';
+import { App } from '@capacitor/app';
 import MobileAnalytics from './MobileAnalytics.jsx';
 import MobileSessionLog from './MobileSessionLog.jsx';
 import MobileStrength from './MobileStrength.jsx';
@@ -27,6 +29,20 @@ function PlaceholderCard({ message }) {
 
 export default function MobileApp() {
   const [activeTab, setActiveTab] = useState('analytics');
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+    const handle = App.addListener('backButton', () => {
+      if (activeTab !== 'analytics') {
+        setActiveTab('analytics');
+      } else {
+        App.minimizeApp();
+      }
+    });
+    return () => {
+      handle.then((h) => h.remove());
+    };
+  }, [activeTab]);
 
   let content;
   if (activeTab === 'analytics') {


### PR DESCRIPTION
## What changed and why

Installs four Capacitor 8 plugins to make the Android APK functionally complete per WO-006. Without this, `navigator.bluetooth` is `undefined` in Android WebView and the PM5 live session view is non-functional on Android. All other browser APIs (vibration, localStorage, service worker) already work in the WebView and are unchanged.

## Changes

**`@capgo/capacitor-bluetooth-low-energy`** — calls `BluetoothLowEnergy.shimWebBluetooth()` at startup (native only), which patches `navigator.bluetooth` so `pm5Bluetooth.js` and `usePM5.js` work without a full BLE rewrite. The web PWA continues to use the real Web Bluetooth API unchanged via `Capacitor.isNativePlatform()` guard.

**`@capacitor/network`** — replaces `navigator.onLine` / `window.addEventListener('online')` in `useOfflineQueue.js` with a reliable native network status listener. The browser/PWA path is preserved as a fallback.

**`@capacitor/app`** — `usePM5.js` disconnects BLE when the app is backgrounded (prevents GATT errors on next connect). `MobileApp.jsx` handles the Android hardware back button (navigate to analytics tab → `minimizeApp()` if already there).

**`@capacitor/local-notifications`** — new `utils/notifications.js` provides `scheduleReadinessAlert()` and `scheduleSessionReminder()` with permission handling and Android notification channel registration. Not wired to a schedule yet — acceptance test triggers manually.

**`AndroidManifest.xml`** — adds `BLUETOOTH_SCAN` (neverForLocation), `BLUETOOTH_CONNECT`, `android.hardware.bluetooth_le` feature, `ACCESS_NETWORK_STATE`, `VIBRATE`, `POST_NOTIFICATIONS`, `SCHEDULE_EXACT_ALARM`. `xmlns:tools` added for `tools:targetApi`.

`CapacitorHttp` is intentionally not enabled — it breaks Supabase Realtime WebSocket upgrades.

## How to test manually

1. `npm run build && npx cap sync android && cd android && ./gradlew :app:assembleDebug`
2. Install APK on Android device with BLE. Open Erg Live tab → tap Connect → PM5 streams watts/pace.
3. Background the app while PM5 is connected → no GATT error on next connect.
4. Airplane mode → log a session → restore network → session syncs without reload.
5. From console: `scheduleReadinessAlert()` → notification appears in system tray.
6. Open app in Chrome (web PWA) → `navigator.bluetooth` is the real Web Bluetooth API, no console errors.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkiXtiVwNgvn3LNm8XzJHR)_