### PR TITLE
config: add doctrine_sha drift guard

### DIFF
--- a/.github/workflows/doctrine-sha-guard.yml
+++ b/.github/workflows/doctrine-sha-guard.yml
@@ -1,0 +1,65 @@
+name: Doctrine SHA guard
+
+# The doctrine_sha anchor (Supabase `anchors` table) pins the canonical commit of
+# the doctrine docs — CLAUDE.md + .claude/skills/training-science.md — so Code and
+# Coach agree which doctrine version is live. When those docs change on main, the
+# anchor must be superseded to the new commit. That update lives in the DB (Coach's
+# content lane), not git, so CI can't perform it directly — but it can make the
+# drift impossible to miss. This guard fires exactly when doctrine docs land on
+# main and opens (or comments on) a single tracking issue carrying the new SHA,
+# turning silent drift into an actionable reminder.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'CLAUDE.md'
+      - '.claude/skills/training-science.md'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: doctrine-sha-guard
+  cancel-in-progress: false
+
+jobs:
+  remind:
+    name: Flag doctrine_sha drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or update the doctrine_sha reminder issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          title="chore(doctrine): supersede doctrine_sha to latest main"
+          body=$(printf '%s\n' \
+            "The doctrine docs changed on \`main\` in commit \`${SHA}\`." \
+            "" \
+            "The \`doctrine_sha\` anchor (Supabase \`anchors\` table) still points at the previous commit, so Code and Coach may disagree on which doctrine version is live." \
+            "" \
+            "**Action — Coach's content lane, Scott authorises:** supersede \`doctrine_sha\` to \`${SHA}\`. Set \`superseded_at = now()\` on the current row and insert a new row with the new SHA, then close this issue:" \
+            "" \
+            "\`\`\`sql" \
+            "update public.anchors set superseded_at = now()" \
+            " where key = 'doctrine_sha' and superseded_at is null;" \
+            "insert into public.anchors (user_id, key, value, source, valid_from, note)" \
+            "values ('<scott-uuid>', 'doctrine_sha', '${SHA}'," \
+            "        'doctrine docs changed on main', current_date," \
+            "        'CLAUDE.md + .claude/skills/training-science.md');" \
+            "\`\`\`" \
+            "" \
+            "_Auto-filed by the Doctrine SHA guard. If this issue is already open, the latest SHA is appended as a comment rather than duplicated._")
+          existing=$(gh issue list --repo "$REPO" --state open \
+            --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "$body"
+          else
+            gh issue create --repo "$REPO" --title "$title" --body "$body" \
+              --assignee "$OWNER"
+          fi

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -146,6 +146,19 @@ Issue ──▶ /feature or /orchestrate ──▶ research → spec → build �
 Pick an issue, run the pipeline (or hand-build for small changes), and the output
 is a PR linked back to the issue. Same rail, every time.
 
+## Doctrine SHA
+
+The `doctrine_sha` anchor (Supabase `anchors` table) pins the canonical commit of
+the doctrine docs — `CLAUDE.md` + `.claude/skills/training-science.md` — so Code
+and Coach agree which doctrine version is live. **When you change either doc, the
+anchor must be superseded to the new `main` commit.** That update is a DB write in
+Coach's content lane (Scott authorises), not a git change.
+
+You don't have to remember: the **Doctrine SHA guard**
+(`.github/workflows/doctrine-sha-guard.yml`) fires whenever those docs land on
+`main` and opens/updates a single tracking issue carrying the new SHA. Close the
+issue once Coach has superseded the anchor.
+
 ## Project-management agents
 
 The Agency agent library is installed (see `.claude/agents/`). The most useful


### PR DESCRIPTION
Closes #99

## What changed and why

The `doctrine_sha` anchor (Supabase `anchors` table) pins the canonical commit of the doctrine docs — `CLAUDE.md` + `.claude/skills/training-science.md` — so Code and Coach agree which doctrine version is live. When those docs change, the anchor must be superseded to the new commit; but that update is a DB write in **Coach's content lane**, so CI can't perform it directly. Without a guard, the docs and the pinned SHA silently drift apart. This surfaced as a flag on the context-store PR (#94).

Adds a **post-merge guard** — the smallest mechanism that catches the case with no secrets and no DB access:

- **`.github/workflows/doctrine-sha-guard.yml`** — triggers on `push` to `main` with a `paths` filter on the two doctrine docs. It opens (or, if one is already open, comments on) a **single tracking issue** carrying the new commit SHA and the exact supersede SQL, assigned to the repo owner. Uses only `gh` + `issues: write`.
- **`WORKFLOW.md`** — documents the `doctrine_sha` rule and the automated reminder.

Fires exactly when doctrine lands on `main`, so unrelated PRs get zero friction. Final item (S4) of the context-store activation sprint (#95) — completes the sprint.

## How to test manually

The workflow only runs from `main` (push trigger), so it can't execute on this PR. Verified: YAML parses (`yaml.safe_load` OK) and the paths filter targets `CLAUDE.md` + `.claude/skills/training-science.md`. After merge, a subsequent PR that edits either doc — once merged — will file the reminder issue with that merge's SHA.

## Checklist

- [x] CI is green (lint, test, build) — config/docs only; no `web/` surface
- [x] Tests cover the change, or I've noted why they don't — N/A, a CI workflow (validated by YAML parse; runs only post-merge)
- [x] `npm run build` passes locally — unaffected (no source changes)
- [x] No unexpected console errors in the browser — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gta8vvNbtZXkFZbM2WhpdL)_