### PR TITLE
infra: automate the Issue → PR → CI workflow rail

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -1,0 +1,74 @@
+# Agent routing — which agent for which job
+
+> The full Agency library (232 agents, 16 divisions) plus 12 erg pipeline agents
+> are installed in `.claude/agents/`. This file is the map: pick the right one
+> fast instead of scrolling 244 files. Background on the library is in CLAUDE.md
+> ("Agency Agents"); the build pipeline is in FACTORY.md.
+
+## Always give Agency agents erg context
+
+Agency agents are generic — they know nothing about rowing, CTL/ATL, or the schema.
+Paste this when you invoke one:
+
+> Personal rowing/cycling/strength training dashboard (React 18 + Vite, Supabase,
+> Vercel, Capacitor/Android). `sessions` table = all workouts; `vitals` table =
+> daily RHR/HRV/sleep/bodyweight. Training-load model is CTL/ATL/TSB. Domain
+> detail lives in `.claude/skills/` (training-science, supabase-patterns,
+> architecture, testing-patterns).
+
+## First choice: build through the pipeline, not loose agents
+
+For anything that ships code, use the command — it sequences the right pipeline
+agents and gates on your approval. Reach for individual Agency agents only for the
+advisory/planning work in the table below.
+
+| Command | Use for |
+|---|---|
+| `/feature <desc>` or `/orchestrate` | New feature or bug fix — full chain: research → spec → build → test → review → PR |
+| `/refactor <module>` | One strangler-fig extraction from `erg-dashboard.jsx` |
+| `/research <topic>` | Investigate an API/library/concept before building |
+
+Pipeline agents (in `.claude/agents/`, driven by the orchestrator): `researcher`,
+`story-writer`, `spec-writer`, `backend-builder`, `frontend-builder`,
+`test-verifier`, `implementation-validator`, `code-reviewer`, `refactor-agent`.
+
+## Advisory Agency agents — task → agent
+
+Only four divisions are high-value for a solo dashboard. The rest (game-dev, GIS,
+sales, real-estate, …) are noise here.
+
+### Product — what to build next
+| Task | Agent |
+|---|---|
+| Re-rank the backlog, decide what's next | `product-manager` |
+| Plan a focused batch / "sprint" of issues | `product-sprint-prioritizer` (Sprint Prioritizer) |
+| Turn raw user feedback into priorities | `feedback-synthesizer` |
+
+### Project management — sequencing & tracking
+| Task | Agent |
+|---|---|
+| Track in-flight issues/PRs, flag stalls | `project-management-project-shepherd` (Project Shepherd) |
+| Turn a rough idea into well-formed, sequenced issues | `project-manager-senior` |
+| Map a multi-step effort into a dependency-ordered plan | `experiment-tracker` / `project-shepherd` |
+
+### Testing — quality & coverage
+| Task | Agent |
+|---|---|
+| Interpret a coverage report, find the weak spots | `testing-test-results-analyzer` (Test Results Analyzer) |
+| Validate an API/integration before wiring it in | `api-tester` |
+| Audit accessibility of a view | `accessibility-auditor` |
+| Performance-profile a slow view or query | `performance-benchmarker` |
+
+### Support — ops & reporting
+| Task | Agent |
+|---|---|
+| Supabase / Vercel health, deploy or runtime issues | `infrastructure-maintainer` |
+| Turn dashboard data into a written readout | `analytics-reporter` |
+| Optimise a repetitive manual process | `workflow-optimizer` |
+
+## Rule of thumb
+
+Advisory agents **inform, plan, and validate** — they don't write app code. Code
+ships only through the pipeline (`/feature`, `/orchestrate`, `/refactor`) and lands
+as a PR per WORKFLOW.md. If an Agency agent's output is a recommendation, the next
+step is an Issue, not a commit.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,42 @@
+name: 🐛 Bug
+description: Something is broken or behaving incorrectly
+labels: ['P1', 'bug']
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: What's wrong
+      description: One or two sentences on the broken behaviour.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: input
+    id: expected
+    attributes:
+      label: Expected
+      description: What should have happened?
+    validations:
+      required: true
+  - type: input
+    id: actual
+    attributes:
+      label: Actual
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Environment / context
+      description: Web or Android APK? Console errors? Affected view (Coach, ErgLive, mobile tab)?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,32 @@
+name: 🧹 Chore
+description: Config, infra, dependencies, docs, or housekeeping
+labels: ['infra']
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs doing
+      description: The housekeeping task and why it's worth doing.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - config
+        - infra (CI / workflows)
+        - dependencies
+        - docs
+        - testing
+      multiple: true
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of done
+      value: |
+        - [ ]
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 How work flows here
+    url: https://github.com/skizzy1986/erg-dashboard/blob/main/WORKFLOW.md
+    about: Read WORKFLOW.md first — every change is an Issue → branch → PR → CI → main.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,37 @@
+name: ✨ Feature
+description: A new capability or enhancement to build
+labels: ['P2']
+body:
+  - type: input
+    id: outcome
+    attributes:
+      label: Outcome-shaped title check
+      description: Restate the goal as an outcome, not a vibe ("Sync Strava activities into sessions", not "Strava stuff").
+      placeholder: When this ships, the user can…
+    validations:
+      required: true
+  - type: textarea
+    id: what-why
+    attributes:
+      label: What and why
+      description: What are we building, and why is it worth doing now?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: A checklist of observable conditions that mean "done".
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / context
+      description: Affected files, training-science context (CTL/ATL, sessions/vitals), or links.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,42 @@
+name: 🧱 Refactor
+description: Extract or restructure code (strangler-fig decomposition of the monolith)
+labels: ['refactor']
+body:
+  - type: input
+    id: module
+    attributes:
+      label: Module / target
+      description: What's being extracted or restructured? (e.g. "StrengthLogger.jsx → views/")
+    validations:
+      required: true
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Target layer
+      description: Per the strangler-fig migration order in .claude/skills/architecture.md.
+      options:
+        - constants
+        - utils
+        - hooks
+        - components
+        - views
+        - entry point (App.jsx)
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (one extraction only)
+      description: One extraction per issue. What moves, what stays, what props thread through?
+    validations:
+      required: true
+  - type: textarea
+    id: safety
+    attributes:
+      label: Safety check
+      value: |
+        - [ ] App stays fully functional after the move (no behaviour change)
+        - [ ] Tests pass / added for the extracted unit
+        - [ ] `npm run build` exits 0
+    validations:
+      required: false

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,36 @@
+# PR auto-labeler config (actions/labeler@v5). Maps changed paths to the area
+# labels defined in .github/labels.yml. Labels must already exist (synced by
+# .github/workflows/labels.yml).
+
+testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/__tests__/**'
+          - '**/*.test.{js,jsx}'
+
+android:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'web/android/**'
+          - 'web/capacitor.config.json'
+
+integration:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'supabase/**'
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+
+infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+refactor:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'web/src/erg-dashboard.jsx'
+          - 'web/src/StrengthLogger.jsx'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,39 @@
+# Canonical label taxonomy for erg-dashboard (see WORKFLOW.md §1).
+# Synced to the repo by .github/workflows/labels.yml. Edit here, not in the UI.
+
+# Priority — relative stack rank, re-sorted often.
+- name: P0
+  color: 'b60205'
+  description: Do now — blocks other work or keeps the system honest
+- name: P1
+  color: 'd93f0b'
+  description: Next — most valuable in-flight feature or foundation
+- name: P2
+  color: 'fbca04'
+  description: Later — quality, or large new bets
+
+# Type / area
+- name: bug
+  color: 'd73a4a'
+  description: Something is broken or behaving incorrectly
+- name: refactor
+  color: '5319e7'
+  description: Strangler-fig decomposition of the monolith
+- name: integration
+  color: '0e8a16'
+  description: External data source (Strava, Garmin, Concept2) or Supabase backend
+- name: testing
+  color: '1d76db'
+  description: Tests, coverage, and test tooling
+- name: docs
+  color: '0075ca'
+  description: Documentation and project process
+- name: infra
+  color: 'c5def5'
+  description: CI, workflows, config, build
+- name: android
+  color: '3ddc84'
+  description: Capacitor / Android APK
+- name: dependencies
+  color: '0366d6'
+  description: Dependency updates (Dependabot)

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: Dependabot auto-merge
+
+# Auto-approves and enables auto-merge for Dependabot patch/minor PRs. Auto-merge
+# only completes once the required CI gates (lint, test, build) are green, so the
+# existing checks remain authoritative. Major updates are left for manual review.
+#
+# Prerequisite: repo Settings → General → "Allow auto-merge" must be enabled.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Approve and auto-merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge (patch & minor)
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR labeler
+
+# Applies area labels to PRs based on which files changed (see .github/labeler.yml).
+
+on: [pull_request_target]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label by changed paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,29 @@
+name: Sync labels
+
+# Keeps the repo's labels in lockstep with .github/labels.yml so issue templates
+# and the PR auto-labeler always have the labels they reference.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels.yml
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    name: Sync labels from labels.yml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          # Leave labels not in labels.yml in place (e.g. GitHub defaults); set
+          # to true later for a strict, fully-managed taxonomy.
+          delete-other-labels: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ Every PR is gated by three GitHub Actions jobs that must pass before merge:
 | Job | What it checks |
 |---|---|
 | `Lint & Format` | ESLint errors + Prettier formatting + `npm audit --audit-level=high` |
