### PR TITLE
feat(db): context store — coach_log + anchors tables with RLS

### DIFF
--- a/supabase/migrations/006_context_store.sql
+++ b/supabase/migrations/006_context_store.sql
@@ -1,0 +1,57 @@
+-- 006_context_store.sql
+-- Context store: one Supabase-resident source of truth that both tools read
+-- (Coach chat via MCP, Code via DB). Applied live as migration
+-- `context_store_coach_log_and_anchors`.
+--
+-- Two tables, distinct jobs:
+--   coach_log — append-only diary + decision record (never edited in place;
+--               reversals write a NEW row with `supersedes` -> the old row).
+--   anchors   — current calibration + phase state; exactly one live row per key
+--               (superseded_at IS NULL) so "current value per key" is a one-row read.
+--
+-- Structural seed rows (rowing_cp, bike_ftp, current_phase, current_block,
+-- doctrine_sha) are inserted separately with an explicit user_id — auth.uid()
+-- does not resolve through the MCP connector — and are NOT part of this schema file.
+
+-- coach_log: append-only diary + decision record
+create table if not exists public.coach_log (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid references auth.users not null default auth.uid(),
+  date        date not null default current_date,
+  entry_type  text not null check (entry_type in ('diary','decision','observation')),
+  body        text not null,
+  author      text not null check (author in ('coach','scott')),
+  tags        text[] not null default '{}',
+  supersedes  uuid references public.coach_log(id),
+  created_at  timestamptz not null default now()
+);
+alter table public.coach_log enable row level security;
+drop policy if exists coach_log_owner on public.coach_log;
+create policy coach_log_owner on public.coach_log
+  for all to authenticated
+  using (user_id = auth.uid()) with check (user_id = auth.uid());
+create index if not exists coach_log_user_date  on public.coach_log (user_id, date desc);
+create index if not exists coach_log_supersedes on public.coach_log (supersedes);
+
+-- anchors: current calibration + phase state (one live row per key)
+create table if not exists public.anchors (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid references auth.users not null default auth.uid(),
+  key           text not null,
+  value         text not null,
+  unit          text,
+  status        text check (status in ('provisional','unvalidated','confirmed')),
+  source        text,
+  valid_from    date not null default current_date,
+  superseded_at timestamptz,
+  note          text,
+  created_at    timestamptz not null default now()
+);
+alter table public.anchors enable row level security;
+drop policy if exists anchors_owner on public.anchors;
+create policy anchors_owner on public.anchors
+  for all to authenticated
+  using (user_id = auth.uid()) with check (user_id = auth.uid());
+-- guarantees "current value per key" is a single-row read:
+create unique index if not exists anchors_one_live_per_key
+  on public.anchors (user_id, key) where superseded_at is null;


### PR DESCRIPTION
## What changed and why

Stands up a Supabase-resident **context store** so project context lives in one backend that both tools read — Coach (chat via MCP) and Code (via DB) — instead of being split across Coach memory, `CLAUDE.md`, and Drive.

Two tables with distinct jobs (kept separate):

| Table | Job | Key detail |
|---|---|---|
| `coach_log` | Append-only diary + decision record | `supersedes` nullable self-FK — reversals write a **new** row, history is never mutated |
| `anchors` | Current calibration + phase state | Partial unique index `(user_id, key) where superseded_at is null` makes "current value per key" a one-row read |

Both tables: RLS enabled, single `ALL` owner policy `user_id = auth.uid()`, `user_id uuid not null default auth.uid()`, native `date`/`timestamptz` throughout (not the legacy `sessions.date` text pattern) — matching the existing modern convention.

Applied live as migration `context_store_coach_log_and_anchors` and seeded with the five structural anchors (`rowing_cp`, `bike_ftp`, `current_phase`, `current_block`, `doctrine_sha` → `0013c9f`) via explicit `user_id`. `coach_log` content is Coach's lane and is intentionally left empty. This file (`006_context_store.sql`) is the version-controlled schema mirror.

## How to test manually

Schema/data change, not exercised by CI. Verified live against project `swdrueaserjzhuxnzmeu`:

```sql
-- current value per key (one live row each): returns 5 rows with exact seeded values
select key, value, unit, status from public.anchors where superseded_at is null order by key;
```
- `coach_log` `supersedes` self-join resolves (checked with throwaway rows, then deleted).
- `get_advisors(security)` shows no findings for either new table (RLS + policy present).

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — SQL migration, no JS surface; full suite (290 tests) still passes
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gta8vvNbtZXkFZbM2WhpdL)_