### PR TITLE
docs: reconcile CLAUDE.md with current model + schema; add Code↔Coach coordination note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ web/                The app lives under web/ (Vite + Capacitor monorepo layout)
     StrengthLogger.jsx Large component, not yet extracted (~1,665 lines)
     main.jsx        Auth gate (Supabase email/password login)
 supabase/
-  functions/        Edge Functions (vitals-import from Google Health CSV)
+  functions/        Edge Functions (vitals-import from Google Health API)
 coach/
   PROJECT_MANAGEMENT_ANALYSIS.md  PM/workflow analysis (2026-06-29)
   work-orders/      DEPRECATED — historical specs; tracking is now GitHub Issues
@@ -93,14 +93,53 @@ Use `/refactor` to run each extraction step safely.
 
 ## Supabase Schema
 
-| Table    | Purpose                                        |
-|----------|------------------------------------------------|
-| sessions | All workouts — erg, strength, cycling, rest    |
-| vitals   | Daily health — RHR, HRV, sleep, bodyweight     |
+**13 tables, 22 migrations** (project `swdrueaserjzhuxnzmeu`, ap-northeast-1) as of
+2026-07-01. The core calendar plus the strength subsystem (Cowork-built, now in
+active coach use):
 
-sessions columns: `date, type, label, duration, srpe, exercises, watts, hr, distance, status`
+| Table               | Purpose                                                         |
+|---------------------|-----------------------------------------------------------------|
+| `sessions`          | Master training calendar — all modalities (erg, strength, bike, rest) |
+| `vitals`            | Daily health — RHR, HRV, sleep, bodyweight + Google-Health activity  |
+| `templates`         | Strength session templates (5, coach-origin: 2 Upper / 2 Lower / Prehab) |
+| `template_exercises`| Per-template prescriptions (sets/reps/rpe/`set_plan` jsonb/timed)     |
+| `strength_workouts` | Completed strength session container; links to calendar + template   |
+| `strength_sets`     | Per-set actuals (weight/reps/rpe/warmup/hold) — real logged data only |
+| `workout_assignments`| Template→date prescription (pending/in_progress/completed/skipped)   |
+| `exercises`         | Exercise library — 873 rows, **text ids**                            |
+| `exercise_media`    | Demo media per exercise (reference content, not user data)           |
+| `exercise_prefs`    | Per-user, per-exercise preferences (e.g. rest seconds)               |
+| `coach_messages`    | Legacy/experimental in-app chat rail (see Coaching data model)       |
+| `backup_snapshots`  | Daily full-DB JSON snapshots (backup cron)                           |
 
-Status values: `"logged"` (completed) or `"planned"` (prescription).
+**`sessions` columns:** `date` (**text `MM/DD/YY`**), `type`, `label`, `duration`,
+`srpe`, `prs`, `exercises` (jsonb), `coach_note`, `status`, `coach_flag`,
+`avg_watts`, `avg_hr`, `distance_m`, `source` (default `portal`; Coach writes
+`coach`), `user_id`. **No watt-target columns — targets live in `label` +
+`coach_note`.** Status values: `"logged"` (completed) or `"planned"` (prescription).
+
+**`vitals`:** `date` is a real `date` type; upsert on `(user_id, date)`. RHR/HRV/
+sleep/bodyweight and the Google-Health columns (`steps_count`, `distance_m`,
+`active_minutes`, `calories_kcal`) auto-fill via the vitals-import cron.
+**`readiness` + `soreness` are the only manual inputs** (morning check-in).
+
+**Strength logging convention:** a coach-logged strength session is a
+`strength_workouts` container with `status='completed'`, `origin='coach'`, linked
+to the calendar via `session_id → sessions.id` and to the template via
+`template_id`; the breakdown goes in `notes` and `prs` lands on the `sessions`
+row. Only populate `strength_sets` when real per-set data exists (in-app logging)
+— never fabricate reps from Fitbod session-level stickers. `workout_assignments`
+is not yet wired into the coach flow.
+
+**Data-layer gotchas (honour on every write):**
+- Supply the `user_id` UUID explicitly on inserts — `auth.uid()` is the column
+  default but does not resolve through the MCP connector.
+- Order `sessions` chronologically with `to_date(date,'MM/DD/YY')` (date is text).
+- `UNIQUE(date, label)` on `sessions` — temp-suffix labels before bulk shuffles
+  (`set label = label || '~tmp'`).
+- Vitals upsert: `on conflict (user_id, date) do update`.
+- DDL via `apply_migration` (named), not raw `execute_sql`.
+- Read back every write.
 
 ## Training Science Domain
 
@@ -115,11 +154,20 @@ Status values: `"logged"` (completed) or `"planned"` (prescription).
   Negative = fatigued. The "form" number.
 - **sRPE** — How hard a session felt on a 1–10 scale (subjective).
 - **CP** (Critical Power) — The highest power you can sustain indefinitely.
