### PR TITLE
config: ratchet coverage floor to 68/67/64 after App.jsx rename

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -99,10 +99,12 @@ export default defineConfig({
       //   measured: lines 48.98 / functions 46.81 / branches 40.38
       thresholds: {
         // Global floor — ratcheted up as extractions land tests (measured
-        // ~62/60/62 after the overview extraction + child-component tests).
-        lines: 52,
-        functions: 50,
-        branches: 48,
+        // lines 71.76 / functions 71.52 / branches 68.62 on 2026-07-11, after
+        // the App.jsx rename brought the former monolith into scope with its
+        // render test; ~4 points headroom for denominator drift).
+        lines: 68,
+        functions: 67,
+        branches: 64,
         // Commercial-baseline gate (80/80/70) for new/extracted code, applied
         // per-file as it lands. The global floor above ratchets toward this as
         // the monolith is decomposed and its exclusions fall away.


### PR DESCRIPTION
## What

"PR D" of the App Rename Sprint — the coverage ratchet that follows PR #145.

With `App.jsx` (the former monolith) now inside the coverage denominator and carrying its render test, the measured aggregate on `main` is:

| Metric | Measured (2026-07-11) | Old floor | New floor |
|---|---|---|---|
| Lines | 71.76% | 52 | **68** |
| Functions | 71.52% | 50 | **67** |
| Branches | 68.62% | 48 | **64** |

~4 points of headroom is kept for denominator drift as future PRs land. Per the ratchet rule in `web/vite.config.js`, the numbers only go up.

## Verification

- `npx vitest run --coverage` passes locally against the new thresholds (379/379 tests, summary above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
