### PR TITLE
docs: rewrite README to reflect current full-stack build and direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,130 +1,242 @@
-# Erg Coaching Dashboard — External Deployment
+# Erg Dashboard
 
-A standalone React app version of the training dashboard. Unlike the Claude
-artifact, this runs as a real web app: any npm library works, it can be hosted
-at a permanent URL, and it can grow a backend later.
+A personal training system for rowing, strength, and cycling — built to replace
+Strava, Garmin Connect, Concept2 Logbook, and TrainingPeaks with a single,
+fully personalised app.
 
----
+[![CI — Web](https://github.com/skizzy1986/erg-dashboard/actions/workflows/ci-web.yml/badge.svg)](https://github.com/skizzy1986/erg-dashboard/actions/workflows/ci-web.yml)
+[![CI — Android](https://github.com/skizzy1986/erg-dashboard/actions/workflows/ci-android.yml/badge.svg)](https://github.com/skizzy1986/erg-dashboard/actions/workflows/ci-android.yml)
 
-## WHAT THIS IS
-
-- **Framework:** React 18 + Vite (fast modern build tool)
-- **Dependencies:** recharts (charts), mathjs (trend regression)
-- **Output:** a static site (`dist/`) you can host anywhere
-
-The dashboard code is one file: `src/erg-dashboard.jsx`. Everything else is
-scaffolding.
+**v1.3.0** · React 18 + Supabase + Capacitor Android · Deployed on Vercel
 
 ---
 
-## STEP 1 — INSTALL NODE (one-time, on your computer)
+## What This Is
 
-You need Node.js (v18 or newer). Check if you have it:
-
-```
-node --version
-```
-
-If that errors or shows < v18, install the LTS version from https://nodejs.org
-(the "LTS" button). On Windows, the installer handles everything. Restart your
-terminal after installing.
+A full-stack training dashboard built by and for a 50+ recreational rower
+training toward competitive regattas. Not a generic fitness tracker — every
+feature is built to scratch a specific itch that commercial apps don't reach:
+live PM5 Bluetooth data in the browser, HRV-aware readiness scoring, an AI
+coach with full training context, and training load analytics (TSS/CTL/ATL/TSB)
+computed from real session data.
 
 ---
 
-## STEP 2 — RUN IT LOCALLY (see it on your machine)
+## Features
 
-From inside this folder:
+| View | What it does |
+|------|-------------|
+| **Overview** | TSS/CTL/ATL/TSB training load chart, weekly load summary |
+| **Calendar** | Month view of planned vs completed sessions |
+| **Program** | Microcycle schedule with prescribed workouts |
+| **ERG Live** | Real-time Bluetooth connection to Concept2 PM5 (watts, pace, HR) |
+| **Strength Log** | Session logging with PR tracking, rest timers, static hold timer |
+| **Mobility** | Mobility session tracking |
+| **Recovery** | HRV analytics dashboard, readiness score from Google Health data |
+| **Session Log** | Full history with filtering |
+| **Journal** | Daily training notes |
+| **AI Coach** | Streaming chat with Claude, training-context-aware system prompt |
 
-```
-npm install      # one-time: downloads dependencies (~30s)
-npm run dev      # starts the app
-```
+**Mobile:** Android APK (Capacitor 8) with dedicated mobile views — Analytics,
+Recovery, Strength, Session Log, Coach. PWA installable on iOS/web.
 
-It prints a local URL (usually http://localhost:5173). Open that in your
-browser. The app hot-reloads when you edit `src/erg-dashboard.jsx`, so changes
-appear instantly.
-
-To see it on your **phone** while developing: run `npm run dev -- --host`, then
-open the "Network" URL it prints from your phone (same wifi).
-
-Stop the server with Ctrl+C.
-
----
-
-## STEP 3 — BUILD FOR PRODUCTION
-
-```
-npm run build
-```
-
-This creates a `dist/` folder — a self-contained static site. That folder is
-what gets hosted.
-
-Preview the production build locally before deploying:
-
-```
-npm run preview
-```
+**Offline:** Service worker queues sessions written offline; syncs on reconnect.
 
 ---
 
-## STEP 4 — DEPLOY (pick ONE)
+## Stack
 
-### Option A — Vercel (recommended, easiest)
-
-1. Push this folder to a GitHub repo (see STEP 5).
-2. Go to https://vercel.com, sign in with GitHub.
-3. "Add New Project" → import your repo.
-4. Vercel auto-detects Vite. Leave defaults (build: `npm run build`,
-   output: `dist`). Click Deploy.
-5. ~1 minute later you get a permanent URL. Every git push auto-redeploys.
-
-`vercel.json` is already included so this is zero-config.
-
-### Option B — Netlify
-
-Same as Vercel: push to GitHub, connect at https://netlify.com, it detects
-Vite. Build command `npm run build`, publish directory `dist`.
-
-### Option C — Drag-and-drop (no git)
-
-After `npm run build`, go to https://app.netlify.com/drop and drag the `dist/`
-folder onto the page. Instant URL, no account setup. (Downside: no auto-deploy;
-you re-drag after each change.)
+| Layer | Technology |
+|-------|-----------|
+| Frontend | React 18 + Vite |
+| State / data fetching | TanStack React Query v5 |
+| Charts | Recharts |
+| Backend | Supabase (Postgres, Auth, Edge Functions on Deno) |
+| Mobile | Capacitor 8 → Android APK; PWA for iOS/web |
+| Hosting | Vercel (auto-deploy on push) |
+| Bluetooth | `@capgo/capacitor-bluetooth-low-energy` → Concept2 PM5 |
+| AI | Anthropic API (streaming) via Supabase Edge Function proxy |
+| Testing | Vitest + React Testing Library |
+| CI/CD | GitHub Actions |
+| Pre-commit | Husky + lint-staged |
 
 ---
 
-## STEP 5 — GIT (for auto-deploy)
+## Architecture
 
 ```
-git init
-git add .
-git commit -m "Initial dashboard"
+Browser / Android APK
+  └── React 18 SPA (web/src/)
+        ├── views/          — one component per tab (10 desktop + 5 mobile)
+        ├── hooks/          — data fetching (React Query + Supabase), derived state
+        ├── components/     — shared UI (charts, forms, log entries)
+        ├── utils/          — pure functions: TSS calc, HRV analytics, scheduling
+        └── constants/      — training config, exercise library, UI config
+              │
+              ▼
+        Supabase (Postgres + Auth)
+        ├── sessions        — all workouts (erg, strength, cycling, rest, planned)
+        ├── vitals          — daily RHR / HRV / sleep / bodyweight
+        ├── training_load   — computed daily TSS
+        ├── strength_logs   — per-set logs with weights and reps
+        └── coach_messages  — AI coach conversation history
+              │
+              ▼
+        Supabase Edge Functions (Deno)
+        ├── coach-chat        — Anthropic streaming API proxy (JWT-gated)
+        ├── vitals-import     — Google Sheets CSV → vitals (legacy cron)
+        ├── vitals-import-api — Google Health API → vitals (morning cron)
+        └── vitals-sync       — on-demand sync trigger
 ```
 
-Then create an empty repo on GitHub and follow its "push existing repo"
-instructions (two commands it gives you). After that, `git push` deploys.
+The main file `web/src/erg-dashboard.jsx` (~9,700 lines) is being decomposed
+into the modular structure above using a strangler-fig refactor — one safe
+extraction at a time, app stays functional throughout.
 
 ---
 
-## UPDATING THE DASHBOARD
+## Development Setup
 
-The dashboard is `src/erg-dashboard.jsx`. Edit it, then:
+### Prerequisites
 
-- **Local check:** `npm run dev` (instant preview)
-- **Deploy:** `git add . && git commit -m "..." && git push` (Vercel/Netlify
-  auto-rebuild), or `npm run build` + re-drag `dist/` for the drag-drop route.
+- Node.js 22+
+- A Supabase project (free tier works)
+
+### Environment variables
+
+Create `web/.env.local`:
+
+```
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+```
+
+For the `coach-chat` edge function, set `ANTHROPIC_API_KEY` in the Supabase
+Dashboard under Edge Functions → Secrets.
+
+### Local dev
+
+```bash
+cd web
+npm install
+npm run dev          # → http://localhost:5173
+```
+
+### Key commands
+
+```bash
+npm run dev          # Dev server with HMR
+npm run build        # Production build → dist/
+npm run preview      # Preview production build locally
+npm test             # Vitest test suite
+npm run lint         # ESLint
+npm run format       # Prettier (auto-fix)
+npm run format:check # Prettier check (no writes — used in CI)
+npx vitest run --coverage  # Tests + coverage report
+```
 
 ---
 
-## WHERE THIS CAN GO NEXT (optional, bigger projects)
+## Project Structure
 
-This static version unlocks but does not yet include:
+```
+erg-dashboard/
+├── web/
+│   ├── src/
+│   │   ├── constants/        training config, exercise library, UI config
+│   │   ├── hooks/            React Query hooks + Supabase data layer
+│   │   ├── utils/            TSS calc, HRV analytics, scheduling, formatting
+│   │   ├── components/       shared UI components
+│   │   ├── views/            desktop views (CoachView, ErgLiveView, …)
+│   │   │   └── mobile/       mobile-specific views (MobileApp, MobileRecovery, …)
+│   │   ├── services/         pm5Bluetooth.js (BLE abstraction)
+│   │   ├── erg-dashboard.jsx monolith being decomposed (~9,700 lines)
+│   │   └── main.jsx          auth gate (Supabase email/password)
+│   ├── android/              Capacitor Android project
+│   ├── capacitor.config.json
+│   └── vite.config.js        includes Vitest config + PWA manifest
+├── supabase/
+│   ├── functions/            Edge Functions (Deno)
+│   └── migrations/           SQL migration files
+└── .github/
+    └── workflows/
+        ├── ci-web.yml        lint → test → build
+        └── ci-android.yml    build web → sync Capacitor → build APK
+```
 
-- **Self-logging** (a backend + database so the app writes its own session
-  history instead of being a static snapshot). Needs a real backend build.
-- **Direct Strava/Drive pulls** (the app fetching your data itself). Needs API
-  auth + key handling — non-trivial, do deliberately.
+---
 
-These are legitimate next steps but each is a real project. The static deploy
-is the foundation they'd build on.
+## CI/CD
+
+### Web (`ci-web.yml`) — runs on every push and PR
+
+| Job | What it checks |
+|-----|---------------|
+| **Lint & Format** | ESLint + Prettier + `npm audit --audit-level=high` |
+| **Test & Coverage** | All Vitest tests pass; posts coverage summary as a PR comment |
+| **Build** | `npm run build` exits 0 (runs only after Test passes) |
+
+### Android (`ci-android.yml`) — runs on push to main/feature branches
+
+Builds web assets, syncs via `npx cap sync android`, assembles a debug APK
+with Gradle. The APK is uploaded as a build artifact (retained 14 days).
+
+### Other automation
+
+- **Branch protection on `main`:** direct pushes blocked; all changes go
+  through PRs with passing CI.
+- **Vercel:** auto-deploys on push to main; preview URLs on every PR.
+- **Dependabot:** weekly grouped PRs for npm and GitHub Actions updates.
+- **Pre-commit (Husky + lint-staged):** ESLint + Prettier run automatically on
+  staged `.js`/`.jsx` files before every local commit.
+
+---
+
+## Development Workflow
+
+All feature work flows through a **software factory** — a chain of specialist
+Claude agents coordinated by an orchestrator, with human approval gates before
+code is written and before code is merged.
+
+```
+/feature <description>   →  full pipeline
+/refactor <module>       →  safe strangler-fig extraction
+/research <topic>        →  research only, no code
+```
+
+**Pipeline:**
+
+```
+researcher  →  spec-writer  →  [APPROVE SPEC]
+            →  feature-builder  →  test-verifier  →  code-reviewer
+            →  [APPROVE BUILD]  →  PR  →  CI  →  merge
+```
+
+Agents live in `.claude/agents/`. The orchestrator never advances to the next
+stage without explicit approval.
+
+---
+
+## Roadmap
+
+These are planned but not yet built:
+
+- **Strava OAuth2** — activity auto-sync → sessions table
+- **Garmin Connect** — HRV/RHR/sleep import → vitals table
+- **Concept2 Logbook** — erg session auto-import
+- **TrainingPeaks / Ergzone** — replaced by native plan engine
+- **Signed Android release APK** — for Play Store or direct distribution
+
+The foundation for all of these exists: Supabase tables are schema-ready,
+the edge function pattern is established, and the vitals import pipeline
+(Google Health API) demonstrates the cron + on-demand sync model.
+
+---
+
+## Background
+
+Built by Scott with Claude. Started as a static React artifact; grew into a
+full-stack app as training got more serious. The architecture decisions
+(Supabase, Capacitor, strangler-fig refactor) reflect real constraints: a
+single developer, a phone-first training environment, and a preference for
+owning the data rather than being locked into commercial platforms.


### PR DESCRIPTION
Replace the outdated static-site deployment guide (written for v0.1) with an
accurate description of the v1.3.0 project: React 18 + Supabase + Capacitor
Android, 10-view dashboard, PM5 Bluetooth, AI coach, CI/CD pipelines, and the
strangler-fig refactor in progress.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YWB9MhFhKBmVRgVQ1xrDkC