### PR TITLE
docs: sweep stale erg-dashboard.jsx references after App.jsx rename

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -22,7 +22,7 @@ with the right context and gates on your approval.
 | Command | Use for |
 |---|---|
 | `/feature <desc>` or `/orchestrate` | New feature or bug fix — full chain: research → story → spec → build+test → verify → review+validate → PR |
-| `/refactor <module>` | One strangler-fig extraction (erg-dashboard.jsx remainder, ProgramView #77, StrengthLogger #79) |
+| `/refactor <module>` | One strangler-fig extraction (App.jsx remainder, ProgramView #77, StrengthLogger #79) |
 | `/research <topic>` | Investigate an API/library/concept before building |
 
 ### Pipeline roles (stage → Agency agent)

--- a/.claude/skills/architecture.md
+++ b/.claude/skills/architecture.md
@@ -3,7 +3,8 @@ name: architecture
 description: >
   Target folder structure, layer rules, and migration line-number map for the
   erg-dashboard refactor. Read when asked where to put code, how to structure
-  a new feature, or how to safely extract a module from erg-dashboard.jsx.
+  a new feature, or how to safely extract a module from App.jsx or another
+  large file.
 ---
 
 ## Target Structure
@@ -54,9 +55,9 @@ src/
       StrengthChart.jsx e1RM trend + StrengthTooltip
 
   views/                Extract by TAB ID, one per PR. Find each tab by its
-                        section heading / tab constant in erg-dashboard.jsx —
-                        do NOT trust absolute line numbers: the monolith is
-                        ~8,715 lines and every extraction shifts the offsets.
+                        section heading / tab constant in App.jsx (formerly
+                        erg-dashboard.jsx) — do NOT trust absolute line
+                        numbers: every extraction shifts the offsets.
     CoachView.jsx       ✓ extracted    AI coach tab
     ErgView.jsx         ✓ extracted    erg analytics, HR130, pace/splits
     ErgLiveView.jsx     ✓ extracted    live PM5 Bluetooth
@@ -77,8 +78,8 @@ src/
     ProgramMicrocycle.jsx 2-week roster
     ProgramYear.jsx       EVENT_PATHWAY year view
 
-  App.jsx     Global state + nav tabs + ErrorBoundary + view dispatch (~200 lines;
-              not reached yet — entry point is still main.jsx + erg-dashboard.jsx)
+  App.jsx     Global state + nav tabs + ErrorBoundary + view dispatch (~515 lines;
+              ✓ renamed from erg-dashboard.jsx in PR #145, closing #52)
   main.jsx    Auth gate (unchanged)
   supabaseClient.js  Supabase init (unchanged)
 ```

--- a/.claude/skills/erg-context.md
+++ b/.claude/skills/erg-context.md
@@ -19,7 +19,7 @@ Testing Library. Full briefing: `CLAUDE.md`.
 - `web/src/hooks/` — React hooks; Supabase calls live here
 - `web/src/components/` — reusable JSX, props in, no direct Supabase calls
 - `web/src/views/` — tab-level JSX, composes components
-- `web/src/erg-dashboard.jsx` — legacy shell/router (~960 lines); targeted edits only
+- `web/src/App.jsx` — entry shell/router (~515 lines); targeted edits only
 
 ## Code style (non-negotiable)
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor
-description: Extract one module from a named large file (erg-dashboard.jsx remainder, views/ProgramView.jsx, StrengthLogger.jsx) following the strangler-fig pattern. One safe extraction at a time; the app stays fully functional throughout. Never rewrites — only moves code.
+description: Extract one module from a named large file (App.jsx remainder, views/ProgramView.jsx, StrengthLogger.jsx) following the strangler-fig pattern. One safe extraction at a time; the app stays fully functional throughout. Never rewrites — only moves code.
 argument-hint: <module-name>
 ---
 
@@ -15,7 +15,7 @@ Extract ONE module from a named large file, strangler-fig style.
 /refactor <module-name>
 ```
 
-Current extraction targets: the `web/src/erg-dashboard.jsx` shell remainder,
+Current extraction targets: the `web/src/App.jsx` shell remainder,
 `web/src/views/ProgramView.jsx` (#77), `web/src/StrengthLogger.jsx` (#79).
 
 ## Process

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ web/                The app lives under web/ (Vite + Capacitor monorepo layout)
     utils/          Pure functions — analysis, formatting, scheduling
     components/     Shared UI components (LogEntry, WorkoutItem, charts)
     views/          Extracted dashboard tabs (desktop + mobile)
-    erg-dashboard.jsx  Former monolith, now a ~960-line shell/router (see refactor)
+    App.jsx         Entry shell/router (~515 lines) — the former erg-dashboard.jsx monolith
     StrengthLogger.jsx Large component, not yet extracted (~1,665 lines)
     main.jsx        Auth gate (Supabase email/password login)
 supabase/
@@ -77,12 +77,12 @@ coach/
 
 ## Architecture: Strangler Fig Refactor
 
-The refactor is nearly complete (tracked in GitHub issue #52). The former
-monolith `web/src/erg-dashboard.jsx` is down to **~960 lines** (2026-07-02) — a
+The monolith decomposition is complete (#52, closed by PR #145 on 2026-07-11):
+the former `web/src/erg-dashboard.jsx` is now `web/src/App.jsx` — a ~515-line
 shell/router that composes the extracted views. Remaining large files:
-`views/ProgramView.jsx` (~3,050 lines, being split into `views/program/*`, #77)
-and `StrengthLogger.jsx` (~1,665 lines, untested, #79). `App.jsx` has not been
-reached yet. The safe migration order:
+`views/ProgramView.jsx` (~1,900 lines, being split into `views/program/*`, #77)
+and `StrengthLogger.jsx` (~1,665 lines, untested, #79). The migration order
+that got here (kept for reference):
 
 1. Extract constants and utils (zero risk — pure JS, no JSX)
 2. Extract hooks (low risk — same data, reorganised)

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ Browser / Android APK
         └── vitals-sync       — on-demand sync trigger
 ```
 
-The former monolith `web/src/erg-dashboard.jsx` (now ~960 lines — a shell/router)
-has been decomposed into the modular structure above using a strangler-fig
-refactor — one safe extraction at a time, app stays functional throughout. The
-tail end (Program sub-tabs, StrengthLogger, the App.jsx rename) is tracked in
-issue #52.
+The former 9,733-line monolith has been decomposed into the modular structure
+above using a strangler-fig refactor — one safe extraction at a time, app stays
+functional throughout — and the entry point is now `web/src/App.jsx` (~515
+lines, renamed in PR #145, closing #52). The remaining large-file splits
+(Program sub-tabs #77, StrengthLogger #79) are tracked separately.
 
 ---
 
@@ -152,7 +152,7 @@ erg-dashboard/
 │   │   ├── views/            desktop views (CoachView, ErgLiveView, …)
 │   │   │   └── mobile/       mobile-specific views (MobileApp, MobileRecovery, …)
 │   │   ├── services/         pm5Bluetooth.js (BLE abstraction)
-│   │   ├── erg-dashboard.jsx shell/router (~960 lines, formerly the monolith)
+│   │   ├── App.jsx           shell/router (~515 lines, formerly erg-dashboard.jsx)
 │   │   └── main.jsx          auth gate (Supabase email/password)
 │   ├── android/              Capacitor Android project
 │   ├── capacitor.config.json

--- a/coach/PROJECT_MANAGEMENT_ANALYSIS.md
+++ b/coach/PROJECT_MANAGEMENT_ANALYSIS.md
@@ -16,6 +16,11 @@
 > (dormant integrations) and the StrengthLogger test gap remain open, tracked
 > in issues #116 and #114.
 
+> **Addendum 2026-07-11.** The rename landed: `erg-dashboard.jsx` → `web/src/App.jsx`
+> (~515-line shell/router; PR #145, closing #52). Finding 5 is now fully
+> **resolved**; the remaining large-file splits are ProgramView (#77) and
+> StrengthLogger (#79).
+
 ---
 
 ## Executive summary


### PR DESCRIPTION
## What

Doc-only sweep of stale `erg-dashboard.jsx` references after the entry-point rename landed (PR #145, closing #52). This is "PR C" of the App Rename Sprint.

## Changes

- **CLAUDE.md** — project-structure tree entry and the Strangler Fig section now describe `App.jsx` (~515-line shell/router) and mark the decomposition complete; remaining large files updated to current sizes (#77, #79).
- **README.md** — architecture prose and project-structure tree updated.
- **coach/PROJECT_MANAGEMENT_ANALYSIS.md** — dated addendum (2026-07-11) recording that Finding 5 is fully resolved; historical figures left untouched.
- **.claude/AGENTS.md**, **.claude/skills/{architecture,erg-context,refactor}** — extraction targets and layer maps now name `App.jsx`.

Remaining `erg-dashboard.jsx` mentions are intentionally historical ("formerly erg-dashboard.jsx", the dated PM-analysis findings).

## Verification

- `rg 'erg-dashboard\.jsx'` — only historical/"formerly" mentions remain.
- No code touched; full test suite passed on pre-push hook (379/379).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
