### PR TITLE
refactor: extract program microcycle to views/program/ProgramMicrocycle.jsx

### DIFF
--- a/web/src/views/ProgramView.jsx
+++ b/web/src/views/ProgramView.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import WorkoutItem from '../components/WorkoutItem.jsx';
 import { HR_ZONES, EST_MHR, SRPE_SCALE } from '../constants/trainingConfig.js';
 import {
   REP_SCHEMES,
@@ -14,15 +13,13 @@ import {
   NUTRITION_PRINCIPLES,
 } from '../constants/nutrition.js';
 import {
-  MICROCYCLE,
   SEASON,
   SEASON_2,
   EVENT_LADDER,
   VOLUME_PROGRESSION,
   PHASES,
 } from '../constants/schedule.js';
-import { ICON } from '../constants/ui.js';
-import { daySessions } from '../utils/schedule.js';
+import { C, ICON } from '../constants/ui.js';
 import {
   ERGZONE_FORMAT,
   BUILD1_SESSIONS,
@@ -31,13 +28,13 @@ import {
   TECHNIQUE_WORK,
   MOVEMENT_SCREEN,
   MOBILITY_WARMUP,
-  TECHNOGYM_CONVERSION,
   ATHLETE_BACKGROUND,
   RACE_TARGET,
   ORGS,
   EVENT_PATHWAY,
   ANNUAL_ARC,
 } from '../constants/program.js';
+import ProgramMicrocycle from './program/ProgramMicrocycle.jsx';
 
 export default function ProgramView({ expanded, setExpanded }) {
   const [progTab, setProgTab] = useState('phases');
@@ -73,187 +70,7 @@ export default function ProgramView({ expanded, setExpanded }) {
       </div>
 
       {/* ─── 2-WEEK MICROCYCLE ─── */}
-      {progTab === 'week' && (
-        <>
-          <div
-            style={{
-              background: '#1e1e30',
-              border: '1px solid #4a4a68',
-              borderLeft: '3px solid #f472b6',
-              borderRadius: 6,
-              padding: '12px 14px',
-              marginBottom: 14,
-              fontSize: 11,
-              color: '#aaaacc',
-              lineHeight: 1.6,
-            }}
-          >
-            <span style={{ color: '#f472b6', fontWeight: 700 }}>
-              ROSTER = PERIODIZATION:{' '}
-            </span>
-            Your 1-on/1-off FIFO roster is the load/recovery wave. Home week
-            loads, FIFO week auto-deloads. Erg is protected; strength yields
-            when scarce. This repeats as your base microcycle all year.
-          </div>
-          {[MICROCYCLE.home, MICROCYCLE.fifo].map((wk) => (
-            <div key={wk.label} style={{ marginBottom: 16 }}>
-              <div
-                style={{
-                  background: '#2a2a48',
-                  border: `1px solid ${wk.color}30`,
-                  borderLeft: `3px solid ${wk.color}`,
-                  borderRadius: 6,
-                  padding: '11px 14px',
-                  marginBottom: 8,
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: 12,
-                    fontWeight: 700,
-                    color: wk.color,
-                  }}
-                >
-                  {wk.label}
-                </div>
-                <div
-                  style={{
-                    fontSize: 10,
-                    color: '#7e7e9a',
-                    marginTop: 2,
-                  }}
-                >
-                  {wk.sub}
-                </div>
-                {wk.machineNote && (
-                  <div
-                    style={{
-                      fontSize: 9,
-                      color: '#a78bfa',
-                      marginTop: 6,
-                      lineHeight: 1.5,
-                      borderTop: '1px solid #3e3e5a',
-                      paddingTop: 6,
-                    }}
-                  >
-                    🚣 {wk.machineNote}
-                  </div>
-                )}
-              </div>
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 8,
-                }}
-              >
-                {wk.days.map((d) => {
-                  const sessions = daySessions(d);
-                  const railObj = { top: d.day.toUpperCase() };
-                  return (
-                    <div
-                      key={d.day}
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 3,
-                      }}
-                    >
-                      {sessions.length === 0 ? (
-                        <WorkoutItem
-                          session={null}
-                          rail={railObj}
-                          showRail={true}
-                        />
-                      ) : (
-                        sessions.map((s, j) => (
-                          <WorkoutItem
-                            key={j}
-                            session={s}
-                            rail={railObj}
-                            showRail={j === 0}
-                          />
-                        ))
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
-          <div
-            style={{
-              background: '#1e1e30',
-              border: '1px solid #ffd70030',
-              borderLeft: '3px solid #ffd700',
-              borderRadius: 6,
-              padding: '11px 14px',
-              fontSize: 11,
-              color: '#888860',
-              lineHeight: 1.6,
-            }}
-          >
-            ⚠️ FIFO week is maintenance, not failure. Missing a session on a
-            12-hour-shift day is the correct call. The home week is where you
-            build; the work swing is where you recover. Sleep above all during
-            the swing — it's already compressed by the roster.
-          </div>
-          <div
-            style={{
-              background: '#1e1e30',
-              border: '1px solid #a78bfa30',
-              borderLeft: '3px solid #a78bfa',
-              borderRadius: 6,
-              padding: '11px 14px',
-              marginTop: 8,
-              fontSize: 11,
-              color: '#aaaacc',
-              lineHeight: 1.6,
-            }}
-          >
-            🔬{' '}
-            <span style={{ color: '#a78bfa', fontWeight: 700 }}>
-              Technogym ↔ Concept2 conversion (auto-building from Strava):{' '}
-            </span>
-            {TECHNOGYM_CONVERSION.status}{' '}
-            <span style={{ color: '#888860' }}>
-              {TECHNOGYM_CONVERSION.method}
-            </span>{' '}
-            Once enough paired HR130 points land, this yields real watt targets
-            for the camp machine.{' '}
-            <span style={{ color: '#7e7e9a' }}>
-              {TECHNOGYM_CONVERSION.caveats}
-            </span>
-          </div>
-          <div
-            style={{
-              background: '#1e1e30',
-              border: '1px solid #00d4ff30',
-              borderLeft: '3px solid #00d4ff',
-              borderRadius: 6,
-              padding: '11px 14px',
-              marginTop: 8,
-              fontSize: 11,
-              color: '#aaaacc',
-              lineHeight: 1.6,
-            }}
-          >
-            📅{' '}
-            <span style={{ color: '#00d4ff', fontWeight: 700 }}>
-              Next two cycles — PUSH then RECOVER:{' '}
-            </span>
-            This home week is a genuine loading week — push volume while fresh
-            (the trained cyclist's engine can absorb it). Then FIFO next week is
-            the consolidation deload that banks the gains. Push/recover built
-            into the roster. Critical: push THIS week, don't fight the FIFO
-            deload next week — adaptation happens during recovery. "Push" in
-            base = more volume, longer long row, progressed strength, the rate
-            ladder — NOT intensity (threshold/VO2 belong in Build 1, Sept+).
-            Governor: family stress is real load — if HRV drops or sRPE climbs
-            mid-week, ease off. Data leads.
-          </div>
-        </>
-      )}
+      {progTab === 'week' && <ProgramMicrocycle />}
 
       {/* ─── ANNUAL ARC ─── */}
       {progTab === 'year' && (

--- a/web/src/views/program/ProgramMicrocycle.jsx
+++ b/web/src/views/program/ProgramMicrocycle.jsx
@@ -1,0 +1,183 @@
+import WorkoutItem from '../../components/WorkoutItem.jsx';
+import { MICROCYCLE } from '../../constants/schedule.js';
+import { TECHNOGYM_CONVERSION } from '../../constants/program.js';
+import { daySessions } from '../../utils/schedule.js';
+
+export default function ProgramMicrocycle() {
+  return (
+    <>
+      <div
+        style={{
+          background: '#1e1e30',
+          border: '1px solid #4a4a68',
+          borderLeft: '3px solid #f472b6',
+          borderRadius: 6,
+          padding: '12px 14px',
+          marginBottom: 14,
+          fontSize: 11,
+          color: '#aaaacc',
+          lineHeight: 1.6,
+        }}
+      >
+        <span style={{ color: '#f472b6', fontWeight: 700 }}>
+          ROSTER = PERIODIZATION:{' '}
+        </span>
+        Your 1-on/1-off FIFO roster is the load/recovery wave. Home week loads,
+        FIFO week auto-deloads. Erg is protected; strength yields when scarce.
+        This repeats as your base microcycle all year.
+      </div>
+      {[MICROCYCLE.home, MICROCYCLE.fifo].map((wk) => (
+        <div key={wk.label} style={{ marginBottom: 16 }}>
+          <div
+            style={{
+              background: '#2a2a48',
+              border: `1px solid ${wk.color}30`,
+              borderLeft: `3px solid ${wk.color}`,
+              borderRadius: 6,
+              padding: '11px 14px',
+              marginBottom: 8,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 12,
+                fontWeight: 700,
+                color: wk.color,
+              }}
+            >
+              {wk.label}
+            </div>
+            <div
+              style={{
+                fontSize: 10,
+                color: '#7e7e9a',
+                marginTop: 2,
+              }}
+            >
+              {wk.sub}
+            </div>
+            {wk.machineNote && (
+              <div
+                style={{
+                  fontSize: 9,
+                  color: '#a78bfa',
+                  marginTop: 6,
+                  lineHeight: 1.5,
+                  borderTop: '1px solid #3e3e5a',
+                  paddingTop: 6,
+                }}
+              >
+                🚣 {wk.machineNote}
+              </div>
+            )}
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 8,
+            }}
+          >
+            {wk.days.map((d) => {
+              const sessions = daySessions(d);
+              const railObj = { top: d.day.toUpperCase() };
+              return (
+                <div
+                  key={d.day}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 3,
+                  }}
+                >
+                  {sessions.length === 0 ? (
+                    <WorkoutItem
+                      session={null}
+                      rail={railObj}
+                      showRail={true}
+                    />
+                  ) : (
+                    sessions.map((s, j) => (
+                      <WorkoutItem
+                        key={j}
+                        session={s}
+                        rail={railObj}
+                        showRail={j === 0}
+                      />
+                    ))
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+      <div
+        style={{
+          background: '#1e1e30',
+          border: '1px solid #ffd70030',
+          borderLeft: '3px solid #ffd700',
+          borderRadius: 6,
+          padding: '11px 14px',
+          fontSize: 11,
+          color: '#888860',
+          lineHeight: 1.6,
+        }}
+      >
+        ⚠️ FIFO week is maintenance, not failure. Missing a session on a
+        12-hour-shift day is the correct call. The home week is where you build;
+        the work swing is where you recover. Sleep above all during the swing —
+        it's already compressed by the roster.
+      </div>
+      <div
+        style={{
+          background: '#1e1e30',
+          border: '1px solid #a78bfa30',
+          borderLeft: '3px solid #a78bfa',
+          borderRadius: 6,
+          padding: '11px 14px',
+          marginTop: 8,
+          fontSize: 11,
+          color: '#aaaacc',
+          lineHeight: 1.6,
+        }}
+      >
+        🔬{' '}
+        <span style={{ color: '#a78bfa', fontWeight: 700 }}>
+          Technogym ↔ Concept2 conversion (auto-building from Strava):{' '}
+        </span>
+        {TECHNOGYM_CONVERSION.status}{' '}
+        <span style={{ color: '#888860' }}>{TECHNOGYM_CONVERSION.method}</span>{' '}
+        Once enough paired HR130 points land, this yields real watt targets for
+        the camp machine.{' '}
+        <span style={{ color: '#7e7e9a' }}>{TECHNOGYM_CONVERSION.caveats}</span>
+      </div>
+      <div
+        style={{
+          background: '#1e1e30',
+          border: '1px solid #00d4ff30',
+          borderLeft: '3px solid #00d4ff',
+          borderRadius: 6,
+          padding: '11px 14px',
+          marginTop: 8,
+          fontSize: 11,
+          color: '#aaaacc',
+          lineHeight: 1.6,
+        }}
+      >
+        📅{' '}
+        <span style={{ color: '#00d4ff', fontWeight: 700 }}>
+          Next two cycles — PUSH then RECOVER:{' '}
+        </span>
+        This home week is a genuine loading week — push volume while fresh (the
+        trained cyclist's engine can absorb it). Then FIFO next week is the
+        consolidation deload that banks the gains. Push/recover built into the
+        roster. Critical: push THIS week, don't fight the FIFO deload next week
+        — adaptation happens during recovery. "Push" in base = more volume,
+        longer long row, progressed strength, the rate ladder — NOT intensity
+        (threshold/VO2 belong in Build 1, Sept+). Governor: family stress is
+        real load — if HRV drops or sRPE climbs mid-week, ease off. Data leads.
+      </div>
+    </>
+  );
+}

--- a/web/src/views/program/__tests__/ProgramMicrocycle.test.jsx
+++ b/web/src/views/program/__tests__/ProgramMicrocycle.test.jsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ProgramMicrocycle from '../ProgramMicrocycle.jsx';
+
+describe('ProgramMicrocycle', () => {
+  it('renders both roster weeks', () => {
+    render(<ProgramMicrocycle />);
+    expect(screen.getAllByText(/HOME WEEK/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/FIFO WEEK/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the Technogym conversion note', () => {
+    render(<ProgramMicrocycle />);
+    expect(
+      screen.getByText(/Technogym ↔ Concept2 conversion/i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Part of #77 (PR 2 of 3 — the program decomposition). Part of #52.

## What changed and why

Strangler-fig extraction continues on the Program tab: PR1 (#110) moved the whole tab into `views/ProgramView.jsx`; this PR splits the "2-Wk Cycle" sub-tab out into its own component, per #110's stated plan ("PR2/PR3 will split its week/year sub-tabs into `views/program/*`"). PR 3/3 will extract the "Annual" sub-tab next and close #77.

- **`web/src/views/program/ProgramMicrocycle.jsx`** (new) — the 2-week home/FIFO roster content, moved out verbatim as a standalone `export default function ProgramMicrocycle()`. No props needed (self-contained: `MICROCYCLE`, `TECHNOGYM_CONVERSION`, `WorkoutItem`, `daySessions`).
- **`web/src/views/ProgramView.jsx`** renders `{progTab === 'week' && <ProgramMicrocycle />}` and sheds the now-unused imports.
- **Bugfix, found while rewriting the import block:** the phases tab referenced `C[s.type]` (session-type color lookup) but `C` was never imported from `constants/ui.js` — only `ICON` was. This is a live `ReferenceError` that fires whenever the phases tab renders a weekly-template row for a non-rest session type. Fixed by adding `C` to the existing import.
- Render test covers both roster weeks + the Technogym conversion note. Global coverage 64/64/64 vs the 52/50/48 gate.

## How to test manually

Open the app → **Program** tab → **2-Wk Cycle**: renders identically to before. **Phases**: previously would throw a `ReferenceError` on load (uncaught in production since `PHASES[].weekly` always includes non-rest sessions) — now renders correctly.

## Checklist

- [x] CI is green (lint, test, build) — verified locally: 325 tests pass, build exit 0, lint 0 errors, format clean
- [x] Tests cover the change — render test for `ProgramMicrocycle`; global coverage 64/64/64
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser


---
_Generated by [Claude Code](https://claude.ai/code/session_016pudSYssWmXrMis3qFsnRn)_