### PR TITLE
ci: add pre-push test hook + CodeQL SAST

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+# SAST for our own code. `npm audit` (in ci-web.yml) only covers dependencies;
+# CodeQL scans the source we write. Runs on every PR and weekly on a schedule.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '23 4 * * 1' # Mondays 04:23 UTC
+
+jobs:
+  analyze:
+    name: Analyze (JavaScript/TypeScript)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      # No build step: JavaScript/TypeScript is analysed directly (no autobuild).
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+cd web && npx vitest run


### PR DESCRIPTION
Closes #64

## What changed and why

Two independent safety nets, config-only:

**Pre-push test hook (`.husky/pre-push`)**
- Runs `cd web && npx vitest run` so a failing test is blocked **locally** before it ever reaches CI. Mirrors the existing pre-commit style (`cd web && npx lint-staged`).
- Pre-commit stays lint/format-only (<5s per CLAUDE.md); tests run at push time, where the extra ~7s is acceptable.
- Verified: executing the hook runs the suite from `web/` (193 tests pass); this very push exercised it.

**CodeQL SAST (`.github/workflows/codeql.yml`)**
- Scans the JS/TS **we write** on every PR and weekly (Mon 04:23 UTC). `npm audit` (in `ci-web.yml`) only covers dependencies — CodeQL covers our own code.
- `languages: javascript-typescript`, `security-and-quality` query suite, no build step (interpreted language, no autobuild).

## How to test manually

- `git push` with a deliberately failing test is now blocked locally by the pre-push hook.
- After merge, the CodeQL check appears on PRs and runs weekly under the Actions tab.

## Checklist

- [x] CI is green (lint, test, build) — config-only; suite verified locally (193 pass)
- [x] Tests cover the change, or I've noted why they don't — N/A (CI/hook config)
- [x] `npm run build` passes locally — unaffected
- [x] No unexpected console errors in the browser — N/A

---

> **Notes (not blockers):**
> - CodeQL requires code scanning to be enabled for the repo (free on public repos; needs GitHub Advanced Security on private repos). If the repo is private without GHAS, the analyze step will error until that's enabled — the workflow file is still correct.
> - Action versions use `@v3`/`@v7` tags here; **#63** SHA-pins and standardizes action versions across all workflows, including this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLks4YNjeoUsUHc5SDLVkx)_