### PR TITLE
fix(ci): make Dependabot auto-merge actually merge + add maintenance jobs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,19 @@
 name: Dependabot auto-merge
 
-# Auto-approves and enables auto-merge for Dependabot patch/minor PRs. Auto-merge
-# only completes once the required CI gates (lint, test, build) are green, so the
-# existing checks remain authoritative. Major updates are left for manual review.
+# Enables auto-merge for Dependabot patch/minor PRs. Auto-merge only completes
+# once the required CI gates (lint, test, build) are green, so the existing
+# checks remain authoritative. Major updates are left for manual review.
+#
+# No approval step: branch protection does not require reviews, and GitHub
+# Actions is not permitted to approve PRs in this repo (the approve attempt is
+# what broke the 2026-07-02 run on PR #124).
 #
 # Prerequisite: repo Settings → General → "Allow auto-merge" must be enabled.
+#
+# Caveat: the merge is performed with GITHUB_TOKEN, so the resulting push to
+# main does not trigger push-to-main workflows (CI, CodeQL, e2e, Lighthouse,
+# doctrine-sha-guard). All of them also run on the PR and/or on schedule, and
+# Vercel deploys via its own GitHub App, so nothing load-bearing is skipped.
 
 on: pull_request
 
@@ -14,7 +23,7 @@ permissions:
 
 jobs:
   auto-merge:
-    name: Approve and auto-merge
+    name: Enable auto-merge
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
@@ -24,13 +33,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve and enable auto-merge (patch & minor)
+      - name: Enable auto-merge (patch & minor)
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.update-type == 'version-update:semver-minor'
-        run: |
-          gh pr review --approve "$PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-maintenance.yml
+++ b/.github/workflows/dependabot-maintenance.yml
@@ -1,0 +1,86 @@
+name: Dependabot maintenance
+
+# Keeps the Dependabot auto-merge pipeline flowing despite the "branches must be
+# up to date" protection rule. When the first grouped Monday PR merges, the
+# others fall behind and stall: Dependabot only reliably self-rebases on
+# conflicts, not merely-behind branches.
+#
+# rebase-behind nudges stalled PRs with an "@dependabot rebase" comment —
+# Dependabot's own push retriggers CI, which lets an already-armed auto-merge
+# complete. (gh pr update-branch would NOT work here: a GITHUB_TOKEN push never
+# retriggers the required checks, so auto-merge would stall forever.)
+#
+# stall-alert opens/updates a tracking issue for Dependabot PRs open >3 days —
+# usually a failing check or a major bump awaiting manual review.
+
+on:
+  schedule:
+    # Mondays, after the ~01:37 UTC Dependabot batch, to un-stall the merge cascade
+    - cron: '17 4,8,12,16 * * 1'
+    # Thursdays, for the stalled-PR sweep
+    - cron: '17 9 * * 4'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_REPO: ${{ github.repository }}
+
+jobs:
+  rebase-behind:
+    name: Rebase Dependabot PRs that fell behind
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '17 4,8,12,16 * * 1'
+    steps:
+      - name: Comment "@dependabot rebase" on behind PRs
+        run: |
+          gh pr list --author 'app/dependabot' --state open \
+            --json number,mergeStateStatus \
+            --jq '.[] | select(.mergeStateStatus == "BEHIND") | .number' |
+          while read -r pr; do
+            echo "PR #$pr is behind — requesting rebase"
+            gh pr comment "$pr" --body '@dependabot rebase'
+          done
+
+  stall-alert:
+    name: Flag Dependabot PRs open more than 3 days
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '17 9 * * 4'
+    steps:
+      - name: Open or update the tracking issue
+        run: |
+          cutoff=$(date -u -d '3 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          stalled=$(gh pr list --author 'app/dependabot' --state open \
+            --json number,title,createdAt,statusCheckRollup |
+            jq -r --arg cutoff "$cutoff" '
+              [ .[] | select(.createdAt < $cutoff) |
+                "- #\(.number) \(.title) (open since \(.createdAt[:10]), checks: \(
+                  [.statusCheckRollup[]? | (.conclusion // "PENDING")] |
+                  if length == 0 then "none"
+                  elif all(. == "SUCCESS") then "green"
+                  else "not green" end))"
+              ] | join("\n")')
+
+          title='Dependabot PRs need attention'
+          existing=$(gh issue list --state open --search "\"$title\" in:title" \
+            --json number,title |
+            jq -r --arg t "$title" '.[] | select(.title == $t) | .number' | head -1)
+
+          if [ -z "$stalled" ]; then
+            echo "No Dependabot PRs open >3 days."
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --comment 'All Dependabot PRs resolved — closing.'
+            fi
+            exit 0
+          fi
+
+          body=$(printf 'These Dependabot PRs have been open for more than 3 days — stalled auto-merge, failing checks, or majors awaiting manual review:\n\n%s\n\n_Maintained automatically by the Dependabot maintenance workflow._' "$stalled")
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body "$body"
+            echo "Updated issue #$existing"
+          else
+            gh issue create --title "$title" --body "$body" --label dependencies
+          fi


### PR DESCRIPTION
## What changed and why

The 2026-07-02 auto-merge run on PR #124 failed with "GitHub Actions is not permitted to approve pull requests", and because approve + merge shared one fail-fast run block, auto-merge was never enabled. Branch protection doesn't require reviews (recent PRs merged with zero), so this drops the approve step entirely and adds a `dependabot-maintenance.yml` workflow: a Monday `·@·d·ependabot r·ebase` nudge for PRs stalled behind main by the up-to-date rule, and a Thursday "Dependabot PRs need attention" issue for PRs open >3 days.

## How to test manually

Real proof is next Monday's Dependabot batch. Interim: `workflow_dispatch` the maintenance workflow after merge and confirm both jobs run green (no-op comments/issue if nothing is stalled).

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — workflow-only diff; YAML validated and jq logic tested against sample data locally
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no app code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfS7kaaDyiauFy9FZy7Fxw

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfS7kaaDyiauFy9FZy7Fxw)_