### PR TITLE
test: add Playwright E2E smoke tests asserting each tab renders

### DIFF
--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -1,0 +1,41 @@
+name: E2E — Web Smoke
+
+# Playwright smoke tests: assert every dashboard tab mounts without error.
+# Runs on PRs (and pushes to main) but is NOT a required check yet — it informs,
+# it does not gate. The webServer in playwright.config.js builds the app with a
+# stub Supabase config; the auth gate is satisfied by a seeded localStorage
+# session, so no real backend is contacted.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: e2e-web-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: web
+
+jobs:
+  e2e:
+    name: Playwright Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 .env
 coverage
 scripts/
+test-results
+playwright-report
+.playwright

--- a/web/e2e/smoke.spec.js
+++ b/web/e2e/smoke.spec.js
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+
+// Auth gate: main.jsx renders the dashboard only when supabase.auth.getSession()
+// returns a session. supabase-js reads it from localStorage under
+// `sb-<project-ref>-auth-token` and, for an unexpired token, returns it without
+// any network call (verified in @supabase/auth-js __loadSession). The preview
+// build uses VITE_SUPABASE_URL=https://test-project.supabase.co (see
+// playwright.config.js), so the project ref is `test-project`.
+const STORAGE_KEY = 'sb-test-project-auth-token';
+
+function fakeSession() {
+  const expiresAt = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // +24h
+  return {
+    access_token: 'e2e-fake-access-token',
+    refresh_token: 'e2e-fake-refresh-token',
+    token_type: 'bearer',
+    expires_in: 86400,
+    expires_at: expiresAt,
+    user: {
+      id: '00000000-0000-0000-0000-000000000000',
+      aud: 'authenticated',
+      role: 'authenticated',
+      email: 'e2e@example.com',
+      app_metadata: { provider: 'email' },
+      user_metadata: {},
+      created_at: '2026-01-01T00:00:00.000Z',
+    },
+  };
+}
+
+// Every dashboard tab (matches the NAV in erg-dashboard.jsx).
+const TABS = [
+  'overview',
+  'calendar',
+  'program',
+  'plan',
+  'live',
+  'erg',
+  'strength',
+  'logger',
+  'mobility',
+  'recovery',
+  'log',
+  'journal',
+  'coach',
+];
+
+// Label shown on each nav button is the tab key, uppercased.
+const NAV_LABEL = (tab) => tab.toUpperCase();
+
+// The ErrorBoundary fallback in erg-dashboard.jsx renders this sentence when a
+// view crashes on render. Its absence is the "mounted without error" signal.
+const ERROR_BOUNDARY_TEXT = 'hit a render error';
+
+test.describe('dashboard smoke', () => {
+  let consoleErrors;
+
+  test.beforeEach(async ({ page, context }) => {
+    consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => consoleErrors.push(String(err)));
+
+    // Stub all Supabase REST/auth traffic so no real backend is needed and the
+    // app's data fetches resolve cleanly with empty results.
+    await context.route(/test-project\.supabase\.co\/.*/, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'access-control-allow-origin': '*' },
+        body: '[]',
+      });
+    });
+
+    // Seed the fake session before any app code runs so the auth gate passes.
+    await context.addInitScript(
+      ([key, session]) => {
+        window.localStorage.setItem(key, JSON.stringify(session));
+      },
+      [STORAGE_KEY, fakeSession()]
+    );
+  });
+
+  test('app gets past the auth gate and shows the dashboard nav', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    // The login screen would show a SIGN IN button; the dashboard shows the nav.
+    await expect(
+      page.getByRole('button', { name: NAV_LABEL('overview'), exact: true })
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'SIGN IN' })).toHaveCount(0);
+  });
+
+  for (const tab of TABS) {
+    test(`tab "${tab}" mounts without error`, async ({ page }) => {
+      await page.goto('/');
+
+      const navButton = page.getByRole('button', {
+        name: NAV_LABEL(tab),
+        exact: true,
+      });
+      await expect(navButton).toBeVisible();
+      await navButton.click();
+
+      // The active tab button is highlighted with the accent border colour.
+      await expect(navButton).toHaveCSS('border-top-color', 'rgb(0, 212, 255)');
+
+      // No error-boundary fallback rendered.
+      await expect(page.getByText(ERROR_BOUNDARY_TEXT)).toHaveCount(0);
+
+      // No console errors / uncaught exceptions during mount.
+      expect(consoleErrors, consoleErrors.join('\n')).toEqual([]);
+    });
+  }
+});

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -62,4 +62,12 @@ export default [
       },
     },
   },
