### PR TITLE
feat(ble): activate native Bluetooth shim on Android APK

### DIFF
--- a/web/src/hooks/usePM5.js
+++ b/web/src/hooks/usePM5.js
@@ -22,6 +22,21 @@ export function usePM5() {
 
   useEffect(() => {
     if (!Capacitor.isNativePlatform()) return;
+    const initBle = async () => {
+      try {
+        const { BluetoothLowEnergy } =
+          await import('@capgo/capacitor-bluetooth-low-energy');
+        await BluetoothLowEnergy.requestPermissions();
+        BluetoothLowEnergy.shimWebBluetooth();
+      } catch (err) {
+        setError(err.message);
+      }
+    };
+    initBle();
+  }, []);
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
     const handle = App.addListener('pause', () => {
       if (deviceRef.current?.gatt?.connected) {
         disconnectPM5(deviceRef.current);


### PR DESCRIPTION
On Capacitor Android builds, Web Bluetooth is unavailable in the
WebView. On mount, usePM5 now dynamically imports the Capgo BLE plugin,
requests Android 12+ runtime permissions, and calls shimWebBluetooth()
to patch navigator.bluetooth — letting the existing pm5Bluetooth.js
connect/notify code run unchanged on both APK and browser.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S1s91zyw3cVs5AzZaEbZjb