### PR TITLE
docs: reconcile CLAUDE.md for the context store (coach_log + anchors)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,9 @@ Use `/refactor` to run each extraction step safely.
 
 ## Supabase Schema
 
-**13 tables, 22 migrations** (project `swdrueaserjzhuxnzmeu`, ap-northeast-1) as of
-2026-07-01. The core calendar plus the strength subsystem (Cowork-built, now in
-active coach use):
+**14 tables, 23 migrations** (project `swdrueaserjzhuxnzmeu`, ap-northeast-1) as of
+2026-07-01. The core calendar, the strength subsystem (Cowork-built, now in active
+coach use), and the context store (Code↔Coach shared memory, added by #94):
 
 | Table               | Purpose                                                         |
 |---------------------|-----------------------------------------------------------------|
@@ -111,6 +111,8 @@ active coach use):
 | `exercise_prefs`    | Per-user, per-exercise preferences (e.g. rest seconds)               |
 | `coach_messages`    | Legacy/experimental in-app chat rail (see Coaching data model)       |
 | `backup_snapshots`  | Daily full-DB JSON snapshots (backup cron)                           |
+| `coach_log`         | **Context store** — append-only diary + decision record (Coach's content) |
+| `anchors`           | **Context store** — current calibration + phase state (one live row/key)  |
 
 **`sessions` columns:** `date` (**text `MM/DD/YY`**), `type`, `label`, `duration`,
 `srpe`, `prs`, `exercises` (jsonb), `coach_note`, `status`, `coach_flag`,
@@ -130,6 +132,30 @@ to the calendar via `session_id → sessions.id` and to the template via
 row. Only populate `strength_sets` when real per-set data exists (in-app logging)
 — never fabricate reps from Fitbod session-level stickers. `workout_assignments`
 is not yet wired into the coach flow.
+
+**Context store (`coach_log` + `anchors`) — the single source of truth both tools
+read (Coach via MCP, Code via DB).** Native `date`/`timestamptz` throughout (not the
+legacy `sessions.date` text pattern); RLS single-owner policy like the modern tables.
+
+- **`coach_log`** — append-only diary + decision record. Columns: `date`,
+  `entry_type` (`diary` | `decision` | `observation`), `body` (the narrative/
+  reasoning), `author` (`coach` | `scott`), `tags` (text[]), `supersedes` (nullable
+  self-FK), `created_at`. **Never edit a row in place** — to reverse a past decision,
+  insert a NEW row with `supersedes` pointing at the one it overrides. History is the
+  record of *why we changed our mind*.
+- **`anchors`** — current calibration + phase state. Columns: `key`, `value` (text),
+  `unit`, `status` (`provisional` | `unvalidated` | `confirmed`), `source`,
+  `valid_from`, `superseded_at` (nullable), `note`. **One live row per key** — a
+  partial unique index on `(user_id, key) where superseded_at is null` makes "current
+  value per key" a one-row read. To update, set `superseded_at = now()` on the old row
+  and insert the new one (don't overwrite). Live keys: `rowing_cp`, `bike_ftp`,
+  `current_phase`, `current_block`, `doctrine_sha`.
+- **`doctrine_sha`** pins the canonical doctrine commit (this file +
+  `.claude/skills/training-science.md`). Doctrine *prose stays in git*; only the SHA
+  lives in a row, so both tools agree which version is live. When a doctrine doc
+  changes, Coach supersedes this anchor.
+- **Lanes:** Code owns the schema (tables, structural seed, migrations); Coach owns
+  row content (diary, decisions, anchor updates) via scoped writes; Scott authorises.
 
 **Data-layer gotchas (honour on every write):**
 - Supply the `user_id` UUID explicitly on inserts — `auth.uid()` is the column


### PR DESCRIPTION
Closes #96

## What changed and why

`CLAUDE.md` — the file both tools read at session start — predated the context-store PR (#94). This reconciles it so `coach_log` + `anchors` are documented and the shared source of truth is accurate.

- Add `coach_log` and `anchors` to the Supabase Schema table; correct the count to **14 tables / 23 migrations** (also fixes the prior "13" drift).
- New **Context store** subsection covering: column shapes, the **append-only + `supersedes`** rule for `coach_log`, the **one-live-row-per-key** (partial unique index) rule for `anchors`, the `doctrine_sha` pin (doctrine prose stays in git), and the **Code / Coach / Scott lane model**.

First item (S1) of the context-store activation sprint (#95).

## How to test manually

Documentation only — no code paths affected.

## Checklist

- [x] CI is green (lint, test, build) — docs-only; no `web/` changes
- [x] Tests cover the change, or I've noted why they don't — N/A, Markdown only
- [x] `npm run build` passes locally — unaffected (no source changes)
- [x] No unexpected console errors in the browser — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gta8vvNbtZXkFZbM2WhpdL)_