+  {
+    files: ['e2e/**/*.{js,jsx}', 'playwright.config.js'],
+    languageOptions: {
+      globals: {
+        process: 'readonly',
+      },
+    },
+  },
 ];

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.56.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2892,6 +2893,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
+      "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -8530,6 +8547,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "lint": "eslint src/",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
@@ -20,13 +21,13 @@
     ]
   },
   "dependencies": {
-    "@capgo/capacitor-bluetooth-low-energy": "^8.1.0",
     "@capacitor/android": "^8.4.1",
     "@capacitor/app": "^8.0.0",
     "@capacitor/cli": "^8.4.1",
     "@capacitor/core": "^8.4.1",
     "@capacitor/local-notifications": "^8.0.0",
     "@capacitor/network": "^8.0.0",
+    "@capgo/capacitor-bluetooth-low-energy": "^8.1.0",
     "@supabase/supabase-js": "^2.108.2",
     "@tanstack/react-query": "^5.101.1",
     "mathjs": "^15.2.0",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.56.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// E2E smoke tests build the app with a stub Supabase config and serve it via
+// `vite preview`. The auth gate is satisfied by seeding a fake session into
+// localStorage (see e2e/smoke.spec.js) — no real backend is contacted.
+const PORT = 4173;
+const STUB_ENV = {
+  ...process.env,
+  VITE_SUPABASE_URL: 'https://test-project.supabase.co',
+  VITE_SUPABASE_ANON_KEY: 'test-anon-key',
+};
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `npm run build && npm run preview -- --port ${PORT} --strictPort`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: STUB_ENV,
+  },
+});

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -49,6 +49,8 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.js'],
+    // Playwright E2E specs live in e2e/ and must not be collected by Vitest.
+    exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary', 'json'],


### PR DESCRIPTION
Closes #65

## What changed and why

C4 of the CI hardening (#61) — an E2E smoke net that catches integration breakage unit tests miss as code moves between files during the refactor. Asserts **all 13 dashboard tabs mount without error**.

**Files:**
- `web/playwright.config.js` — single chromium project, `webServer` builds + serves `vite preview` on :4173 with stub Supabase env.
- `web/e2e/smoke.spec.js` — seeds a fake Supabase session + route-stubs the API to get past the auth gate (no app changes), then for each tab (overview, calendar, program, plan, live, erg, strength, logger, mobility, recovery, log, journal, coach): clicks it, asserts it activates, asserts no ErrorBoundary fallback and **zero console/page errors**.
- `.github/workflows/e2e-web.yml` — runs on PRs + push to main: `npm ci` → `npx playwright install --with-deps chromium` → `npm run test:e2e`, uploads the report artifact.
- `web/vite.config.js` — excludes `e2e/**` so Vitest never collects the Playwright spec.
- `web/eslint.config.js` — `process` global override for e2e/config files.
- `package.json` — `@playwright/test@1.56.0` devDep + `test:e2e` script; `.gitignore` ignores report/results.

## How the auth gate was solved (no app changes)

`main.jsx`'s `AuthGate` renders the dashboard when `supabase.auth.getSession()` returns an unexpired session — which `auth-js` reads straight from `localStorage` with **no network call**. The spec seeds a minimal valid session under the derived key (`sb-test-project-auth-token`, from the stub `VITE_SUPABASE_URL`) via `addInitScript`, and route-stubs Supabase traffic to `[]`.

## Verification (local, in the agent worktree)

- `npx playwright test` → **14 passed** (~9s, using the preinstalled Chromium — no download)
- `npx vitest run` → **229 passed**, e2e spec not collected
- coverage 51.44% lines / 47.97% fn / 45.87% br — above the gate
- `npm run build` exit 0; `npm run lint` 0 errors; `npm run format:check` clean

## Notes / follow-ups (not blockers)

- **Not wired as a required check** — separate workflow; promote to required in branch protection if you want it gating merges.
- **Playwright version is coupled to the sandbox's preinstalled Chromium (rev 1194 ↔ `@playwright/test` 1.56.0).** CI is unaffected (installs via `--with-deps`), but a Dependabot bump would break *local* sandbox runs unless `executablePath` is set. Worth excluding Playwright from Dependabot's auto-bump group, or pinning. I can do that as a tiny follow-up.
- Smoke pass is desktop-viewport only; mobile views (`useIsMobile` < 768px) are out of scope here (tracked under #53/#79).

## Checklist

- [x] CI is green (lint, test, build) — verified locally incl. the new e2e suite
- [x] Tests cover the change — 14 E2E assertions across all tabs
- [x] `npm run build` passes locally
- [x] No unexpected console errors — the smoke test explicitly asserts none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLks4YNjeoUsUHc5SDLVkx)_