### PR TITLE
docs: reconcile CLAUDE.md + architecture.md against reality (H0)

### DIFF
--- a/.claude/skills/architecture.md
+++ b/.claude/skills/architecture.md
@@ -10,20 +10,24 @@ description: >
 
 ```
 src/
-  constants/
-    colors.js         C (session type colors), ICON, LIFT_COLOR, HR_ZONES
-    calibration.js    CALIBRATION_STATUS, CRITICAL_POWER, POWER_DURATION, FTP_TEST
-    program.js        PHASES, STRENGTH_TEMPLATES, BUILD1_SESSIONS, REP_SCHEMES,
-                      LOWER_DIFFERENTIATION, VOLUME_EXTRAS
-    season.js         SEASON, SEASON_2, EVENT_LADDER, EVENT_PATHWAY, ANNUAL_ARC,
-                      ATHLETE_BACKGROUND, MICROCYCLE
-    guide.js          SRPE_GUIDE, NUTRITION_PRINCIPLES, STRENGTH_PRINCIPLES,
-                      PREHAB_NOTE, TECHNIQUE_WORK, MOVEMENT_SCREEN,
-                      MOBILITY_WARMUP, NIGGLES, TECHNOGYM_CONVERSION,
-                      DAILY_ROUTINE, ADAPTIVE_RULES, RULE_EVOLUTION
-    logs.js           recoveryLog, nutritionLog, bpLog, mobilityLog, bloodsLog,
-                      DECISION_LOG, HYPOTHESES, RULE_FIRING_HISTORY,
-                      CONFIDENCE_MIGRATION, ergTrend, DAILY_TSS
+  constants/            ACTUAL flat layout. The colors/calibration/program/season/
+                        guide/logs split was the original plan; the files were
+                        extracted flat instead — THIS is the real convention, name
+                        new constant files to match it:
+    ui.js             C (session-type colors), ICON
+    trainingConfig.js SRPE_GUIDE, SRPE_SCALE, CALIBRATION_STATUS, CRITICAL_POWER,
+                      POWER_DURATION, FTP_TEST, HR_ZONES, PACE_ZONES, HR130_POWER,
+                      EST_MHR, RHR_BASELINE, HRV_BASELINE
+    schedule.js       PHASES, PHASE_CONTEXT, MICROCYCLE, SEASON, SEASON_2,
+                      EVENT_LADDER, VOLUME_PROGRESSION
+    exercises.js      STRENGTH_TEMPLATES, REP_SCHEMES, LOWER_DIFFERENTIATION,
+                      PREHAB_NOTE, STRENGTH_PRINCIPLES
+    nutrition.js      MACRO_TARGETS, NUTRITION_TARGETS, MF_PROGRAM, DEFICIT_PROGRAM,
+                      FUELLING, NUTRITION_PRINCIPLES
+    tssData.js        DAILY_TSS
+    (logs.js + coaching.js — recoveryLog, nutritionLog, bpLog, DECISION_LOG,
+     HYPOTHESES, RULE_FIRING_HISTORY, ADAPTIVE_RULES, DAILY_ROUTINE, RULE_EVOLUTION,
+     ergTrend — are still inside the monolith; PR1 (#68) extracts them flat.)
 
   hooks/
     useSessions.js    Supabase fetch + merge with seed; returns { sessions, dbStatus }
@@ -49,19 +53,32 @@ src/
       ErgChart.jsx    HR130 barometer + ErgTooltip
       StrengthChart.jsx e1RM trend + StrengthTooltip
 
-  views/
-    OverviewView.jsx    Tab: home dashboard (lines 2864–3223)
-    CalendarView.jsx    Tab: 17-day calendar (lines 2108–2175)
-    ProgramView.jsx     Tab: periodization, templates, rules (lines 2176–2863)
-    PlanView.jsx        Tab: upcoming planned sessions (lines 2072–2107)
-    ErgView.jsx         Tab: erg analytics, HR130 (lines 3224–3413)
-    StrengthView.jsx    Tab: e1RM trends (lines 3414–3505)
-    MobilityView.jsx    Tab: mobility routines (lines 3506–3579)
-    RecoveryView.jsx    Tab: HRV/RHR/sleep, readiness (lines 3580–3755)
-    LogView.jsx         Tab: session history (lines 3756–3793)
-    JournalView.jsx     Tab: decision log, hypotheses (lines 3794–3871)
+  views/                Extract by TAB ID, one per PR. Find each tab by its
+                        section heading / tab constant in erg-dashboard.jsx —
+                        do NOT trust absolute line numbers: the monolith is
+                        ~8,715 lines and every extraction shifts the offsets.
+    CoachView.jsx       ✓ extracted    AI coach tab
+    ErgView.jsx         ✓ extracted    erg analytics, HR130, pace/splits
+    ErgLiveView.jsx     ✓ extracted    live PM5 Bluetooth
+    JournalView.jsx     tab `journal`  — decision log, hypotheses        (PR5, #72)
+    RecoveryView.jsx    tab `recovery` — HRV/RHR/sleep, readiness         (PR6, #73)
+    OverviewView.jsx    tab `overview` — home dashboard (~1,370 lines)    (PR7, #74)
+    StrengthView.jsx    tab `strength` — e1RM trends                      (PR8, #75)
+    MobilityView.jsx    tab `mobility` — mobility routines                (PR9, #76)
+    CalendarView.jsx    tab `calendar` — 17-day calendar                  (#78)
+    PlanView.jsx        tab `plan`     — upcoming planned sessions        (#78)
+    LogView.jsx         tab `log`      — session history                  (#78)
+    program/            tab `program`  — ~3,071 lines, SPLIT (see below)  (#77)
 
-  App.jsx     Global state + nav tabs + ErrorBoundary + view dispatch (~200 lines)
+  views/program/        The Program tab is too large for one ProgramView.jsx.
+                        Decision recorded in H0 (#67): split across ~3 PRs into —
+    ProgramView.jsx       shell + tab navigation
+    ProgramPhases.jsx     PHASES, ANNUAL_ARC
+    ProgramMicrocycle.jsx 2-week roster
+    ProgramYear.jsx       EVENT_PATHWAY year view
+
+  App.jsx     Global state + nav tabs + ErrorBoundary + view dispatch (~200 lines;
+              not reached yet — entry point is still main.jsx + erg-dashboard.jsx)
   main.jsx    Auth gate (unchanged)
   supabaseClient.js  Supabase init (unchanged)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,11 +135,17 @@ Every PR is gated by three GitHub Actions jobs that must pass before merge:
 | Job | What it checks |
 |---|---|
 | `Lint & Format` | ESLint errors + Prettier formatting + `npm audit --audit-level=high` |
-| `Test & Coverage` | All Vitest tests pass; line ≥50%, function ≥30%, branch ≥35% |
+| `Test & Coverage` | All Vitest tests pass; coverage meets the ratcheting thresholds in `web/vite.config.js` — baseline **48% lines / 46% functions / 40% branches** (set by the #62 keystone), raised as extractions add tests |
 | `Build` | `npm run build` exits 0 (runs only after Test passes) |
 
-Coverage thresholds are defined in `vite.config.js` (`test.coverage.thresholds`).
-A PR comment with a coverage summary is posted automatically by
+Coverage thresholds live in `web/vite.config.js` (`test.coverage.thresholds`) and
+**ratchet upward**. Scope is explicit — `coverage.all` + `include: ['src/**']`
+with the not-yet-extracted monolith, `StrengthLogger.jsx`, `main.jsx`, and
+pure-data `constants/**` excluded — so the gate measures real coverage instead of
+passing by accident on whatever files a test happened to import. Each refactor
+extraction removes its file from `exclude` and lands tests in the **same** PR;
+the thresholds are then raised toward it. The numbers only go up. A PR comment
+with a coverage summary is posted automatically by
 `davelosert/vitest-coverage-report-action`.
 
 **Branch protection on `main`:** direct pushes are blocked. All changes must
@@ -302,4 +308,4 @@ without needing to prompt Coach.
 - Always run `npm test` before committing
 - Always run `npm run lint` and `npm run format:check` before pushing — CI will fail if either does not pass
 - Never bypass the pre-commit hook (`--no-verify`) without an explicit reason
-- Coverage thresholds (50% lines, 30% functions, 35% branches — see `web/vite.config.js`) are enforced in CI — new code should include tests
+- Coverage thresholds (baseline 48% lines / 46% functions / 40% branches — the ratchet in `web/vite.config.js`) are enforced in CI — new code should include tests, and the numbers only go up


### PR DESCRIPTION
Closes #67

## What changed and why

Clears doc drift before the refactor burndown (#52) starts — a new contributor (human or agent) was being briefed against a map that no longer matches the territory.

**`CLAUDE.md` — coverage gates**
- The CI table and Safety Constraints said `50% / 30% / 35%`, which matched neither the old config (70/70/60) nor reality. Updated to the **#62 ratchet baseline — 48% lines / 46% functions / 40% branches** — and rewrote the surrounding note to explain the explicit scope (`coverage.all` + `include`, monolith excluded) and the ratchet discipline, pointing to `web/vite.config.js` as the source of truth.

**`.claude/skills/architecture.md`**
- **Constants convention:** replaced the prescribed-but-never-used split (`colors.js` / `calibration.js` / `program.js` / `season.js` / `guide.js` / `logs.js`) with the **actual flat files** (`ui` / `trainingConfig` / `schedule` / `exercises` / `nutrition` / `tssData`), with their real exports, so new constant files get named to match what exists.
- **Stale line-number map:** the view map used absolute line numbers that assumed a ~3,900-line monolith; it's now ~8,715 and the offsets drift with every extraction. Replaced them with **tab-id section markers** + the extraction PR each maps to, and marked the already-extracted views (Coach/Erg/ErgLive).
- **Program-tab split decision (recorded):** the ~3,071-line Program tab becomes `views/program/{ProgramView, ProgramPhases, ProgramMicrocycle, ProgramYear}.jsx` (deviation from the single-`ProgramView` plan) — per #77.

## How to test manually

Docs only — no code paths affected. CI lint/test/build pass trivially.

## Checklist

- [x] CI is green (lint, test, build) — docs-only, no source touched
- [x] Tests cover the change, or I've noted why they don't — N/A (docs)
- [x] `npm run build` passes locally — unaffected
- [x] No unexpected console errors in the browser — N/A

---

> **Sequencing:** the coverage numbers here reflect the baseline set by **#62** (the keystone). Merge **#62 first** so the doc matches `web/vite.config.js` on landing. The #67 issue predated #62 and said "→ 70/70/60"; that target was overtaken by the keystone's honest baseline, so this reconciles to 48/46/40 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLks4YNjeoUsUHc5SDLVkx)_