### PR TITLE
docs: reconcile docs with post-extraction reality + fix Dependabot web/ scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,20 @@
 version: 2
 updates:
+  # Root package.json holds only tooling (husky); the app lives in web/
   - package-ecosystem: npm
     directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /web
     schedule:
       interval: weekly
       day: monday

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ web/                The app lives under web/ (Vite + Capacitor monorepo layout)
     utils/          Pure functions — analysis, formatting, scheduling
     components/     Shared UI components (LogEntry, WorkoutItem, charts)
     views/          Extracted dashboard tabs (desktop + mobile)
-    erg-dashboard.jsx  Monolith being decomposed (~9,700 lines — see refactor)
+    erg-dashboard.jsx  Former monolith, now a ~960-line shell/router (see refactor)
     StrengthLogger.jsx Large component, not yet extracted (~1,665 lines)
     main.jsx        Auth gate (Supabase email/password login)
 supabase/
@@ -77,10 +77,12 @@ coach/
 
 ## Architecture: Strangler Fig Refactor
 
-The main file (`web/src/erg-dashboard.jsx`, **~9,700 lines** as of 2026-06-29 —
-the refactor is in progress and tracked in GitHub issue #52) is being decomposed
-into a modular structure. `App.jsx` has not been reached yet. The safe migration
-order:
+The refactor is nearly complete (tracked in GitHub issue #52). The former
+monolith `web/src/erg-dashboard.jsx` is down to **~960 lines** (2026-07-02) — a
+shell/router that composes the extracted views. Remaining large files:
+`views/ProgramView.jsx` (~3,050 lines, being split into `views/program/*`, #77)
+and `StrengthLogger.jsx` (~1,665 lines, untested, #79). `App.jsx` has not been
+reached yet. The safe migration order:
 
 1. Extract constants and utils (zero risk — pure JS, no JSX)
 2. Extract hooks (low risk — same data, reorganised)
@@ -209,7 +211,7 @@ Every PR is gated by three GitHub Actions jobs that must pass before merge:
 | Job | What it checks |
 |---|---|
 | `Lint & Format` | ESLint errors + Prettier formatting + `npm audit --audit-level=high` |
-| `Test & Coverage` | All Vitest tests pass; coverage meets the ratcheting thresholds in `web/vite.config.js` — baseline **48% lines / 46% functions / 40% branches** (set by the #62 keystone), raised as extractions add tests |
+| `Test & Coverage` | All Vitest tests pass; coverage meets the ratcheting thresholds in `web/vite.config.js` (`test.coverage.thresholds` — the **only** source of truth for the numbers), raised as extractions add tests |
 | `Build` | `npm run build` exits 0 (runs only after Test passes) |
 
 Coverage thresholds live in `web/vite.config.js` (`test.coverage.thresholds`) and
@@ -396,4 +398,4 @@ without needing to prompt Coach.
 - Always run `npm test` before committing
 - Always run `npm run lint` and `npm run format:check` before pushing — CI will fail if either does not pass
 - Never bypass the pre-commit hook (`--no-verify`) without an explicit reason
-- Coverage thresholds (baseline 48% lines / 46% functions / 40% branches — the ratchet in `web/vite.config.js`) are enforced in CI — new code should include tests, and the numbers only go up
+- Coverage thresholds (the ratchet in `web/vite.config.js` — the only source of truth for the numbers) are enforced in CI — new code should include tests, and the numbers only go up

--- a/FACTORY.md
+++ b/FACTORY.md
@@ -5,10 +5,11 @@ How feature work runs here, adapted from the "software factory with Claude Code"
 ## The five layers
 1. **Context** — explore before building (`codebase-researcher` runs first).
 2. **Knowledge** — `CLAUDE.md` (durable facts), these agents, and the `.claude/` config.
-3. **Agents** — seven specialists in `.claude/agents/`, each with least-privilege tools:
-   - `codebase-researcher` (Read/Grep/Glob) · `story-writer` (Read) · `spec-writer` (Read/Grep/Glob) — read-only
-   - `backend-builder`, `frontend-builder`, `test-verifier` (Read/Edit/Write/Bash) — write
-   - `implementation-validator` (Read/Grep/Glob) — read-only judge
+3. **Agents** — twelve pipeline specialists in `.claude/agents/`, each with least-privilege tools (plus the 232-agent Agency advisory library — see `.claude/AGENTS.md` for the routing map):
+   - `codebase-researcher` (Read/Grep/Glob) · `researcher` (+WebSearch/WebFetch) · `story-writer` (Read) · `spec-writer` (Read/Grep/Glob) — read-only
+   - `backend-builder`, `frontend-builder`, `feature-builder`, `test-verifier`, `refactor-agent` (Read/Edit/Write/Bash) — write
+   - `implementation-validator`, `code-reviewer` (Read/Grep/Glob) — read-only judges
+   - `orchestrator` — coordinates the chain
 4. **Workflow** — the chain in `.claude/commands/orchestrate.md`, with three human gates.
 5. **Delivery** — PR + the validator's verdict + confirm Vercel goes READY.
 
@@ -18,7 +19,7 @@ The lane/least-privilege idea we hand-rolled (read-only by default, escalate to 
 ## Run it
 - `/orchestrate <feature idea>` — runs the whole chain with the three approval gates.
 - Or invoke an agent directly for a one-off (e.g. ask for `codebase-researcher` before a manual change).
-- Start smaller if seven feels like a lot: researcher → builder → validator is a valid minimal chain.
+- Start smaller if twelve feels like a lot: researcher → builder → validator is a valid minimal chain.
 
 ## Gates (don't skip)
 1. After the **story** — right problem?

--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ Browser / Android APK
         └── vitals-sync       — on-demand sync trigger
 ```
 
-The main file `web/src/erg-dashboard.jsx` (~9,700 lines) is being decomposed
-into the modular structure above using a strangler-fig refactor — one safe
-extraction at a time, app stays functional throughout.
+The former monolith `web/src/erg-dashboard.jsx` (now ~960 lines — a shell/router)
+has been decomposed into the modular structure above using a strangler-fig
+refactor — one safe extraction at a time, app stays functional throughout. The
+tail end (Program sub-tabs, StrengthLogger, the App.jsx rename) is tracked in
+issue #52.
 
 ---
 
@@ -150,7 +152,7 @@ erg-dashboard/
 │   │   ├── views/            desktop views (CoachView, ErgLiveView, …)
 │   │   │   └── mobile/       mobile-specific views (MobileApp, MobileRecovery, …)
 │   │   ├── services/         pm5Bluetooth.js (BLE abstraction)
-│   │   ├── erg-dashboard.jsx monolith being decomposed (~9,700 lines)
+│   │   ├── erg-dashboard.jsx shell/router (~960 lines, formerly the monolith)
 │   │   └── main.jsx          auth gate (Supabase email/password)
 │   ├── android/              Capacitor Android project
 │   ├── capacitor.config.json

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -79,13 +79,14 @@ Three required checks on every PR (`.github/workflows/ci-web.yml`):
 | Gate | Checks |
 |---|---|
 | **Lint & Format** | ESLint + Prettier + `npm audit --audit-level=high` |
-| **Test & Coverage** | Vitest passes; line ≥50%, function ≥30%, branch ≥35% |
+| **Test & Coverage** | Vitest passes; coverage meets the ratcheting thresholds in `web/vite.config.js` |
 | **Build** | `npm run build` exits 0 (runs after Test) |
 
 `main` is protected: no direct pushes, branch must be up to date, all checks
-green. A coverage comment posts automatically. The coverage numbers are the
-source of truth in `web/vite.config.js` (`test.coverage.thresholds`) — update
-them there, then mirror here.
+green. A coverage comment posts automatically. The coverage numbers live in
+**one place only** — `web/vite.config.js` (`test.coverage.thresholds`). Do not
+mirror them into docs; they ratchet upward with every extraction and mirrored
+copies drift.
 
 ## 5. Merge and clean up
 

--- a/coach/PROJECT_MANAGEMENT_ANALYSIS.md
+++ b/coach/PROJECT_MANAGEMENT_ANALYSIS.md
@@ -4,6 +4,18 @@
 > Produced 2026-06-29 by the Project Management division. Read alongside
 > `WORKFLOW.md` (the new standing process) and `CLAUDE.md` (project briefing).
 
+> **Addendum 2026-07-02 — status update.** Three days of execution overtook
+> several findings; treat the figures below as historical. Finding 1 (three
+> disconnected trackers) and Finding 3 (agents documented-but-not-installed)
+> are **resolved** — GitHub Issues/Projects is the single rail, 244 agents are
+> installed. Finding 5 (stalled refactor) is **nearly resolved**:
+> `erg-dashboard.jsx` is down from 9,733 to **~960 lines** (a shell/router;
+> ~20 extraction PRs merged 2026-06-29 → 07-01); the endgame is tracked in
+> issue #114. The CI coverage gate cited in Finding 7 now lives solely in
+> `web/vite.config.js` (a ratchet — do not quote numbers in docs). Findings 6
+> (dormant integrations) and the StrengthLogger test gap remain open, tracked
+> in issues #116 and #114.
+
 ---
 
 ## Executive summary


### PR DESCRIPTION
Part of #113 (Sprint 1 — Truth & Triage).

## What changed and why

The 2026-07-02 planning sweep found the docs badly behind the code. Docs + config only — no app code.

- **`CLAUDE.md` / `README.md`** — both still described `erg-dashboard.jsx` as a ~9,700-line monolith; after #89/#106–#110 it is a **~960-line shell/router**. Rewrote the refactor sections to describe the endgame state (remaining: `ProgramView` split #77, `StrengthLogger` #79, App.jsx milestone).
- **Coverage numbers de-duplicated** — three docs mirrored the thresholds and all three disagreed (WORKFLOW.md said 50/30/35, CLAUDE.md said 48/46/40, the actual gate is the ratchet in `web/vite.config.js`). Removed every mirrored number; docs now point at `vite.config.js` as the only source of truth, so there is nothing left to drift. (A CI guard enforcing this is a Sprint 3 item, #115.)
- **`FACTORY.md`** — "seven specialists" → the actual twelve pipeline agents + a pointer to the Agency library routing map.
- **`coach/PROJECT_MANAGEMENT_ANALYSIS.md`** — dated addendum marking Findings 1/3/5 resolved and its monolith/coverage figures historical.
- **`.github/dependabot.yml`** — the npm ecosystem only watched the root `package.json` (which holds just husky), so the `web/` app dependencies received **no Dependabot updates**. Added a second npm entry for `directory: /web` with the same weekly grouped config.

## How to test manually

Docs: read the diff. Dependabot: after merge, check Insights → Dependency graph → Dependabot shows `/web/package.json` as a tracked manifest (first run next Monday).

## Checklist

- [x] CI is green (lint, test, build) — no app code changed; pre-push hook ran the full suite locally: **323 tests pass**
- [x] Tests cover the change, or I've noted why they don't — docs/config only, no testable surface
- [x] `npm run build` passes locally — no `web/src` changes
- [x] No unexpected console errors in the browser — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019N6FVxdYLxfQYyZhjGuvPB

---
_Generated by [Claude Code](https://claude.ai/code/session_019N6FVxdYLxfQYyZhjGuvPB)_