### PR TITLE
refactor: extract pure formatters to utils/formatting.js + tests

### DIFF
--- a/web/src/components/WorkoutItem.jsx
+++ b/web/src/components/WorkoutItem.jsx
@@ -1,16 +1,5 @@
 import { useState } from 'react';
-
-function workoutAccent(txt) {
-  if (!txt) return '#3a3a4a';
-  const t = txt.toLowerCase();
-  if (t.includes('lower')) return '#34d399';
-  if (t.includes('upper')) return '#a78bfa';
-  if (t.includes('rate ladder') || t.includes('threshold')) return '#ffd700';
-  if (t.includes('interval') || t.includes('vo')) return '#ff6b35';
-  if (t.includes('yoga') || t.includes('foam') || t.includes('rest'))
-    return '#3a3a4a';
-  return '#00d4ff'; // erg aerobic default
-}
+import { workoutAccent } from '../utils/formatting.js';
 
 export default function WorkoutItem({
   session,

--- a/web/src/erg-dashboard.jsx
+++ b/web/src/erg-dashboard.jsx
@@ -59,6 +59,12 @@ import {
   PHASE_CONTEXT,
 } from './constants/schedule.js';
 import { C, ICON } from './constants/ui.js';
+import {
+  normType,
+  assessMacro,
+  macroColor,
+  bpCategory,
+} from './utils/formatting.js';
 
 /* ═══════════════════════════════════════════════════════════════
    ERG COACHING DASHBOARD · v1.2 beta
@@ -115,24 +121,6 @@ class ErrorBoundary extends Component {
     return this.props.children;
   }
 }
-
-// Normalize incoming session `type` to the canonical taxonomy the colour/icon
-// maps use. Coach CSV uses "erg"/"strength"; the log form writes "Strength";
-// seed + program data already use canonical names. Keeps every source coloured.
-const normType = (t, label = '') => {
-  if (C[t]) return t; // already canonical
-  const lt = (t || '').toLowerCase();
-  const ll = (label || '').toLowerCase();
-  if (lt === 'erg') return 'Z2 Aerobic';
-  if (lt === 'strength') {
-    if (/upper/.test(ll)) return 'Upper Strength';
-    if (/lower/.test(ll)) return 'Lower Strength';
-    return 'Combined';
-  }
-  if (lt === 'cycling' || lt === 'bike' || lt === 'ride') return 'Cycling';
-  if (lt === 'mobility' || lt === 'rest') return 'Rest';
-  return t; // unknown -> grey fallback
-};
 
 // ── SESSION LOG (add entries here as block progresses) ──────────
 
@@ -1646,18 +1634,6 @@ const nutritionLog = [
   },
 ];
 
-function assessMacro(val, range) {
-  if (typeof val !== 'number' || !Array.isArray(range) || range.length < 2)
-    return '—';
-  if (val >= range[0] && val <= range[1]) return '✅';
-  if (val < range[0]) return val >= range[0] * 0.9 ? '⚠️' : '❌';
-  return val <= range[1] * 1.15 ? '⚠️' : '❌';
-}
-
-function macroColor(status) {
-  return status === '✅' ? '#34d399' : status === '⚠️' ? '#ffd700' : '#ff2d55';
-}
-
 // ── RECOVERY METRICS ──────────────────────────────────────────
 // From Fitbit Charge 6: RHR, HRV (overnight), sleep duration/score.
 // ⚠️ SEED VALUES ARE PLACEHOLDERS — replace with real Fitbit data.
@@ -1772,27 +1748,6 @@ const bpLog = [
     clean: false,
   },
 ];
-
-// AU/most guidelines: treated target generally < 130–135 systolic, < 80 diastolic.
-// Confirm YOUR target with your GP — this is generic reference only.
-function bpCategory(sys, dia) {
-  // Validation: flag implausible readings rather than rendering garbage as a category.
-  if (
-    typeof sys !== 'number' ||
-    typeof dia !== 'number' ||
-    sys < 60 ||
-    sys > 260 ||
-    dia < 30 ||
-    dia > 160 ||
-    dia >= sys
-  ) {
-    return { label: 'Check reading', color: '#888' };
-  }
-  if (sys < 120 && dia < 80) return { label: 'Optimal', color: '#34d399' };
-  if (sys < 130 && dia < 80) return { label: 'Normal', color: '#34d399' };
-  if (sys < 140 || dia < 90) return { label: 'High-normal', color: '#ffd700' };
-  return { label: 'Elevated — note for GP', color: '#ff6b35' };
-}
 
 function calcReadiness(day, tsb) {
   if (!day || typeof day.rhr !== 'number') {

--- a/web/src/utils/__tests__/formatting.test.js
+++ b/web/src/utils/__tests__/formatting.test.js
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normType,
+  workoutAccent,
+  assessMacro,
+  macroColor,
+  bpCategory,
+} from '../formatting.js';
+
+describe('normType', () => {
+  it('passes through canonical types unchanged', () => {
+    expect(normType('Z2 Aerobic')).toBe('Z2 Aerobic');
+    expect(normType('Threshold')).toBe('Threshold');
+    expect(normType('Upper Strength')).toBe('Upper Strength');
+    expect(normType('Cycling')).toBe('Cycling');
+    expect(normType('Rest')).toBe('Rest');
+  });
+
+  it('maps "erg" to Z2 Aerobic', () => {
+    expect(normType('erg')).toBe('Z2 Aerobic');
+    expect(normType('ERG')).toBe('Z2 Aerobic');
+  });
+
+  it('maps "strength" with an upper label to Upper Strength', () => {
+    expect(normType('strength', 'Upper Body Push')).toBe('Upper Strength');
+    expect(normType('Strength', 'UPPER')).toBe('Upper Strength');
+  });
+
+  it('maps "strength" with a lower label to Lower Strength', () => {
+    expect(normType('strength', 'Lower Body')).toBe('Lower Strength');
+  });
+
+  it('maps "strength" with no upper/lower hint to Combined', () => {
+    expect(normType('strength')).toBe('Combined');
+    expect(normType('strength', 'Full session')).toBe('Combined');
+  });
+
+  it('maps bike/ride/cycling synonyms to Cycling', () => {
+    expect(normType('cycling')).toBe('Cycling');
+    expect(normType('bike')).toBe('Cycling');
+    expect(normType('ride')).toBe('Cycling');
+  });
+
+  it('maps mobility and rest to Rest', () => {
+    expect(normType('mobility')).toBe('Rest');
+    expect(normType('rest')).toBe('Rest');
+  });
+
+  it('returns unknown types verbatim as a grey fallback', () => {
+    expect(normType('swimming')).toBe('swimming');
+  });
+
+  it('handles undefined / empty type without throwing', () => {
+    expect(normType(undefined)).toBe(undefined);
+    expect(normType('')).toBe('');
+  });
+
+  it('defaults the label argument to an empty string', () => {
+    expect(normType('strength')).toBe('Combined');
+  });
+});
+
+describe('workoutAccent', () => {
+  it('returns the grey default for empty input', () => {
+    expect(workoutAccent('')).toBe('#3a3a4a');
+    expect(workoutAccent(undefined)).toBe('#3a3a4a');
+  });
+
+  it('colours lower-body sessions green', () => {
+    expect(workoutAccent('Lower Strength')).toBe('#34d399');
+  });
+
+  it('colours upper-body sessions purple', () => {
+    expect(workoutAccent('Upper Strength')).toBe('#a78bfa');
+  });
+
+  it('colours rate ladder / threshold sessions yellow', () => {
+    expect(workoutAccent('Rate Ladder')).toBe('#ffd700');
+    expect(workoutAccent('Threshold pieces')).toBe('#ffd700');
+  });
+
+  it('colours interval / VO2 sessions orange', () => {
+    expect(workoutAccent('VO2 max intervals')).toBe('#ff6b35');
+    expect(workoutAccent('Interval session')).toBe('#ff6b35');
+  });
+
+  it('colours yoga / foam / rest sessions grey', () => {
+    expect(workoutAccent('Yoga flow')).toBe('#3a3a4a');
+    expect(workoutAccent('Foam rolling')).toBe('#3a3a4a');
+    expect(workoutAccent('Rest day')).toBe('#3a3a4a');
+  });
+
+  it('falls back to erg aerobic blue for anything else', () => {
+    expect(workoutAccent('Z2 Aerobic')).toBe('#00d4ff');
+    expect(workoutAccent('Steady state')).toBe('#00d4ff');
+  });
+
+  it('is case-insensitive', () => {
+    expect(workoutAccent('LOWER')).toBe('#34d399');
+  });
+});
+
+describe('assessMacro', () => {
+  it('returns a dash when value is not a number', () => {
+    expect(assessMacro('120', [100, 150])).toBe('—');
+    expect(assessMacro(undefined, [100, 150])).toBe('—');
+  });
+
+  it('returns a dash when range is not a valid two-element array', () => {
+    expect(assessMacro(120, [100])).toBe('—');
+    expect(assessMacro(120, null)).toBe('—');
+    expect(assessMacro(120, 'range')).toBe('—');
+  });
+
+  it('returns a tick when value is within range (inclusive)', () => {
+    expect(assessMacro(125, [100, 150])).toBe('✅');
+    expect(assessMacro(100, [100, 150])).toBe('✅');
+    expect(assessMacro(150, [100, 150])).toBe('✅');
+  });
+
+  it('warns when value is just below the floor (>= 90% of min)', () => {
+    expect(assessMacro(95, [100, 150])).toBe('⚠️');
+    expect(assessMacro(90, [100, 150])).toBe('⚠️');
+  });
+
+  it('fails when value is well below the floor (< 90% of min)', () => {
+    expect(assessMacro(80, [100, 150])).toBe('❌');
+  });
+
+  it('warns when value is just above the ceiling (<= 115% of max)', () => {
+    expect(assessMacro(170, [100, 150])).toBe('⚠️');
+    expect(assessMacro(172.5, [100, 150])).toBe('⚠️');
+  });
+
+  it('fails when value is well above the ceiling (> 115% of max)', () => {
+    expect(assessMacro(180, [100, 150])).toBe('❌');
+  });
+});
+
+describe('macroColor', () => {
+  it('returns green for a tick', () => {
+    expect(macroColor('✅')).toBe('#34d399');
+  });
+
+  it('returns yellow for a warning', () => {
+    expect(macroColor('⚠️')).toBe('#ffd700');
+  });
+
+  it('returns red for a fail (or any other status)', () => {
+    expect(macroColor('❌')).toBe('#ff2d55');
+    expect(macroColor('—')).toBe('#ff2d55');
+  });
+});
+
+describe('bpCategory', () => {
+  it('flags non-numeric readings', () => {
+    expect(bpCategory('120', 80)).toEqual({
+      label: 'Check reading',
+      color: '#888',
+    });
+    expect(bpCategory(120, undefined)).toEqual({
+      label: 'Check reading',
+      color: '#888',
+    });
+  });
+
+  it('flags implausible systolic values', () => {
+    expect(bpCategory(50, 70)).toMatchObject({ label: 'Check reading' });
+    expect(bpCategory(300, 90)).toMatchObject({ label: 'Check reading' });
+  });
+
+  it('flags implausible diastolic values', () => {
+    expect(bpCategory(120, 20)).toMatchObject({ label: 'Check reading' });
+    expect(bpCategory(120, 200)).toMatchObject({ label: 'Check reading' });
+  });
+
+  it('flags readings where diastolic >= systolic', () => {
+    expect(bpCategory(110, 110)).toMatchObject({ label: 'Check reading' });
+    expect(bpCategory(100, 120)).toMatchObject({ label: 'Check reading' });
+  });
+
+  it('classifies optimal readings', () => {
+    expect(bpCategory(115, 75)).toEqual({
+      label: 'Optimal',
+      color: '#34d399',
+    });
+  });
+
+  it('classifies normal readings (120-129 systolic, < 80 diastolic)', () => {
+    expect(bpCategory(125, 78)).toEqual({
+      label: 'Normal',
+      color: '#34d399',
+    });
+  });
+
+  it('classifies high-normal readings', () => {
+    expect(bpCategory(135, 85)).toEqual({
+      label: 'High-normal',
+      color: '#ffd700',
+    });
+    expect(bpCategory(125, 85)).toEqual({
+      label: 'High-normal',
+      color: '#ffd700',
+    });
+  });
+
+  it('classifies elevated readings to note for the GP', () => {
+    expect(bpCategory(150, 95)).toEqual({
+      label: 'Elevated — note for GP',
+      color: '#ff6b35',
+    });
+  });
+});

--- a/web/src/utils/formatting.js
+++ b/web/src/utils/formatting.js
@@ -1,0 +1,64 @@
+import { C } from '../constants/ui.js';
+
+// Normalize incoming session `type` to the canonical taxonomy the colour/icon
+// maps use. Coach CSV uses "erg"/"strength"; the log form writes "Strength";
+// seed + program data already use canonical names. Keeps every source coloured.
+export const normType = (t, label = '') => {
+  if (C[t]) return t; // already canonical
+  const lt = (t || '').toLowerCase();
+  const ll = (label || '').toLowerCase();
+  if (lt === 'erg') return 'Z2 Aerobic';
+  if (lt === 'strength') {
+    if (/upper/.test(ll)) return 'Upper Strength';
+    if (/lower/.test(ll)) return 'Lower Strength';
+    return 'Combined';
+  }
+  if (lt === 'cycling' || lt === 'bike' || lt === 'ride') return 'Cycling';
+  if (lt === 'mobility' || lt === 'rest') return 'Rest';
+  return t; // unknown -> grey fallback
+};
+
+export function workoutAccent(txt) {
+  if (!txt) return '#3a3a4a';
+  const t = txt.toLowerCase();
+  if (t.includes('lower')) return '#34d399';
+  if (t.includes('upper')) return '#a78bfa';
+  if (t.includes('rate ladder') || t.includes('threshold')) return '#ffd700';
+  if (t.includes('interval') || t.includes('vo')) return '#ff6b35';
+  if (t.includes('yoga') || t.includes('foam') || t.includes('rest'))
+    return '#3a3a4a';
+  return '#00d4ff'; // erg aerobic default
+}
+
+export function assessMacro(val, range) {
+  if (typeof val !== 'number' || !Array.isArray(range) || range.length < 2)
+    return '—';
+  if (val >= range[0] && val <= range[1]) return '✅';
+  if (val < range[0]) return val >= range[0] * 0.9 ? '⚠️' : '❌';
+  return val <= range[1] * 1.15 ? '⚠️' : '❌';
+}
+
+export function macroColor(status) {
+  return status === '✅' ? '#34d399' : status === '⚠️' ? '#ffd700' : '#ff2d55';
+}
+
+// AU/most guidelines: treated target generally < 130–135 systolic, < 80 diastolic.
+// Confirm YOUR target with your GP — this is generic reference only.
+export function bpCategory(sys, dia) {
+  // Validation: flag implausible readings rather than rendering garbage as a category.
+  if (
+    typeof sys !== 'number' ||
+    typeof dia !== 'number' ||
+    sys < 60 ||
+    sys > 260 ||
+    dia < 30 ||
+    dia > 160 ||
+    dia >= sys
+  ) {
+    return { label: 'Check reading', color: '#888' };
+  }
+  if (sys < 120 && dia < 80) return { label: 'Optimal', color: '#34d399' };
+  if (sys < 130 && dia < 80) return { label: 'Normal', color: '#34d399' };
+  if (sys < 140 || dia < 90) return { label: 'High-normal', color: '#ffd700' };
+  return { label: 'Elevated — note for GP', color: '#ff6b35' };
+}


### PR DESCRIPTION
Closes #69

## What changed and why

PR2 of the refactor burndown (#52). Extracts five pure formatter functions out of the monolith into a new, fully-tested `utils/` module — and consolidates one that had been duplicated.

**New file `web/src/utils/formatting.js`** (all pure — no React, no side effects, no monolith-local state):
- `normType`, `assessMacro`, `macroColor`, `bpCategory` — moved from `erg-dashboard.jsx`
- `workoutAccent` — was defined **locally in `WorkoutItem.jsx`**, not the monolith; consolidated into the shared util, and `WorkoutItem.jsx` now imports it (single source of truth)

The monolith and `WorkoutItem.jsx` now import the extracted versions — behaviour identical.

**New tests `web/src/utils/__tests__/formatting.test.js`** (mirrors `trainingLoad.test.js`): every branch covered — each session-type mapping, all macro thresholds + invalid inputs, all BP categories + validation guards.

Because the #62 keystone counts `utils/**`, these tests aren't optional — they keep the ratchet green.

## Coverage

| Scope | Lines | Functions | Branches |
|---|---|---|---|
| `formatting.js` | **100%** (33/33) | **100%** (5/5) | **100%** (83/83) |
| Overall (gate 48/46/40) | 51.44% | 47.97% | 45.87% ✅ |

Monolith: 8,715 → **8,670** lines (−45); `WorkoutItem.jsx`: 236 → 225 (−11).

## How to test manually

Not needed — pure functions, covered by new unit tests. `cd web && npx vitest run` → 229 pass.

## Checklist

- [x] CI is green (lint, test, build) — verified in worktree: build exit 0, 229 tests pass, coverage exit 0, lint 0 errors, format clean
- [x] Tests cover the change — new `formatting.test.js`, 100% on the module
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — pure functions, no render change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLks4YNjeoUsUHc5SDLVkx)_