-  Currently estimated at ~190W; CP test planned for 1 Jul.
-- **Polarized TID** — 80% easy (Zone 2), 20% hard (threshold/VO₂max).
+  **~205W provisional (rowing)**; revalidate via rested 1-min + 4-min tests.
+  Rowing zones off this anchor: **UT2 113–144 / UT1 144–164 / AT 164–205 W**.
+- **Current model — pure base + strength** (reverted from polarised on 2026-06-29):
+  rowing is aerobic volume only (UT1/UT2 — no programmed threshold/VO₂); the bike
+  is a complementary Z1/Z2 aerobic carrier, never a programmed intensity source;
+  strength is **2 Upper + 2 Lower per week**, Lowers ≥3 days apart, alternating
+  RDL-led / quad-unilateral to manage the rehab hamstring.
 - **Microcycle** — One week training pattern. Home weeks = loading. FIFO = deload.
 
 ## Integration Roadmap
+
+**Live now:** **Google Health API** auto-syncs daily vitals into the `vitals`
+table (RHR/HRV/sleep/bodyweight + steps/distance/active-minutes/calories) via the
+`vitals-import` edge function + cron. No manual health-export step.
 
 Planned external data sources (to be built after refactor foundation is solid):
 
@@ -260,6 +308,20 @@ library documentation. Use it before WebSearch for any library in the stack.
 **Fall back to WebSearch when:** `resolve-library-id` returns no results, or the
 library is a tooling utility unlikely to be indexed (Husky, lint-staged, mathjs,
 vite-plugin-pwa).
+
+### Supabase (coaching data model)
+
+The **integration model was ratified 2026-07-01**: Coach (Claude in chat) operates
+natively via the **Supabase MCP connector, writing directly to the DB** (`source='coach'`)
+— reading vitals, and inserting/updating `sessions`, `strength_workouts`, etc. This
+is the live coaching rail, so **Code and Coach share one source of truth: this file
+plus the schema above.** The in-app Anthropic-API path (`coach_messages` table) was
+trialed and set aside — treat it as legacy/experimental unless revived.
+
+**Bridge discipline persists** even though Code holds repo + schema + deploy: Scott
+authorises consequential/destructive/schema changes; review structure before material
+writes; read back every write. Honour the data-layer gotchas under *Supabase Schema*
+on every insert.
 
 ## Change Procedure (PR-centric)
 

