### PR TITLE
ci: make coverage scope explicit + ratchet from honest baseline

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -52,10 +52,36 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'json'],
+      // Make scope explicit. Without `include` + `all`, v8 only counts files a
+      // test happens to import, so the untested monolith is invisible and the
+      // gate passes by accident. `all: true` counts every in-scope src file.
+      all: true,
+      include: ['src/**'],
+      // Excluded from the coverage denominator (documented why each is here):
+      //  - erg-dashboard.jsx: the not-yet-decomposed monolith (#52). Each
+      //    extraction PR removes the file(s) it extracts from this list in the
+      //    same PR, so a file cannot leave `exclude` without hitting threshold.
+      //  - StrengthLogger.jsx: large untested component, extraction tracked (#79).
+      //  - main.jsx: auth/bootstrap entry point, not unit-testable in jsdom.
+      //  - constants/**: pure data tables — no logic to cover; counting them
+      //    only distorts the denominator.
+      //  - test-setup.js: the test harness itself.
+      exclude: [
+        'src/erg-dashboard.jsx',
+        'src/StrengthLogger.jsx',
+        'src/main.jsx',
+        'src/constants/**',
+        'src/test-setup.js',
+      ],
+      // Baseline measured 2026-06-29 after making scope explicit (was passing
+      // by accident at ~74% because only test-imported files counted). These
+      // are the honest starting numbers — RATCHET THEM UP as each extraction
+      // PR removes a file from `exclude` and lands its tests. Never lower them.
+      //   measured: lines 48.98 / functions 46.81 / branches 40.38
       thresholds: {
-        lines: 70,
-        functions: 70,
-        branches: 60,
+        lines: 48,
+        functions: 46,
+        branches: 40,
       },
     },
   },


### PR DESCRIPTION
Closes #62

## What changed and why

Makes the coverage gate honest: v8 only counts files a test happens to import, so with no `coverage.include`/`all` the 8,715-line monolith was invisible to the gate and coverage was passing **by accident** (~74% measured across only ~17 imported files). This adds `coverage.all` + `include: ['src/**']` so every in-scope source file counts, excludes the not-yet-extracted surfaces, and resets the thresholds to the real measured baseline so the gate becomes an honest **ratchet**.

**Scope now explicit (`web/vite.config.js`):**
- `all: true` + `include: ['src/**']` — count every in-scope file, not just test-imported ones.
- `exclude` (each documented inline): `erg-dashboard.jsx` (the monolith, #52), `StrengthLogger.jsx` (#79), `main.jsx` (auth/bootstrap entry), `constants/**` (pure data), `test-setup.js` (the harness).

**Baseline measured after scoping** — the honest starting numbers:

| Metric | Before (by accident) | After (real) | Threshold set |
|---|---|---|---|
| Lines | 74.74% | **48.98%** | 48 |
| Functions | 71.34% | **46.81%** | 46 |
| Branches | 65.46% | **40.38%** | 40 |

**The discipline this unlocks:** every later extraction PR under #52 removes the file(s) it extracts from `exclude` **in the same PR**, so a file cannot leave the exclude list without meeting threshold — "test every extraction" is now mechanically enforced. Ratchet the thresholds up as coverage rises; never lower them.

Keystone of the C-series (#61). **Must merge before any extraction PR under #52.**

## How to test manually

Not needed — config-only change, fully exercised by CI. To verify locally: `cd web && npx vitest run --coverage` reports against the explicit file set and exits 0 at the baseline above.

## Checklist

- [x] CI is green (lint, test, build) — verified locally: coverage exit 0, build exit 0, lint 0 errors, format clean
- [x] Tests cover the change, or I've noted why they don't — config-only; the existing 193-test suite is the exercise
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

---

> **Heads-up (out of scope, not fixed here):** `web/package-lock.json` has no entry for `@vitest/coverage-v8` though it's in `package.json` devDeps — CI's `npx vitest run --coverage` auto-fetches it at runtime so coverage works, but `npm ci` won't install it. Worth a follow-up `npm install` + lockfile commit to pin it. Kept out of this keystone to stay minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLks4YNjeoUsUHc5SDLVkx)_