### PR TITLE
refactor: extract strength tab to views/StrengthView.jsx

### DIFF
--- a/web/src/erg-dashboard.jsx
+++ b/web/src/erg-dashboard.jsx
@@ -15,11 +15,11 @@ import CoachView from './views/CoachView.jsx';
 import ErgView from './views/ErgView.jsx';
 import JournalView from './views/JournalView.jsx';
 import RecoveryView from './views/RecoveryView.jsx';
+import StrengthView from './views/StrengthView.jsx';
 import WorkoutItem from './components/WorkoutItem.jsx';
 import LogSessionForm from './components/LogSessionForm.jsx';
 import LogEntry from './components/LogEntry.jsx';
 import ErgTooltip from './components/ErgTooltip.jsx';
-import StrengthTooltip from './components/StrengthTooltip.jsx';
 import LoadTooltip from './components/LoadTooltip.jsx';
 import { calcTrainingLoad, deriveTargets } from './utils/trainingLoad.js';
 import {
@@ -39,9 +39,7 @@ import {
 import {
   REP_SCHEMES,
   LOWER_DIFFERENTIATION,
-  PREHAB_NOTE,
   STRENGTH_PRINCIPLES,
-  STRENGTH_TEMPLATES,
 } from './constants/exercises.js';
 import {
   MACRO_TARGETS,
@@ -181,16 +179,6 @@ const strengthTrend = {
     { date: '6/4', e1rm: 41.9 },
     { date: '6/7', e1rm: 46.2 },
   ],
-};
-
-const LIFT_COLOR = {
-  'Back Squat': '#34d399',
-  'Romanian Deadlift': '#34d399',
-  'Bench Press': '#a78bfa',
-  'Incline Bench': '#a78bfa',
-  'Barbell Row': '#00d4ff',
-  'Lat Pulldown': '#00d4ff',
-  'Shoulder Press': '#f472b6',
 };
 
 // ── PROGRAM STRUCTURE ─────────────────────────────────────────
@@ -795,7 +783,6 @@ const ANNUAL_ARC = [
 // ── MAIN APP ──────────────────────────────────────────────────
 export default function App() {
   const [view, setView] = useState('overview');
-  const [activeLift, setActiveLift] = useState('Back Squat');
   const [expanded, setExpanded] = useState(null);
   const [ftp, setFtp] = useState(190);
   const [progTab, setProgTab] = useState('phases'); // phases | week | year
@@ -902,8 +889,6 @@ export default function App() {
   const totalErgDist = 55000; // metres, from logged sessions
   const latestSquat = strengthTrend['Back Squat'].slice(-1)[0];
   const totalSessions = loggedSessions.length;
-
-  const liftColor = LIFT_COLOR[activeLift] || '#00d4ff';
 
   return (
     <div
@@ -5839,273 +5824,10 @@ export default function App() {
 
           {/* ── STRENGTH VIEW ── */}
           {view === 'strength' && (
-            <>
-              {/* Lift selector */}
-              <div
-                style={{
-                  display: 'flex',
-                  gap: 4,
-                  flexWrap: 'wrap',
-                  marginBottom: 12,
-                }}
-              >
-                {Object.keys(strengthTrend).map((lift) => (
-                  <button
-                    key={lift}
-                    onClick={() => setActiveLift(lift)}
-                    style={{
-                      background:
-                        activeLift === lift
-                          ? `${LIFT_COLOR[lift]}20`
-                          : 'transparent',
-                      border:
-                        activeLift === lift
-                          ? `1px solid ${LIFT_COLOR[lift]}`
-                          : '1px solid #4a4a68',
-                      color: activeLift === lift ? LIFT_COLOR[lift] : '#7e7e9a',
-                      borderRadius: 4,
-                      padding: '5px 10px',
-                      fontSize: 9,
-                      letterSpacing: 0.5,
-                      cursor: 'pointer',
-                      fontFamily: "'DM Mono',monospace",
-                    }}
-                  >
-                    {lift}
-                  </button>
-                ))}
-              </div>
-
-              {/* e1RM chart */}
-              <div
-                style={{
-                  background: '#2a2a48',
-                  border: '1px solid #4a4a68',
-                  borderRadius: 6,
-                  padding: '14px 16px',
-                  marginBottom: 12,
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: 9,
-                    letterSpacing: 3,
-                    color: liftColor,
-                    marginBottom: 12,
-                  }}
-                >
-                  {activeLift.toUpperCase()} · e1RM (kg)
-                </div>
-                {strengthTrend[activeLift].length > 1 ? (
-                  <ResponsiveContainer width="100%" height={140}>
-                    <LineChart
-                      data={strengthTrend[activeLift]}
-                      margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
-                    >
-                      <XAxis
-                        dataKey="date"
-                        tick={{
-                          fontSize: 9,
-                          fill: '#7e7e9a',
-                          fontFamily: "'DM Mono',monospace",
-                        }}
-                        axisLine={false}
-                        tickLine={false}
-                      />
-                      <YAxis
-                        domain={['auto', 'auto']}
-                        tick={{
-                          fontSize: 9,
-                          fill: '#7e7e9a',
-                          fontFamily: "'DM Mono',monospace",
-                        }}
-                        tickFormatter={(v) => `${v}kg`}
-                        axisLine={false}
-                        tickLine={false}
-                        width={42}
-                      />
-                      <Tooltip content={<StrengthTooltip />} />
-                      <Line
-                        type="monotone"
-                        dataKey="e1rm"
-                        stroke={liftColor}
-                        strokeWidth={2}
-                        dot={{
-                          r: 4,
-                          fill: liftColor,
-                          stroke: '#08080d',
-                          strokeWidth: 1,
-                        }}
-                        activeDot={{ r: 5 }}
-                      />
-                    </LineChart>
-                  </ResponsiveContainer>
-                ) : (
-                  <div
-                    style={{
-                      padding: '20px 0',
-                      textAlign: 'center',
-                      color: '#5a5a74',
-                      fontSize: 11,
-                    }}
-                  >
-                    One data point — chart builds as sessions are logged
-                  </div>
-                )}
-                {/* Latest e1rm callout */}
-                <div
-                  style={{
-                    marginTop: 10,
-                    display: 'flex',
-                    alignItems: 'baseline',
-                    gap: 8,
-                  }}
-                >
-                  <span
-                    style={{ fontSize: 22, fontWeight: 700, color: liftColor }}
-                  >
-                    {strengthTrend[activeLift].slice(-1)[0].e1rm}kg
-                  </span>
-                  <span style={{ fontSize: 10, color: '#7e7e9a' }}>
-                    current e1RM · {strengthTrend[activeLift].slice(-1)[0].date}
-                  </span>
-                  {strengthTrend[activeLift].length > 1 &&
-                    (() => {
-                      const first = strengthTrend[activeLift][0].e1rm;
-                      const last = strengthTrend[activeLift].slice(-1)[0].e1rm;
-                      const diff = (last - first).toFixed(1);
-                      return (
-                        <span style={{ fontSize: 10, color: '#34d399' }}>
-                          +{diff}kg
-                        </span>
-                      );
-                    })()}
-                </div>
-              </div>
-
-              {/* Strength session list */}
-              {/* Saved Templates */}
-              <div
-                style={{
-                  background: '#2a2a48',
-                  border: '1px solid #4a4a68',
-                  borderRadius: 6,
-                  padding: '14px 16px',
-                  marginBottom: 12,
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: 9,
-                    letterSpacing: 3,
-                    color: '#a78bfa',
-                    marginBottom: 4,
-                  }}
-                >
-                  SAVED TEMPLATES · FITBOD
-                </div>
-                <div
-                  style={{
-                    fontSize: 9,
-                    color: '#6c6c88',
-                    marginBottom: 12,
-                    lineHeight: 1.5,
-                  }}
-                >
-                  Fixed workouts, low variability. Stops auto-generation
-                  inserting leg accessories or dropping pulls. Fitbod still
-                  suggests load progression.
-                </div>
-                {STRENGTH_TEMPLATES.map((t) => (
-                  <div
-                    key={t.name}
-                    style={{
-                      marginBottom: 12,
-                      paddingBottom: 12,
-                      borderBottom: '1px solid #3e3e5a',
-                    }}
-                  >
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'baseline',
-                        marginBottom: 6,
-                      }}
-                    >
-                      <span
-                        style={{
-                          fontSize: 12,
-                          fontWeight: 700,
-                          color: t.color,
-                        }}
-                      >
-                        {t.name}
-                      </span>
-                      <span style={{ fontSize: 9, color: '#7e7e9a' }}>
-                        {t.focus}
-                      </span>
-                    </div>
-                    {t.exercises.map((ex, i) => (
-                      <div
-                        key={i}
-                        style={{
-                          fontSize: 11,
-                          color: '#aaaacc',
-                          lineHeight: 1.7,
-                          paddingLeft: 4,
-                        }}
-                      >
-                        · {ex}
-                      </div>
-                    ))}
-                  </div>
-                ))}
-                <div
-                  style={{
-                    fontSize: 9,
-                    color: '#6c6c88',
-                    lineHeight: 1.5,
-                    fontStyle: 'italic',
-                  }}
-                >
-                  Weekly: Upper 1 + Lower 1 + Upper 2 + Lower 2. Pull:press bias
-                  maintained across the week. Squat heavy on Lower 1,
-                  explosive/light on Lower 2 (daily undulating).
-                </div>
-                <div
-                  style={{
-                    fontSize: 9,
-                    color: '#f472b6',
-                    lineHeight: 1.6,
-                    marginTop: 8,
-                    borderTop: '1px solid #3e3e5a',
-                    paddingTop: 8,
-                  }}
-                >
-                  💗 Prehab + Shoulder: {PREHAB_NOTE}
-                </div>
-              </div>
-
-              <div
-                style={{
-                  fontSize: 9,
-                  letterSpacing: 3,
-                  color: '#7e7e9a',
-                  marginBottom: 8,
-                }}
-              >
-                STRENGTH SESSIONS
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                {strengthSessions
-                  .slice()
-                  .reverse()
-                  .map((entry, i) => (
-                    <LogEntry key={i} entry={entry} />
-                  ))}
-              </div>
-            </>
+            <StrengthView
+              strengthTrend={strengthTrend}
+              strengthSessions={strengthSessions}
+            />
           )}
 
           {/* ── MOBILITY VIEW ── */}

--- a/web/src/views/StrengthView.jsx
+++ b/web/src/views/StrengthView.jsx
@@ -1,0 +1,290 @@
+import { useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import StrengthTooltip from '../components/StrengthTooltip.jsx';
+import LogEntry from '../components/LogEntry.jsx';
+import { STRENGTH_TEMPLATES, PREHAB_NOTE } from '../constants/exercises.js';
+
+const LIFT_COLOR = {
+  'Back Squat': '#34d399',
+  'Romanian Deadlift': '#34d399',
+  'Bench Press': '#a78bfa',
+  'Incline Bench': '#a78bfa',
+  'Barbell Row': '#00d4ff',
+  'Lat Pulldown': '#00d4ff',
+  'Shoulder Press': '#f472b6',
+};
+
+export default function StrengthView({ strengthTrend, strengthSessions }) {
+  const [activeLift, setActiveLift] = useState('Back Squat');
+  const liftColor = LIFT_COLOR[activeLift] || '#00d4ff';
+
+  return (
+    <>
+      {/* Lift selector */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 4,
+          flexWrap: 'wrap',
+          marginBottom: 12,
+        }}
+      >
+        {Object.keys(strengthTrend).map((lift) => (
+          <button
+            key={lift}
+            onClick={() => setActiveLift(lift)}
+            style={{
+              background:
+                activeLift === lift ? `${LIFT_COLOR[lift]}20` : 'transparent',
+              border:
+                activeLift === lift
+                  ? `1px solid ${LIFT_COLOR[lift]}`
+                  : '1px solid #4a4a68',
+              color: activeLift === lift ? LIFT_COLOR[lift] : '#7e7e9a',
+              borderRadius: 4,
+              padding: '5px 10px',
+              fontSize: 9,
+              letterSpacing: 0.5,
+              cursor: 'pointer',
+              fontFamily: "'DM Mono',monospace",
+            }}
+          >
+            {lift}
+          </button>
+        ))}
+      </div>
+
+      {/* e1RM chart */}
+      <div
+        style={{
+          background: '#2a2a48',
+          border: '1px solid #4a4a68',
+          borderRadius: 6,
+          padding: '14px 16px',
+          marginBottom: 12,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 9,
+            letterSpacing: 3,
+            color: liftColor,
+            marginBottom: 12,
+          }}
+        >
+          {activeLift.toUpperCase()} · e1RM (kg)
+        </div>
+        {strengthTrend[activeLift].length > 1 ? (
+          <ResponsiveContainer width="100%" height={140}>
+            <LineChart
+              data={strengthTrend[activeLift]}
+              margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+            >
+              <XAxis
+                dataKey="date"
+                tick={{
+                  fontSize: 9,
+                  fill: '#7e7e9a',
+                  fontFamily: "'DM Mono',monospace",
+                }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                domain={['auto', 'auto']}
+                tick={{
+                  fontSize: 9,
+                  fill: '#7e7e9a',
+                  fontFamily: "'DM Mono',monospace",
+                }}
+                tickFormatter={(v) => `${v}kg`}
+                axisLine={false}
+                tickLine={false}
+                width={42}
+              />
+              <Tooltip content={<StrengthTooltip />} />
+              <Line
+                type="monotone"
+                dataKey="e1rm"
+                stroke={liftColor}
+                strokeWidth={2}
+                dot={{
+                  r: 4,
+                  fill: liftColor,
+                  stroke: '#08080d',
+                  strokeWidth: 1,
+                }}
+                activeDot={{ r: 5 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        ) : (
+          <div
+            style={{
+              padding: '20px 0',
+              textAlign: 'center',
+              color: '#5a5a74',
+              fontSize: 11,
+            }}
+          >
+            One data point — chart builds as sessions are logged
+          </div>
+        )}
+        {/* Latest e1rm callout */}
+        <div
+          style={{
+            marginTop: 10,
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 8,
+          }}
+        >
+          <span style={{ fontSize: 22, fontWeight: 700, color: liftColor }}>
+            {strengthTrend[activeLift].slice(-1)[0].e1rm}kg
+          </span>
+          <span style={{ fontSize: 10, color: '#7e7e9a' }}>
+            current e1RM · {strengthTrend[activeLift].slice(-1)[0].date}
+          </span>
+          {strengthTrend[activeLift].length > 1 &&
+            (() => {
+              const first = strengthTrend[activeLift][0].e1rm;
+              const last = strengthTrend[activeLift].slice(-1)[0].e1rm;
+              const diff = (last - first).toFixed(1);
+              return (
+                <span style={{ fontSize: 10, color: '#34d399' }}>
+                  +{diff}kg
+                </span>
+              );
+            })()}
+        </div>
+      </div>
+
+      {/* Strength session list */}
+      {/* Saved Templates */}
+      <div
+        style={{
+          background: '#2a2a48',
+          border: '1px solid #4a4a68',
+          borderRadius: 6,
+          padding: '14px 16px',
+          marginBottom: 12,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 9,
+            letterSpacing: 3,
+            color: '#a78bfa',
+            marginBottom: 4,
+          }}
+        >
+          SAVED TEMPLATES · FITBOD
+        </div>
+        <div
+          style={{
+            fontSize: 9,
+            color: '#6c6c88',
+            marginBottom: 12,
+            lineHeight: 1.5,
+          }}
+        >
+          Fixed workouts, low variability. Stops auto-generation inserting leg
+          accessories or dropping pulls. Fitbod still suggests load progression.
+        </div>
+        {STRENGTH_TEMPLATES.map((t) => (
+          <div
+            key={t.name}
+            style={{
+              marginBottom: 12,
+              paddingBottom: 12,
+              borderBottom: '1px solid #3e3e5a',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'baseline',
+                marginBottom: 6,
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 12,
+                  fontWeight: 700,
+                  color: t.color,
+                }}
+              >
+                {t.name}
+              </span>
+              <span style={{ fontSize: 9, color: '#7e7e9a' }}>{t.focus}</span>
+            </div>
+            {t.exercises.map((ex, i) => (
+              <div
+                key={i}
+                style={{
+                  fontSize: 11,
+                  color: '#aaaacc',
+                  lineHeight: 1.7,
+                  paddingLeft: 4,
+                }}
+              >
+                · {ex}
+              </div>
+            ))}
+          </div>
+        ))}
+        <div
+          style={{
+            fontSize: 9,
+            color: '#6c6c88',
+            lineHeight: 1.5,
+            fontStyle: 'italic',
+          }}
+        >
+          Weekly: Upper 1 + Lower 1 + Upper 2 + Lower 2. Pull:press bias
+          maintained across the week. Squat heavy on Lower 1, explosive/light on
+          Lower 2 (daily undulating).
+        </div>
+        <div
+          style={{
+            fontSize: 9,
+            color: '#f472b6',
+            lineHeight: 1.6,
+            marginTop: 8,
+            borderTop: '1px solid #3e3e5a',
+            paddingTop: 8,
+          }}
+        >
+          💗 Prehab + Shoulder: {PREHAB_NOTE}
+        </div>
+      </div>
+
+      <div
+        style={{
+          fontSize: 9,
+          letterSpacing: 3,
+          color: '#7e7e9a',
+          marginBottom: 8,
+        }}
+      >
+        STRENGTH SESSIONS
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {strengthSessions
+          .slice()
+          .reverse()
+          .map((entry, i) => (
+            <LogEntry key={i} entry={entry} />
+          ))}
+      </div>
+    </>
+  );
+}

--- a/web/src/views/__tests__/StrengthView.test.jsx
+++ b/web/src/views/__tests__/StrengthView.test.jsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import StrengthView from '../StrengthView.jsx';
+
+const strengthTrend = {
+  'Back Squat': [
+    { date: '6/3', e1rm: 109.7 },
+    { date: '6/9', e1rm: 118.0 },
+  ],
+  // Single data point → exercises the empty-state branch when selected.
+  'Bench Press': [{ date: '6/3', e1rm: 63.4 }],
+};
+
+const strengthSessions = [
+  { type: 'strength', label: 'Upper A', date: '6/9', exercises: ['Bench 3x5'] },
+];
+
+describe('StrengthView', () => {
+  it('renders the default lift trend, templates, and sessions', () => {
+    render(
+      <StrengthView
+        strengthTrend={strengthTrend}
+        strengthSessions={strengthSessions}
+      />
+    );
+    // Default active lift = Back Squat (multi-point → chart + delta callout).
+    expect(screen.getByText(/BACK SQUAT · e1RM/i)).toBeInTheDocument();
+    expect(screen.getByText(/118kg/)).toBeInTheDocument();
+    expect(screen.getByText('+8.3kg')).toBeInTheDocument();
+    expect(screen.getByText(/SAVED TEMPLATES/i)).toBeInTheDocument();
+    expect(screen.getByText('STRENGTH SESSIONS')).toBeInTheDocument();
+  });
+
+  it('switches to a single-point lift and shows the empty-state copy', () => {
+    render(
+      <StrengthView
+        strengthTrend={strengthTrend}
+        strengthSessions={strengthSessions}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Bench Press' }));
+    expect(screen.getByText(/BENCH PRESS · e1RM/i)).toBeInTheDocument();
+    expect(screen.getByText(/One data point/i)).toBeInTheDocument();
+  });
+});

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -102,11 +102,16 @@ export default defineConfig({
         lines: 48,
         functions: 46,
         branches: 40,
-        // Commercial-baseline gate (80/80/70) for new code, applied per-file as
-        // it lands. The global floor above ratchets toward this as the monolith
-        // is extracted and its exclusions fall away.
+        // Commercial-baseline gate (80/80/70) for new/extracted code, applied
+        // per-file as it lands. The global floor above ratchets toward this as
+        // the monolith is decomposed and its exclusions fall away.
         'src/utils/sentry.js': { lines: 80, functions: 80, branches: 70 },
         'src/components/ErrorFallback.jsx': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/views/StrengthView.jsx': {
           lines: 80,
           functions: 80,
           branches: 70,


### PR DESCRIPTION
Closes #75

## What changed and why

Strangler-fig extraction #2 of the refactor + commercial-baselines sprint (part of #52). Moves the ~270-line `strength` tab out of the 6,581-line monolith into its own view, with **no behaviour change** — code is moved, not rewritten.

- **`web/src/views/StrengthView.jsx`** (new) owns its local `activeLift` state, the `LIFT_COLOR` map, and derived `liftColor`. `strengthTrend` + `strengthSessions` are passed in as props — `strengthTrend` stays in the monolith because the overview's `latestSquat` still reads it.
- **`web/src/erg-dashboard.jsx`** now renders `{view === 'strength' && <StrengthView strengthTrend={…} strengthSessions={…} />}` and drops the now-unused `StrengthTooltip` / `PREHAB_NOTE` / `STRENGTH_TEMPLATES` imports. **Monolith: 6,581 → 6,303 lines (−278).**
- **`web/vite.config.js`** adds the per-file **80/80/70** coverage gate for `StrengthView.jsx` (the commercial-baseline destination).

## How to test manually

Open the app → **Strength** tab: lift selector switches the e1RM chart, the delta callout and templates render, and a single-point lift shows the empty-state copy — identical to before.

## Checklist

- [x] CI is green (lint, test, build) — verified locally: 299 tests pass, build exit 0, lint 0 errors, format clean
- [x] Tests cover the change — render test at **92.8 / 87.5 / 91.7**, clears the 80/80/70 gate
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpVepBTPDtuiHLfZxCM2RX)_