### PR TITLE
feat: design tokens — theme.js + CSS variables consolidating duplicate palettes

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,10 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#0a0a0f" />
+    <!-- keep in sync with THEME.bg (constants/theme.js) -->
+    <meta name="theme-color" content="#08080d" />
     <title>SplitIQ</title>
     <style>
-      html, body, #root { margin: 0; padding: 0; background: #0a0a0f; }
+      /* keep in sync with THEME.bg (constants/theme.js) */
+      html, body, #root { margin: 0; padding: 0; background: #08080d; }
     </style>
   </head>
   <body>

--- a/web/src/components/WorkoutTarget.jsx
+++ b/web/src/components/WorkoutTarget.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
+import { THEME } from '../constants/theme.js';
 
 const C = {
-  panel: '#1a1a2e',
-  border: '#4a4a68',
-  accent: '#ffd700',
-  text: '#e8e8f0',
-  muted: '#7e7e9a',
+  panel: THEME.surface,
+  border: THEME.border,
+  accent: THEME.gold,
+  text: THEME.text,
+  muted: THEME.muted,
 };
 
 export default function WorkoutTarget({ session }) {

--- a/web/src/constants/__tests__/theme.test.js
+++ b/web/src/constants/__tests__/theme.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { THEME } from '../theme.js';
+
+const EXPECTED_KEYS = [
+  'bg',
+  'surface',
+  'raised',
+  'field',
+  'border',
+  'text',
+  'muted',
+  'cyan',
+  'green',
+  'gold',
+  'orange',
+  'red',
+  'purple',
+  'pink',
+  'teal',
+];
+
+describe('THEME', () => {
+  it('has exactly the 15 expected keys (no more, no fewer)', () => {
+    const keys = Object.keys(THEME);
+    expect(keys).toHaveLength(15);
+    expect(keys.sort()).toEqual([...EXPECTED_KEYS].sort());
+  });
+
+  it('every value is a 6-digit lowercase hex colour', () => {
+    for (const value of Object.values(THEME)) {
+      expect(value).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it('locks the canonical values', () => {
+    expect(THEME.bg).toBe('#08080d');
+    expect(THEME.surface).toBe('#1a1a2e');
+    expect(THEME.raised).toBe('#2a2a48');
+    expect(THEME.field).toBe('#08080d');
+    expect(THEME.border).toBe('#4a4a68');
+    expect(THEME.text).toBe('#e8e8f0');
+    expect(THEME.muted).toBe('#7e7e9a');
+    expect(THEME.cyan).toBe('#00d4ff');
+    expect(THEME.green).toBe('#34d399');
+    expect(THEME.gold).toBe('#ffd700');
+    expect(THEME.orange).toBe('#ff6b35');
+    expect(THEME.red).toBe('#ff2d55');
+    expect(THEME.purple).toBe('#a78bfa');
+    expect(THEME.pink).toBe('#f472b6');
+    expect(THEME.teal).toBe('#2dd4bf');
+  });
+});

--- a/web/src/constants/theme.js
+++ b/web/src/constants/theme.js
@@ -1,0 +1,17 @@
+export const THEME = {
+  bg: '#08080d',
+  surface: '#1a1a2e',
+  raised: '#2a2a48',
+  field: '#08080d',
+  border: '#4a4a68',
+  text: '#e8e8f0',
+  muted: '#7e7e9a',
+  cyan: '#00d4ff',
+  green: '#34d399',
+  gold: '#ffd700',
+  orange: '#ff6b35',
+  red: '#ff2d55',
+  purple: '#a78bfa',
+  pink: '#f472b6',
+  teal: '#2dd4bf',
+};

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -12,8 +12,15 @@ import MobileApp from './views/mobile/MobileApp.jsx';
 import { createNotificationChannels } from './utils/notifications.js';
 import { initSentry } from './utils/sentry.js';
 import ErrorFallback from './components/ErrorFallback.jsx';
+import { THEME } from './constants/theme.js';
+import { cssVars } from './utils/themeCss.js';
 
 initSentry();
+
+const themeStyle = document.createElement('style');
+themeStyle.id = 'theme-vars';
+themeStyle.textContent = cssVars(THEME);
+document.head.appendChild(themeStyle);
 
 if (Capacitor.isNativePlatform()) {
   BluetoothLowEnergy.shimWebBluetooth();
@@ -28,14 +35,14 @@ const queryClient = new QueryClient({
 
 // ── THEME TOKENS (match the dashboard) ───────────────────────────
 const C = {
-  bg: '#0a0a0f',
-  panel: '#2a2a48',
-  field: '#08080d',
-  border: '#4a4a68',
-  accent: '#34d399',
-  text: '#e8e8f0',
-  muted: '#7e7e9a',
-  err: '#ff2d55',
+  bg: THEME.bg,
+  panel: THEME.raised,
+  field: THEME.field,
+  border: THEME.border,
+  accent: THEME.green,
+  text: THEME.text,
+  muted: THEME.muted,
+  err: THEME.red,
 };
 
 // ── LOGIN SCREEN ─────────────────────────────────────────────────

--- a/web/src/utils/__tests__/themeCss.test.js
+++ b/web/src/utils/__tests__/themeCss.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { cssVars } from '../themeCss.js';
+import { THEME } from '../../constants/theme.js';
+
+describe('cssVars', () => {
+  it('emits a --color-<key>: <value>; declaration for every THEME key', () => {
+    const out = cssVars(THEME);
+    for (const [key, value] of Object.entries(THEME)) {
+      expect(out).toContain(`--color-${key}: ${value};`);
+    }
+  });
+
+  it('emits exactly one declaration per THEME key (no missing, no extras)', () => {
+    const out = cssVars(THEME);
+    const count = (out.match(/--color-/g) ?? []).length;
+    expect(count).toBe(Object.keys(THEME).length);
+  });
+
+  it('opens with a :root block', () => {
+    const out = cssVars(THEME);
+    expect(out.startsWith(':root {')).toBe(true);
+    expect(out.trimEnd().endsWith('}')).toBe(true);
+  });
+
+  it('is generic and pure for any object', () => {
+    const out = cssVars({ foo: 'bar', baz: 'qux' });
+    expect(out).toContain('--color-foo: bar;');
+    expect(out).toContain('--color-baz: qux;');
+    expect((out.match(/--color-/g) ?? []).length).toBe(2);
+    expect(out.startsWith(':root {')).toBe(true);
+  });
+});

--- a/web/src/utils/themeCss.js
+++ b/web/src/utils/themeCss.js
@@ -1,0 +1,6 @@
+export function cssVars(theme) {
+  const decls = Object.keys(theme)
+    .map((k) => `  --color-${k}: ${theme[k]};`)
+    .join('\n');
+  return `:root {\n${decls}\n}`;
+}

--- a/web/src/views/CoachView.jsx
+++ b/web/src/views/CoachView.jsx
@@ -1,18 +1,19 @@
 import { useState, useEffect, useRef } from 'react';
 import { useCoach } from '../hooks/useCoach.js';
 import { calcTrainingLoad } from '../utils/trainingLoad.js';
+import { THEME } from '../constants/theme.js';
 
 const C = {
-  bg: '#08080d',
-  panel: '#1a1a2e',
-  border: '#4a4a68',
-  cyan: '#00d4ff',
-  text: '#e8e8f0',
-  muted: '#7e7e9a',
-  err: '#ff2d55',
-  userBubble: '#2a2a48',
-  userBubbleBorder: '#4a4a68',
-  assistantBorder: '#00d4ff',
+  bg: THEME.bg,
+  panel: THEME.surface,
+  border: THEME.border,
+  cyan: THEME.cyan,
+  text: THEME.text,
+  muted: THEME.muted,
+  err: THEME.red,
+  userBubble: THEME.raised,
+  userBubbleBorder: THEME.border,
+  assistantBorder: THEME.cyan,
 };
 
 const STARTER_PROMPTS = [

--- a/web/src/views/ErgLiveView.jsx
+++ b/web/src/views/ErgLiveView.jsx
@@ -6,17 +6,18 @@ import { supabase } from '../supabaseClient';
 import LiveMetric from '../components/LiveMetric';
 import WorkoutTarget from '../components/WorkoutTarget';
 import { parsePace } from '../services/pm5Bluetooth';
+import { THEME } from '../constants/theme.js';
 
 const C = {
-  bg: '#08080d',
-  panel: '#1a1a2e',
-  border: '#4a4a68',
-  accent: '#34d399',
-  cyan: '#00d4ff',
-  gold: '#ffd700',
-  text: '#e8e8f0',
-  muted: '#7e7e9a',
-  err: '#ff2d55',
+  bg: THEME.bg,
+  panel: THEME.surface,
+  border: THEME.border,
+  accent: THEME.green,
+  cyan: THEME.cyan,
+  gold: THEME.gold,
+  text: THEME.text,
+  muted: THEME.muted,
+  err: THEME.red,
 };
 
 const SRPE_GUIDE = [

--- a/web/src/views/mobile/MobileRecovery.jsx
+++ b/web/src/views/mobile/MobileRecovery.jsx
@@ -13,14 +13,15 @@ import { useVitalsSync } from '../../hooks/useVitalsSync.js';
 import { useTSSHistory } from '../../hooks/useTSSHistory.js';
 import { calcTrainingLoad } from '../../utils/trainingLoad.js';
 import { DAILY_TSS } from '../../constants/tssData.js';
+import { THEME } from '../../constants/theme.js';
 
 const C = {
-  bg: '#0a0a0f',
-  panel: '#2a2a48',
-  accent: '#34d399',
-  text: '#e8e8f0',
-  muted: '#7e7e9a',
-  err: '#ff2d55',
+  bg: THEME.bg,
+  panel: THEME.raised,
+  accent: THEME.green,
+  text: THEME.text,
+  muted: THEME.muted,
+  err: THEME.red,
 };
 
 const tickStyle = { fontSize: 9, fill: C.muted };

--- a/web/src/views/mobile/MobileSessionLog.jsx
+++ b/web/src/views/mobile/MobileSessionLog.jsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 import { useSessions } from '../../hooks/useSessions.js';
+import { THEME } from '../../constants/theme.js';
 
 const C = {
-  bg: '#0a0a0f',
-  panel: '#2a2a48',
-  accent: '#34d399',
-  text: '#e8e8f0',
-  muted: '#7e7e9a',
-  err: '#ff2d55',
+  bg: THEME.bg,
+  panel: THEME.raised,
+  accent: THEME.green,
+  text: THEME.text,
+  muted: THEME.muted,
+  err: THEME.red,
 };
 
 function typeColor(type) {

--- a/web/src/views/mobile/MobileStrength.jsx
+++ b/web/src/views/mobile/MobileStrength.jsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 import { useStrengthPRs } from '../../hooks/useStrengthPRs.js';
 import StrengthLogger from '../../StrengthLogger.jsx';
+import { THEME } from '../../constants/theme.js';
 
 const C = {
-  bg: '#0a0a0f',
-  panel: '#2a2a48',
-  accent: '#34d399',
-  text: '#e8e8f0',
-  muted: '#7e7e9a',
+  bg: THEME.bg,
+  panel: THEME.raised,
+  accent: THEME.green,
+  text: THEME.text,
+  muted: THEME.muted,
 };
 
 export default function MobileStrength() {


### PR DESCRIPTION
Closes #148

## What

First slice of the design-token consolidation, per the approved factory-pipeline story/spec:

- **New `web/src/constants/theme.js`** — 15 canonical color tokens, pure data (constants-layer pattern).
- **New `web/src/utils/themeCss.js`** — pure `cssVars(theme)` generator; injected once in `main.jsx` as `<style id="theme-vars">` with `:root { --color-* }` custom properties (mirror for future consumption).
- **8 files migrated**: the hand-copied `const C = {...}` theme blocks in `main.jsx`, `ErgLiveView`, `CoachView`, `WorkoutTarget`, `MobileSessionLog`, `MobileRecovery`, `MobileStrength` now source from `THEME`; `index.html` theme-color/background synced (commented hand-sync — static HTML can't import JS).
- **Drift resolutions (approved)**: `bg #0a0a0f → #08080d` (majority value); panel kept as **two** tokens (`surface #1a1a2e`, `raised #2a2a48`) — panel colors byte-for-byte unchanged.
- **Tests in the same PR**: token-set/value lock (`theme.test.js`), CSS-var mirror derived live from `THEME` (`themeCss.test.js`).

## Verification

- 386/386 tests pass (43 files); coverage 71.7/68.6/71.7 clears the floor and the incoming #147 ratchet.
- `npm run build` green; lint 0 errors (5 pre-existing warnings in untouched files).
- Pipeline verdicts: Code Reviewer **APPROVE**, Reality Checker **ship** (independently re-ran tests, verified panel values preserved, confirmed format noise is local CRLF only).

## Out of scope (follow-up slices)

Inline literals outside the const-C blocks, Recharts colors, `StrengthLogger.jsx` (#79), `ProgramView.jsx` (#77), `var(--color-*)` consumption, light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)