### PR TITLE
fix: fail-closed + timing-safe CRON_SECRET guard on vitals-import(-api)

### DIFF
--- a/supabase/functions/vitals-import-api/cronGuard.ts
+++ b/supabase/functions/vitals-import-api/cronGuard.ts
@@ -1,0 +1,42 @@
+// cronGuard.ts — fail-closed, timing-safe shared-secret check for the
+// x-cron-secret header. Call this before any other work happens.
+//
+// Threat model this closes:
+//   1. CRON_SECRET unset or "" must NEVER authorize a request (previously:
+//      `if (expected && ...)` skipped the check entirely when `expected`
+//      was falsy, silently opening the endpoint to any unauthenticated
+//      caller).
+//   2. Raw string `!==` short-circuits on the first differing byte, so a
+//      naive check leaks how many leading characters of a guessed secret
+//      are correct via response timing. We instead compare fixed-length
+//      SHA-256 digests of both sides with node:crypto's timingSafeEqual,
+//      so every call — right or wrong, short or long, matching or not —
+//      does the identical fixed-size constant-time compare. Hashing first
+//      also sidesteps timingSafeEqual's hard requirement that both inputs
+//      be equal length (it throws otherwise): the two digests are always
+//      exactly 32 bytes, so there is no length branch to leak and no
+//      exception path to reason about.
+import { createHash, timingSafeEqual } from "node:crypto";
+
+const unauthorized = (): Response =>
+  new Response(JSON.stringify({ error: "unauthorized" }), {
+    status: 401,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const sha256 = (input: string): Uint8Array => createHash("sha256").update(input, "utf8").digest();
+
+/**
+ * Returns a 401 Response if the request fails the CRON_SECRET guard.
+ * Returns null if the request is authorized and the caller should proceed.
+ */
+export function checkCronSecret(req: Request): Response | null {
+  const expected = Deno.env.get("CRON_SECRET");
+  if (!expected) return unauthorized(); // unset or "" -> fail closed, no exceptions
+
+  const provided = req.headers.get("x-cron-secret");
+  if (!provided) return unauthorized(); // header missing or "" -> fail closed
+
+  const match = timingSafeEqual(sha256(expected), sha256(provided));
+  return match ? null : unauthorized();
+}

--- a/supabase/functions/vitals-import-api/index.ts
+++ b/supabase/functions/vitals-import-api/index.ts
@@ -12,6 +12,7 @@
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { exchangeToken, listDataPoints } from "./client.ts";
 import { mapResponses } from "./mapper.ts";
+import { checkCronSecret } from "./cronGuard.ts";
 
 function ymd(d: Date): string {
   return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
@@ -30,11 +31,11 @@ Deno.serve(async (req: Request) => {
     } catch (_) { /* swallow — a Slack outage never fails the import */ }
   };
 
-  // 1. shared-secret guard (function is deployed with verify_jwt=false)
-  const expected = Deno.env.get("CRON_SECRET");
-  if (expected && req.headers.get("x-cron-secret") !== expected) {
-    return json({ error: "unauthorized" }, 401);
-  }
+  // 1. shared-secret guard (function is deployed with verify_jwt=false).
+  // Fails closed: an unset/empty CRON_SECRET, or any header mismatch,
+  // always returns 401 — see cronGuard.ts for the timing-safe compare.
+  const guardResponse = checkCronSecret(req);
+  if (guardResponse) return guardResponse;
 
   // 2. validate required env
   const clientId     = Deno.env.get("GOOGLE_HEALTH_CLIENT_ID");
@@ -51,7 +52,6 @@ Deno.serve(async (req: Request) => {
     ["VITALS_USER_ID", userId],
     ["SUPABASE_URL", supaUrl],
     ["SUPABASE_SERVICE_ROLE_KEY", serviceKey],
-    ["CRON_SECRET", expected],
   ].filter(([, v]) => !v).map(([k]) => k);
   if (missing.length) return json({ error: "missing env", missing }, 500);
 

--- a/supabase/functions/vitals-import-api/test.ts
+++ b/supabase/functions/vitals-import-api/test.ts
@@ -1,4 +1,5 @@
 import { extractHrv, extractRhr, extractSleepHours, extractWeightKg, mapResponses } from "./mapper.ts";
+import { checkCronSecret } from "./cronGuard.ts";
 
 let pass = 0, fail = 0;
 const check = (name: string, cond: boolean, actual?: unknown) => {
@@ -96,6 +97,56 @@ check("extractSleepHours: 450min -> 7.5", extractSleepHours({ dataPoints: [{ sle
 check("malformed shape -> null",   extractHrv({ foo: "bar" }) === null, "malformed");
 
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// cronGuard: fail-closed, timing-safe CRON_SECRET check
+// ---------------------------------------------------------------------------
+const CRON_ENV = "CRON_SECRET";
+const savedCronSecret = Deno.env.get(CRON_ENV);
+
+const mockReq = (headerValue?: string) =>
+  new Request("http://localhost/", {
+    headers: headerValue === undefined ? {} : { "x-cron-secret": headerValue },
+  });
+
+// 1. secret unset entirely -> 401, regardless of header
+Deno.env.delete(CRON_ENV);
+check("guard: secret unset -> 401", checkCronSecret(mockReq("anything"))?.status === 401);
+
+// 2. secret set to "" -> 401 (fail closed), even with a matching-looking header
+Deno.env.set(CRON_ENV, "");
+check("guard: secret empty, header empty -> 401", checkCronSecret(mockReq(""))?.status === 401);
+check("guard: secret empty, header set -> 401", checkCronSecret(mockReq("whatever"))?.status === 401);
+
+// From here, a real secret is configured for the remaining cases.
+const REAL_SECRET = "s3cret-value-123-xyz";
+Deno.env.set(CRON_ENV, REAL_SECRET);
+
+// 3. header missing entirely -> 401
+check("guard: header missing -> 401", checkCronSecret(mockReq(undefined))?.status === 401);
+
+// 4. header present but empty -> 401
+check("guard: header empty -> 401", checkCronSecret(mockReq(""))?.status === 401);
+
+// 5. header wrong, same length as secret -> 401, must not throw
+const wrongSameLen = "x".repeat(REAL_SECRET.length);
+check("guard: header wrong (same length) -> 401", checkCronSecret(mockReq(wrongSameLen))?.status === 401);
+
+// 6. header wrong, different length than secret -> 401, must not throw
+//    (this is the case that breaks a naive timingSafeEqual(a, b) call
+//    directly on unequal-length buffers)
+check("guard: header wrong (different length) -> 401", checkCronSecret(mockReq("short"))?.status === 401);
+
+// 7. header correct -> guard passes through (null), no regression
+check("guard: header correct -> null (authorized)", checkCronSecret(mockReq(REAL_SECRET)) === null);
+
+// 8. 401 body shape
+const body401 = await checkCronSecret(mockReq("wrong"))!.json();
+check("guard: 401 body is 'unauthorized'", body401.error === "unauthorized");
+
+// restore prior env state
+if (savedCronSecret === undefined) Deno.env.delete(CRON_ENV);
+else Deno.env.set(CRON_ENV, savedCronSecret);
 
 console.log("\nRESULT:", pass, "passed,", fail, "failed");
 if (fail) Deno.exit(1);

--- a/supabase/functions/vitals-import/cronGuard.ts
+++ b/supabase/functions/vitals-import/cronGuard.ts
@@ -1,0 +1,42 @@
+// cronGuard.ts — fail-closed, timing-safe shared-secret check for the
+// x-cron-secret header. Call this before any other work happens.
+//
+// Threat model this closes:
+//   1. CRON_SECRET unset or "" must NEVER authorize a request (previously:
+//      `if (expected && ...)` skipped the check entirely when `expected`
+//      was falsy, silently opening the endpoint to any unauthenticated
+//      caller).
+//   2. Raw string `!==` short-circuits on the first differing byte, so a
+//      naive check leaks how many leading characters of a guessed secret
+//      are correct via response timing. We instead compare fixed-length
+//      SHA-256 digests of both sides with node:crypto's timingSafeEqual,
+//      so every call — right or wrong, short or long, matching or not —
+//      does the identical fixed-size constant-time compare. Hashing first
+//      also sidesteps timingSafeEqual's hard requirement that both inputs
+//      be equal length (it throws otherwise): the two digests are always
+//      exactly 32 bytes, so there is no length branch to leak and no
+//      exception path to reason about.
+import { createHash, timingSafeEqual } from "node:crypto";
+
+const unauthorized = (): Response =>
+  new Response(JSON.stringify({ error: "unauthorized" }), {
+    status: 401,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const sha256 = (input: string): Uint8Array => createHash("sha256").update(input, "utf8").digest();
+
+/**
+ * Returns a 401 Response if the request fails the CRON_SECRET guard.
+ * Returns null if the request is authorized and the caller should proceed.
+ */
+export function checkCronSecret(req: Request): Response | null {
+  const expected = Deno.env.get("CRON_SECRET");
+  if (!expected) return unauthorized(); // unset or "" -> fail closed, no exceptions
+
+  const provided = req.headers.get("x-cron-secret");
+  if (!provided) return unauthorized(); // header missing or "" -> fail closed
+
+  const match = timingSafeEqual(sha256(expected), sha256(provided));
+  return match ? null : unauthorized();
+}

--- a/supabase/functions/vitals-import/index.ts
+++ b/supabase/functions/vitals-import/index.ts
@@ -13,16 +13,17 @@
 //   CRON_SECRET                shared secret; caller must send header x-cron-secret
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { buildRecords } from "./parser.ts";
+import { checkCronSecret } from "./cronGuard.ts";
 
 Deno.serve(async (req: Request) => {
   const json = (body: unknown, status = 200) =>
     new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
 
-  // shared-secret guard (function is deployed with verify_jwt=false)
-  const expected = Deno.env.get("CRON_SECRET");
-  if (expected && req.headers.get("x-cron-secret") !== expected) {
-    return json({ error: "unauthorized" }, 401);
-  }
+  // shared-secret guard (function is deployed with verify_jwt=false).
+  // Fails closed: an unset/empty CRON_SECRET, or any header mismatch,
+  // always returns 401 — see cronGuard.ts for the timing-safe compare.
+  const guardResponse = checkCronSecret(req);
+  if (guardResponse) return guardResponse;
 
   const vitalsUrl  = Deno.env.get("VITALS_CSV_URL");
   const sleepUrl   = Deno.env.get("SLEEP_CSV_URL");

--- a/supabase/functions/vitals-import/test.ts
+++ b/supabase/functions/vitals-import/test.ts
@@ -1,4 +1,5 @@
 import { buildRecords, isoDate } from "./parser.ts";
+import { checkCronSecret } from "./cronGuard.ts";
 
 // Three separate CSVs mirroring the real Health Data Export tab structure.
 // Includes the 6/18 sleep double-row and Concept2 vitals rows with blank HRV/RHR.
@@ -62,5 +63,55 @@ check("isoDate DD/MM/YYYY converts to ISO", isoDate("14/06/2026") === "2026-06-1
 check("isoDate with timestamp suffix", isoDate("2026-06-14 00:00:00") === "2026-06-14");
 check("isoDate null on garbage", isoDate("not-a-date") === null);
 
+// ---------------------------------------------------------------------------
+// cronGuard: fail-closed, timing-safe CRON_SECRET check
+// ---------------------------------------------------------------------------
+const CRON_ENV = "CRON_SECRET";
+const savedCronSecret = Deno.env.get(CRON_ENV);
+
+const mockReq = (headerValue?: string) =>
+  new Request("http://localhost/", {
+    headers: headerValue === undefined ? {} : { "x-cron-secret": headerValue },
+  });
+
+// 1. secret unset entirely -> 401, regardless of header
+Deno.env.delete(CRON_ENV);
+check("guard: secret unset -> 401", checkCronSecret(mockReq("anything"))?.status === 401);
+
+// 2. secret set to "" -> 401 (fail closed), even with a matching-looking header
+Deno.env.set(CRON_ENV, "");
+check("guard: secret empty, header empty -> 401", checkCronSecret(mockReq(""))?.status === 401);
+check("guard: secret empty, header set -> 401", checkCronSecret(mockReq("whatever"))?.status === 401);
+
+// From here, a real secret is configured for the remaining cases.
+const REAL_SECRET = "s3cret-value-123-xyz";
+Deno.env.set(CRON_ENV, REAL_SECRET);
+
+// 3. header missing entirely -> 401
+check("guard: header missing -> 401", checkCronSecret(mockReq(undefined))?.status === 401);
+
+// 4. header present but empty -> 401
+check("guard: header empty -> 401", checkCronSecret(mockReq(""))?.status === 401);
+
+// 5. header wrong, same length as secret -> 401, must not throw
+const wrongSameLen = "x".repeat(REAL_SECRET.length);
+check("guard: header wrong (same length) -> 401", checkCronSecret(mockReq(wrongSameLen))?.status === 401);
+
+// 6. header wrong, different length than secret -> 401, must not throw
+//    (this is the case that breaks a naive timingSafeEqual(a, b) call
+//    directly on unequal-length buffers)
+check("guard: header wrong (different length) -> 401", checkCronSecret(mockReq("short"))?.status === 401);
+
+// 7. header correct -> guard passes through (null), no regression
+check("guard: header correct -> null (authorized)", checkCronSecret(mockReq(REAL_SECRET)) === null);
+
+// 8. 401 body shape
+const body401 = await checkCronSecret(mockReq("wrong"))!.json();
+check("guard: 401 body is 'unauthorized'", body401.error === "unauthorized");
+
+// restore prior env state
+if (savedCronSecret === undefined) Deno.env.delete(CRON_ENV);
+else Deno.env.set(CRON_ENV, savedCronSecret);
+
 console.log("\nRESULT:", pass, "passed,", fail, "failed");
-if (fail) (globalThis as any).process.exit(1);
+if (fail) Deno.exit(1);


### PR DESCRIPTION
Closes #113 (the CRON_SECRET item only — the rest of #113 is owner-only actions and stays open). Supersedes stale PR #28.

## What changed and why

The `x-cron-secret` guard in `vitals-import` and `vitals-import-api` used `if (expected && req.headers.get("x-cron-secret") !== expected)` — when `CRON_SECRET` was unset or empty, `expected` was falsy and the whole guard was skipped, silently letting any unauthenticated caller through (`vitals-import` had no backstop at all for this; `vitals-import-api` only avoided full exposure incidentally, via an unrelated missing-env 500 check further down). The comparison was also a timing-unsafe `!==`.

Both functions now share an identical `checkCronSecret(req)` helper (`cronGuard.ts`, duplicated per function directory — no `_shared/` convention exists yet, and stacking a second unproven pattern on top of the new `node:crypto` import wasn't worth it for two call sites):
- Fails closed (401) if `CRON_SECRET` is unset/empty, or the `x-cron-secret` header is missing/empty.
- Otherwise compares SHA-256 digests of the secret and the header via `node:crypto`'s `timingSafeEqual` — hashing first sidesteps `timingSafeEqual`'s hard equal-length requirement, so a wrong-length header can't throw or leak length via early return.

`vitals-import-api`'s `missing`-env array no longer duplicates the `CRON_SECRET` check now that the guard itself owns it with a clean 401 (previously an unauthenticated caller with no secret configured could hit a 500 that revealed the misconfiguration).

## How to test manually

Deno isn't installed in the sandbox this was built in (network-blocked install), so `deno run --allow-env supabase/functions/vitals-import/test.ts` / `.../vitals-import-api/test.ts` could not be executed there — the guard logic was verified via a Node shim of the identical code (9/9 cases passed) plus static review. **Recommend running both `test.ts` files locally with Deno before/at merge**, and a post-deploy smoke test (`curl` with correct/missing/wrong `x-cron-secret`) against the deployed functions. Also worth confirming `CRON_SECRET` is actually configured as a secret on `vitals-import` before merge — it previously had no guard at all, so if the secret isn't set, this change will correctly start rejecting the daily cron import (fail-closed) rather than silently continue as before.

## Checklist

- [x] CI is green (lint, test, build) — `npm run build`, `npm run lint`, `npm test` (323/323) all pass locally; this change doesn't touch any Vitest-covered code.
- [x] Tests cover the change — 8 new guard test cases added to both `test.ts` files (secret unset, secret empty, header missing/empty, wrong same-length, wrong different-length, correct match, 401 body shape). See "How to test manually" for the one verification gap (Deno unavailable in the build sandbox).
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — not applicable, this change is backend-only (Supabase Edge Functions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xaz1QVoRQ9zaue2eubjNQQ)_