### PR TITLE
fix: mobile UPCOMING section date bug + CLAUDE.md status doc drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,10 @@ coach use), and the context store (Code↔Coach shared memory, added by #94):
 `srpe`, `prs`, `exercises` (jsonb), `coach_note`, `status`, `coach_flag`,
 `avg_watts`, `avg_hr`, `distance_m`, `source` (default `portal`; Coach writes
 `coach`), `user_id`. **No watt-target columns — targets live in `label` +
-`coach_note`.** Status values: `"logged"` (completed) or `"planned"` (prescription).
+`coach_note`.** Status values: `"actual"`, `"completed"`, or `"logged"` (all mean
+completed — `"logged"` is written by the live PM5 Bluetooth save path, `"actual"`/
+`"completed"` by bulk-imported history), `"planned"` (prescription), or
+`"cancelled"`.
 
 **`vitals`:** `date` is a real `date` type; upsert on `(user_id, date)`. RHR/HRV/
 sleep/bodyweight and the Google-Health columns (`steps_count`, `distance_m`,

--- a/web/src/views/mobile/MobileAnalytics.jsx
+++ b/web/src/views/mobile/MobileAnalytics.jsx
@@ -326,8 +326,8 @@ export default function MobileAnalytics() {
       {(() => {
         const today = new Date().toISOString().slice(0, 10);
         const upcoming = (sessionsData ?? [])
-          .filter((s) => s.status === 'planned' && s.date >= today)
-          .sort((a, b) => (a.date < b.date ? -1 : 1))
+          .filter((s) => s.status === 'planned' && toISODate(s.date) >= today)
+          .sort((a, b) => (toISODate(a.date) < toISODate(b.date) ? -1 : 1))
           .slice(0, 3);
         return (
           <div style={{ marginBottom: 8 }}>

--- a/web/src/views/mobile/__tests__/MobileAnalytics.test.jsx
+++ b/web/src/views/mobile/__tests__/MobileAnalytics.test.jsx
@@ -134,6 +134,46 @@ describe('MobileAnalytics', () => {
     expect(mid.compareDocumentPosition(early) & FOLLOWING).toBeTruthy();
   });
 
+  it('shows a genuinely future planned session even when its M/D/YY date string sorts lexically "before" today', () => {
+    // '1/5/27' (Jan 2027) is well in the future, but as a raw string it sorts
+    // before an ISO "today" like '2026-07-02' because '1' < '2'. Comparing
+    // through toISODate() avoids that trap.
+    mockUseTSSHistory.mockReturnValue({ data: [] });
+    mockUseSessions.mockReturnValue({
+      data: [
+        {
+          id: 10,
+          date: '1/5/27',
+          type: 'erg',
+          label: 'Future planned row',
+          status: 'planned',
+        },
+      ],
+    });
+    render(<MobileAnalytics />);
+    expect(screen.getByText('Future planned row')).toBeInTheDocument();
+  });
+
+  it('excludes a genuinely past planned session even when its M/D/YY date string sorts lexically "after" today', () => {
+    // '7/1/25' (Jul 2025) is in the past, but as a raw string it sorts after
+    // an ISO "today" like '2026-07-02' because '7' > '2'.
+    mockUseTSSHistory.mockReturnValue({ data: [] });
+    mockUseSessions.mockReturnValue({
+      data: [
+        {
+          id: 11,
+          date: '7/1/25',
+          type: 'erg',
+          label: 'Past planned row',
+          status: 'planned',
+        },
+      ],
+    });
+    render(<MobileAnalytics />);
+    expect(screen.queryByText('Past planned row')).not.toBeInTheDocument();
+    expect(screen.getByText('No upcoming sessions')).toBeInTheDocument();
+  });
+
   it('renders CTL/ATL/TSB tiles using calcTrainingLoad output without crashing', () => {
     mockUseTSSHistory.mockReturnValue({
       data: [{ date: '2026-06-13', tss: 50 }],


### PR DESCRIPTION
Closes #133, closes #134 — both filed as follow-ups during review of #132 (now merged).

## What changed and why

`MobileAnalytics.jsx`'s UPCOMING section compared raw `M/D/YY` session dates against an ISO `today` string using plain `>=`/`<`. Because `M/D/YY` text doesn't sort or compare correctly against ISO text (e.g. `"1/5/27"` — a genuinely future date — sorts lexically *before* `"2026-07-02"` because `'1' < '2'`, and a past date like `"7/1/25"` can sort *after* it), this could both hide sessions that should appear and show sessions that shouldn't. Routed the filter and sort through the existing `toISODate()` util, the same fix already applied to RECENT SESSIONS in #132.

Also reconciled `CLAUDE.md`'s documented `sessions.status` values with production reality — the doc said only `"logged"`/`"planned"` existed, but the live table also has `"actual"`, `"completed"`, and `"cancelled"` (the doc/reality mismatch that originally caused the #132 bug).

## How to test manually

Not required — covered by two new regression tests. To sanity-check visually: open the mobile Analytics tab, add a `planned` session dated far in the future (e.g. next January) and confirm it appears in UPCOMING.

## Checklist

- [x] CI is green (lint, test, build) — `npm run lint` (0 errors, pre-existing unrelated warnings only), `npm run format:check`, `npm test` (369/369), `npm run build` all pass locally.
- [x] Tests cover the change — two new cases in `MobileAnalytics.test.jsx` proving the exact lexical-comparison trap described in #133 (a future date that sorts "before" today, and a past date that sorts "after" today).
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — not verified in a live browser session in this sandbox; covered by RTL component tests instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_015UPU4UmbtZhCJcs1GE7ji1)_