### PR TITLE
housekeeping: remove unused DAILY_ROUTINE import

### DIFF
--- a/web/src/erg-dashboard.jsx
+++ b/web/src/erg-dashboard.jsx
@@ -56,7 +56,6 @@ import {
   dayStatus,
   daySessions,
 } from './utils/schedule.js';
-import { DAILY_ROUTINE } from './constants/coaching.js';
 
 /* ═══════════════════════════════════════════════════════════════
    ERG COACHING DASHBOARD · v1.2 beta


### PR DESCRIPTION
## What changed and why

CodeQL flagged `DAILY_ROUTINE` as an unused import in `web/src/erg-dashboard.jsx` ([code-scanning alert #15](https://github.com/skizzy1986/erg-dashboard/security/code-scanning/15)). It was the lone remaining symbol imported from `constants/coaching.js` after #108's import cleanup, so this removes the dead import line entirely. No behaviour change.

## How to test manually

N/A — dead-code removal. Build/lint/tests unaffected.

## Checklist

- [x] CI is green (lint, test, build) — verified locally: build exit 0, format clean
- [x] Tests cover the change — n/a (removing an unused import)
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpVepBTPDtuiHLfZxCM2RX)_