### PR TITLE
ci: add Conventional-Commits PR-title lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,36 @@
+name: PR title lint
+
+# Squash-merge uses the PR title as the commit message, so the title must be a
+# well-formed Conventional Commit. This keeps main's history clean and machine-
+# readable. Allowed types match the prefixes this repo uses (incl. config /
+# housekeeping from WORKFLOW.md branch types).
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            test
+            ci
+            build
+            perf
+            chore
+            style
+            config
+            housekeeping
+            revert


### PR DESCRIPTION
Part of #63 — delivers the one C2 item achievable in this environment. The other three need repo settings or network access (details below).

## What changed and why

**`pr-title-lint.yml`** — Squash-merge uses the PR **title** as the commit message, so titles must be well-formed. `amannn/action-semantic-pull-request` validates every PR title as a Conventional Commit. Allowed types include the repo's `config` / `housekeeping` prefixes (from WORKFLOW.md) on top of the standard set.

> Runs via `pull_request_target`, which always uses the **base branch's** workflow — so it doesn't gate this PR, but activates for all PRs once merged to `main`.

## Why "Part of #63" — the other three items are blocked here

| Item | Status | Why |
|---|---|---|
| PR-title lint | ✅ this PR | — |
| **Dependency-review** | ⛔ blocked | Action requires the repo's **Dependency graph** feature (Settings → Security & analysis). It errors `Dependency review is not supported on this repository` without it. Re-add the workflow once enabled. |
| **SHA-pin + standardize versions** | ⛔ blocked | Pinning needs each action tag's commit SHA; the sandbox proxy and `api.github.com` both 403 any host outside this repo, so SHAs can't be resolved. Do from a networked session, or let Dependabot pin. |
| **Auto-merge on green** | ⛔ blocked | "Allow auto-merge" is a repo **Settings → General** toggle (UI). `dependabot-auto-merge.yml` already depends on it. |

#63 stays open with these three annotated. (Originally this PR also added a dependency-review workflow; I dropped it after CI surfaced the Dependency-graph requirement, so this PR stays green.)

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — N/A (CI config)
- [x] `npm run build` passes locally — unaffected
- [x] No unexpected console errors in the browser — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)