### PR TITLE
Direct workflow through the "Split IQ" GitHub Project

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+Closes #<!-- issue number — links the PR to its issue so merging closes it and the Split IQ board moves it to Done -->
+
 ## What changed and why
 
 <!-- One sentence. What does this PR do and why is it needed? -->

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,30 @@
+name: Add to Split IQ
+
+# Adds new issues and PRs to the "Split IQ" GitHub Project as a CI-driven backstop
+# behind the board's built-in auto-add workflow (see WORKFLOW.md).
+#
+# This is a NO-OP until the ADD_TO_PROJECT_PAT secret is set, because the default
+# GITHUB_TOKEN cannot write to a user-owned Project v2. To enable:
+#   1. Create a classic PAT with `project` + `repo` scope (or a fine-grained PAT
+#      with project write), add it as repo secret ADD_TO_PROJECT_PAT.
+#   2. Replace <N> in project-url below with the Split IQ board's project number
+#      (from its URL: https://github.com/users/skizzy1986/projects/<N>).
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue/PR to the Split IQ board
+        env:
+          PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        if: env.PAT != ''
+        uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/users/skizzy1986/projects/<N>
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -3,12 +3,10 @@ name: Add to Split IQ
 # Adds new issues and PRs to the "Split IQ" GitHub Project as a CI-driven backstop
 # behind the board's built-in auto-add workflow (see WORKFLOW.md).
 #
-# This is a NO-OP until the ADD_TO_PROJECT_PAT secret is set, because the default
-# GITHUB_TOKEN cannot write to a user-owned Project v2. To enable:
-#   1. Create a classic PAT with `project` + `repo` scope (or a fine-grained PAT
-#      with project write), add it as repo secret ADD_TO_PROJECT_PAT.
-#   2. Replace <N> in project-url below with the Split IQ board's project number
-#      (from its URL: https://github.com/users/skizzy1986/projects/<N>).
+# This is a NO-OP unless the ADD_TO_PROJECT_PAT secret is set, because the default
+# GITHUB_TOKEN cannot write to a user-owned Project v2. The secret holds a classic
+# PAT with `project` + `repo` scope (or a fine-grained PAT with project write).
+# Target board: Split IQ — https://github.com/users/skizzy1986/projects/1
 
 on:
   issues:
@@ -26,5 +24,5 @@ jobs:
         if: env.PAT != ''
         uses: actions/add-to-project@v2.0.0
         with:
-          project-url: https://github.com/users/skizzy1986/projects/<N>
+          project-url: https://github.com/users/skizzy1986/projects/1
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
         if: env.PAT != ''
-        uses: actions/add-to-project@v1
+        uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/users/skizzy1986/projects/<N>
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,7 @@ vite-plugin-pwa).
 
 > The standing workflow is defined in **[`WORKFLOW.md`](WORKFLOW.md)**: every
 > change is a **GitHub Issue → branch → PR → CI → `main`**. The backlog is GitHub
-> Issues; status is a GitHub Projects board. The old `coach/work-orders/` system
+> Issues; status is the **"Split IQ"** GitHub Projects board. The old `coach/work-orders/` system
 > is **deprecated**. The steps below are the same PR flow, kept here for quick
 > reference.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -94,9 +94,10 @@ green. A coverage comment posts automatically.
 
 ---
 
-## The status board (GitHub Projects)
+## The status board — "Split IQ" (GitHub Projects)
 