-| `Test & Coverage` | All Vitest tests pass; line ≥70%, function ≥70%, branch ≥60% |
+| `Test & Coverage` | All Vitest tests pass; line ≥50%, function ≥30%, branch ≥35% |
 | `Build` | `npm run build` exits 0 (runs only after Test passes) |
 
 Coverage thresholds are defined in `vite.config.js` (`test.coverage.thresholds`).
@@ -195,6 +195,9 @@ In addition to the 12 project-specific pipeline agents, the **complete Agency
 agent library** (`msitarzewski/agency-agents`) is installed: **16 divisions,
 232 agents**. They are advisory and operational — they inform, plan, validate,
 and support, but do **not** write code directly or replace the core pipeline.
+
+> **Which agent for which job?** See **[`.claude/AGENTS.md`](.claude/AGENTS.md)** —
+> a task → agent routing map so the 244-file library is navigable, not sprawl.
 
 Installed in **two locations** (2026-06-29):
 - Globally at `~/.claude/agents/` (the upstream installer's default).
@@ -299,4 +302,4 @@ without needing to prompt Coach.
 - Always run `npm test` before committing
 - Always run `npm run lint` and `npm run format:check` before pushing — CI will fail if either does not pass
 - Never bypass the pre-commit hook (`--no-verify`) without an explicit reason
-- Coverage thresholds (70% lines/functions, 60% branches) are enforced in CI — new code should include tests
+- Coverage thresholds (50% lines, 30% functions, 35% branches — see `web/vite.config.js`) are enforced in CI — new code should include tests

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -79,11 +79,13 @@ Three required checks on every PR (`.github/workflows/ci-web.yml`):
 | Gate | Checks |
 |---|---|
 | **Lint & Format** | ESLint + Prettier + `npm audit --audit-level=high` |
-| **Test & Coverage** | Vitest passes; line ≥70%, function ≥70%, branch ≥60% |
+| **Test & Coverage** | Vitest passes; line ≥50%, function ≥30%, branch ≥35% |
 | **Build** | `npm run build` exits 0 (runs after Test) |
 
 `main` is protected: no direct pushes, branch must be up to date, all checks
-green. A coverage comment posts automatically.
+green. A coverage comment posts automatically. The coverage numbers are the
+source of truth in `web/vite.config.js` (`test.coverage.thresholds`) — update
+them there, then mirror here.
 
 ## 5. Merge and clean up
 


### PR DESCRIPTION
## What changed and why

Turns the workflow that WORKFLOW.md *documents* into one that's actually *automated*, and fixes a CI gate the docs got wrong. Config/docs only — no app code, no `web/` build impact.

- **Issue templates + label taxonomy** — `.github/ISSUE_TEMPLATE/` forms (feature, bug, refactor, chore) with auto-applied default labels and blank issues disabled; the WORKFLOW.md label set defined in `.github/labels.yml` and synced to the repo by a `label-sync` workflow.
- **Dependabot auto-merge** — patch/minor PRs self-approve and auto-merge once CI is green; majors stay manual.
- **PR auto-labeler** — `actions/labeler` applies area labels by changed path.
- **Agent routing index** — `.claude/AGENTS.md` maps common tasks to the right Agency/pipeline agents (the 244-file library was unnavigable); linked from CLAUDE.md.
- **Coverage docs corrected** — WORKFLOW.md and CLAUDE.md now state the truly-enforced **50/30/35** (was incorrectly documented as 70/70/60), with `web/vite.config.js` named as the source of truth.

## How to test manually

- Issue forms render under *New issue* with correct default labels; blank issues disabled.
- After merge: run the **Sync labels** workflow once (Actions → Run workflow) to create the taxonomy.
- This PR should auto-receive the `infra` + `docs` labels from the labeler once labels exist.

**Requires one repo setting:** Settings → General → *Allow auto-merge* must be enabled for Dependabot auto-merge to complete.

## Checklist

- [ ] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — _config/docs only; no app code to test. All new YAML validated as parseable._
- [x] `npm run build` passes locally — _unaffected; no `web/` changes_
- [x] No unexpected console errors in the browser — _N/A_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyCVpRf1R6SGFQn2EoZGay)_