### PR TITLE
ci: add dependency-review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency review
+
+# Flags vulnerable or disallowed dependencies introduced in a PR's diff, before
+# they land on main. Complements `npm audit` in ci-web.yml (which scans the whole
+# tree) by gating the *change*. Threshold matches the audit gate: fail on high+.
+# Requires the repo's Dependency graph feature (Settings -> Security & analysis).
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
Part of #63 — re-adds the dependency-review gate now that the repo's **Dependency graph** feature is enabled.

## What changed and why

`actions/dependency-review-action` flags vulnerable or disallowed dependencies introduced in a PR's diff, before they reach `main`. Complements `npm audit` (whole-tree scan in `ci-web.yml`) by gating the *change*; `fail-on-severity: high` matches the audit gate.

This was originally in PR #84 but dropped because the action errors `Dependency review is not supported on this repository` when Dependency graph is off. With the feature now enabled, **CI on this PR is the proof it works** — the `Review dependency changes` check should run and pass.

## #63 status after this

| Item | Status |
|---|---|
| PR-title lint | ✅ #84 |
| Dependency-review | ✅ this PR |
| Auto-merge on green | ✅ repo setting "Allow auto-merge" now enabled |
| SHA-pin action versions | ⛔ still blocked — needs network to resolve action commit SHAs (sandbox 403s); Dependabot's `github-actions` updater can pin them, or do it from a networked session |

#63 stays open for the SHA-pinning item only.

## How to test manually

Open any PR touching `package.json`/`package-lock.json` → the check reviews the dependency delta. This PR itself exercises that the action runs without the previous "not supported" error.

## Checklist

- [x] CI is green (lint, test, build) — workflow-only; the new dependency-review check validates on this PR
- [x] Tests cover the change, or I've noted why they don't — N/A (CI config)
- [x] `npm run build` passes locally — unaffected
- [x] No unexpected console errors in the browser — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLks4YNjeoUsUHc5SDLVkx)_