--- a/coach/CODE_TO_COACH_HANDOVER.md
+++ b/coach/CODE_TO_COACH_HANDOVER.md
@@ -1,0 +1,78 @@
+# Code → Coach Handover — Coordination (2026-07-01)
+
+*Reciprocal of `claude_code_handover_v2.md`. Paste into Coach chat when you want the
+two interfaces re-synced. This is about **how Code and Coach stay on the same page**,
+not training content.*
+
+---
+
+## What Code just did
+
+Reconciled `CLAUDE.md` (repo root) to current reality and opened it as a PR. Facts
+were verified read-only against the live DB (`swdrueaserjzhuxnzmeu`) before writing —
+not taken from the handover text alone. Changes:
+
+- **Model** reverted from polarised → **pure base + strength** (bike is complementary
+  Z1/Z2 only; 2 Upper + 2 Lower per week; Lowers ≥3 days apart).
+- **CP anchor** ~190W → **~205W provisional (rowing)** + zones UT2 113–144 /
+  UT1 144–164 / AT 164–205 W. Revalidate via rested 1-min + 4-min.
+- **Supabase Schema** section rewritten to the real **13 tables / 22 migrations**
+  (the whole strength subsystem), with corrected `sessions` columns (`date` is text
+  `MM/DD/YY`, targets live in `label` + `coach_note`), corrected `vitals`, the
+  strength-logging convention, and the data-layer gotchas.
+- **Vitals source**: Google Health **CSV → API** auto-sync.
+- **Coaching data model** recorded: Coach writes to the DB via the Supabase MCP
+  connector (`source='coach'`); the `coach_messages` in-app path is legacy/experimental.
+
+## Corrections to the handover's assumptions (please update your mental model)
+
+The handover was right about the *facts* but wrong about the *document*:
+
+1. **`CLAUDE.md` is not a §-numbered doctrine doc.** There is no §0 bootstrap, §3.6/3.7,
+   §7, or §8 in this repo. It's a software-engineering briefing whose *Training Science
+   Domain*, *Supabase Schema*, and *Integration Roadmap* sections carried the stale
+   facts. Those are the sections that changed — by name, not by number.
+2. **The three-party governance model (Coach / System / Bridge) is deprecated.** It
+   lived in `coach/work-orders/`, retired 2026-06-29 in favour of GitHub Issues/Projects.
+   Don't ask Code to "rewrite §7" — there's nothing to rewrite.
+3. **The `[C Art. X]` "Constitution" is not in this repo.** If it's authoritative, it
+   lives in your context, not the codebase. Code can't reconcile against something it
+   can't see — cite the actual text if you want it honoured here.
+
+## Coordination model going forward
+
+**`CLAUDE.md` (repo root) is the single shared source of truth for both interfaces.**
+Claude Code auto-loads it every session; keep it correct and neither side drifts.
+
+- **Code owns**: the repo, schema **migrations** (`apply_migration`), deploys, and PRs.
+- **Coach owns**: training inputs/assessment and directing what to build; operates on
+  the DB via the Supabase MCP connector, writing training rows with `source='coach'`.
+- **Keeping in sync**:
+  - *Schema change* → flows through Code: `apply_migration` (named) **and** update the
+    *Supabase Schema* section in the **same** change. Never let the DB and the doc diverge.
+  - *Model / anchor change* (CP, zones, base-vs-polarised, strength split) → update the
+    *Training Science Domain* section.
+  - *Integration change* → update *Integration Roadmap* / *MCP Servers*.
+- **Bridge discipline persists**: Scott authorises consequential/destructive/schema
+  changes; review structure before material writes; **read back every write**. Honour
+  the data-layer gotchas (explicit `user_id` UUID — `auth.uid()` doesn't resolve through
+  the connector; `sessions.date` is text, order via `to_date(...,'MM/DD/YY')`;
+  `UNIQUE(date,label)`; vitals upsert on `(user_id,date)`).
+
+## Deferred / open items (not done this session)
+
+- **Task 2** — wire native slash-commands + SessionStart "where are we" / SessionEnd
+  "wrap up" hooks. No command list is defined in the repo yet; Scott needs to specify.
+- **Task 3** — bring `workout_assignments` + per-set `strength_sets` into the flow once
+  the app logger is fit-for-purpose. **Prune the abandoned `in_progress`
+  `strength_workouts` shells (0 sets, no `session_id`)** — destructive, so it's parked
+  until Scott explicitly OKs it. Coach flagged this correctly; Code will execute on his word.
+- **Task 4** — APK / Capacitor packaging.
+- **Task 5** — revalidate rowing CP (rested 1-min + 4-min) when the block allows.
+
+## Known infra gap (for a later PR)
+
+The SessionStart hook installs npm deps at the **repo root only**, but the app and its
+tests live in `web/`. The pre-push hook (`cd web && npx vitest run`) needs `web/`
+dependencies, so a fresh remote session must `npm install` inside `web/` before it can
+push. Worth folding a `web/` install into the SessionStart hook.


### PR DESCRIPTION
## What changed and why

Reconcile the repo's `CLAUDE.md` with the training model and Supabase schema that Coach (Claude in chat) actually operates from, so Code and Coach share one source of truth — and add a reciprocal Code→Coach coordination note.

**`CLAUDE.md`** (facts verified read-only against the live DB `swdrueaserjzhuxnzmeu` — 13 tables, 22 migrations):
- Training model: polarised 80/20 → **pure base + strength** (bike Z1/Z2 complementary only; 2 Upper + 2 Lower/wk).
- CP anchor: ~190W → **~205W provisional (rowing)** + UT2/UT1/AT zones.
- Supabase Schema: expanded from 2 tables to the real **13-table / 22-migration** layout incl. the strength subsystem; corrected `sessions` columns (`date` is text `MM/DD/YY`, targets in `label`/`coach_note`), `vitals` (real date, Google-Health columns, manual readiness/soreness); added write-time data-layer gotchas.
- Vitals source: Google Health **CSV → API** auto-sync.
- Recorded the ratified coaching data model (Coach writes to the DB via the Supabase MCP connector, `source='coach'`; Bridge discipline preserved).

**`coach/CODE_TO_COACH_HANDOVER.md`** (new): the going-forward coordination model — who owns repo/migrations vs. who writes training data, how schema/model changes stay in sync, deferred tasks, and a known SessionStart-hook infra gap. Also corrects the handover's assumption that `CLAUDE.md` is a §-numbered doctrine doc (it isn't; the three-party governance model is deprecated).

## How to test manually

N/A — docs-only. No code paths, components, or build config touched.

## Checklist

- [x] CI is green (lint, test, build) — CI runs inside `web/`; these root/`coach/` docs don't affect it. Full suite passing locally (290 tests).
- [x] Tests cover the change, or I've noted why they don't — docs-only, no tests needed.
- [x] `npm run build` passes locally — unaffected (no source changes).
- [x] No unexpected console errors in the browser — no runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVQiyCTK3W5Muym6RWZ9t3)_