-The board is the at-a-glance answer to "what's happening." Columns:
+The **Split IQ** board is the at-a-glance answer to "what's happening." All work is
+directed through it. Columns:
 
 ```
 Todo  →  In-progress  →  In-review  →  Done
@@ -105,14 +106,26 @@ Todo  →  In-progress  →  In-review  →  Done
 Issues enter in **Todo**, move to **In-progress** when you start a branch, to
 **In-review** when the PR opens, and to **Done** on merge.
 
-> **One-time manual setup (~2 min).** GitHub Projects boards can't be created by
-> automation, so create it once in the UI:
-> 1. Repo → **Projects** → **New project** → **Board** template → name it
->    "erg-dashboard".
-> 2. Add the four columns above (rename the defaults).
-> 3. **Add items** → pull in the open issues (the seeded backlog).
-> 4. Optionally set the board to auto-add new issues and auto-move on PR
->    open/merge (Project → Workflows).
+> **Board automation (one-time UI setup).** The board itself ("Split IQ") already
+> exists. GitHub Projects boards and their built-in workflows can't be configured by
+> repo automation, so turn these on once in the UI — *Project → ⋯ → **Workflows*** —
+> so items flow without manual dragging:
+> 1. **Auto-add to project** → filter `is:issue is:open` (and a second rule for
+>    `is:pr is:open`) → sets **Status = Todo**. This pulls every new issue/PR in.
+> 2. **Item reopened / added** → **Status = Todo**.
+> 3. **Pull request merged** and **Item closed** → **Status = Done**.
+>    (Pair with `Closes #N` in the PR body — see §3 — so a merge closes the issue and
+>    moves it to Done in one step.)
+> 4. Move to **In-progress** / **In-review** by hand when you start a branch / open a
+>    PR (Projects has no native "branch created" trigger).
+
+> **Committed auto-add fallback.** `.github/workflows/add-to-project.yml` adds new
+> issues/PRs to Split IQ from CI as a belt-and-suspenders layer behind the built-in
+> auto-add rule. It stays a **no-op until** you add the `ADD_TO_PROJECT_PAT` secret,
+> because the default `GITHUB_TOKEN` can't write to a user-owned project. To enable:
+> create a **classic PAT** with `project` + `repo` scope (or a fine-grained PAT with
+> project write), add it as repo secret **`ADD_TO_PROJECT_PAT`**, then set the board's
+> project number in `project-url` inside that workflow.
 
 ---
 


### PR DESCRIPTION
<!-- No tracking issue — this formalizes the new "Split IQ" board in the workflow docs. -->

## What changed and why

Points the documented status board at the new **"Split IQ"** Project so all work flows through it, and adds the one piece of board automation that can live in the repo.

- **`WORKFLOW.md`** — renames the status board to **Split IQ**; promotes GitHub's built-in Project workflows (auto-add → Todo, PR-merged / item-closed → Done) from "optional" to the recommended setup; documents the `ADD_TO_PROJECT_PAT` secret.
- **`CLAUDE.md`** — names the status board "Split IQ" in the Change Procedure (WORKFLOW.md stays authoritative).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — adds a `Closes #` reminder so merging closes the issue and the board moves it to Done.
- **`.github/workflows/add-to-project.yml`** (new) — adds new issues/PRs to Split IQ from CI as a backstop behind the built-in auto-add. **Gated on `ADD_TO_PROJECT_PAT`** so it's a no-op (step skipped, CI stays green) until the secret + project number are set.

**Why gated:** the default Actions `GITHUB_TOKEN` cannot write to a *user-owned* Project v2 — that needs a PAT with `project` + `repo` scope. Built-in Project workflows need no secret but are UI-only.

## How to test manually

- New workflow parses as valid YAML; with no `ADD_TO_PROJECT_PAT` secret the `add-to-project` step is **skipped**, so CI Web/Android stay green.
- Changes touch only root markdown + `.github/` — no app code, no `src/` files, so lint/test/build/coverage are unaffected (`format:check` is scoped to `src/`).

### To activate after merge (2 min, not blocking this PR)
1. In the **Split IQ** board → *⋯ → Workflows*: enable Auto-add (`is:issue is:open`, `is:pr is:open`) and PR-merged / item-closed → Done.
2. Create a classic PAT (`project` + `repo`), add it as repo secret `ADD_TO_PROJECT_PAT`, and replace `<N>` in `add-to-project.yml` with the Split IQ project number.

## Checklist

- [x] CI is green (lint, test, build) — no app code changed; new workflow is gated/skips
- [x] Tests cover the change, or I've noted why they don't — docs + CI-config only, no testable logic
- [x] `npm run build` passes locally — unaffected (no `src/` changes)
- [x] No unexpected console errors in the browser — N/A (no app code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAadY5LuRqBoLaX9oVAraf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAadY5LuRqBoLaX9oVAraf)_