### PR TITLE
refactor: extract useSessionLog hook from App.jsx

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, Component, lazy, Suspense } from 'react';
-import { supabase } from './supabaseClient.js';
+import { useSessionLog } from './hooks/useSessionLog.js';
 import StrengthLogger from './StrengthLogger.jsx';
 import ErgLiveView from './views/ErgLiveView.jsx';
 import CoachView from './views/CoachView.jsx';
@@ -25,7 +25,6 @@ import {
   HRV_BASELINE,
 } from './constants/trainingConfig.js';
 import { C } from './constants/ui.js';
-import { normType } from './utils/formatting.js';
 
 /* ═══════════════════════════════════════════════════════════════
    ERG COACHING DASHBOARD · v1.2 beta
@@ -82,10 +81,6 @@ class ErrorBoundary extends Component {
     return this.props.children;
   }
 }
-
-// ── SESSION LOG (add entries here as block progresses) ──────────
-
-const sessionLog = []; // retired — sessions now live in Supabase (migrated)
 
 const strengthTrend = {
   'Back Squat': [
@@ -189,71 +184,8 @@ export default function App() {
   const isMid = vw >= 600; // tablet
   const containerMax = isWide ? 1100 : 680;
 
-  // ── DATABASE SESSIONS (Supabase) — MERGED with hardcoded history ─
-  // Fetch sessions saved to the database on load. These MERGE with the
-  // hardcoded `sessionLog` seed: db sessions first (newest), then the
-  // baked-in history. The app never loses the seed history even if the
-  // DB is empty or unreachable — it just shows the seed alone.
-  const [dbSessions, setDbSessions] = useState([]);
-  const [dbStatus, setDbStatus] = useState('loading'); // loading | ok | error
-  const fetchSessions = () => {
-    supabase
-      .from('sessions')
-      .select('*')
-      .order('created_at', { ascending: false })
-      .then(({ data, error }) => {
-        if (error) {
-          setDbStatus('error');
-          return;
-        }
-        const mapped = (data || [])
-          .filter((r) => r.type !== 'Test')
-          .map((r) => {
-            const raw = (r.type || '').toLowerCase();
-            return {
-              date: r.date,
-              type: normType(r.type, r.label),
-              label: r.label,
-              duration: r.duration,
-              srpe: r.srpe,
-              prs: r.prs,
-              exercises: r.exercises || undefined,
-              coachNote: r.coach_note || undefined,
-              // status drives planned-vs-actual reconciliation. null legacy rows
-              // are treated as actual (completed history) everywhere downstream.
-              status: r.status || null,
-              // flat erg metrics (the `splits` field was removed from the schema)
-              distance_m: r.distance_m,
-              avg_watts: r.avg_watts,
-              avg_hr: r.avg_hr,
-              // raw-type flags survive normType so the renderer can branch reliably
-              _isErg: raw === 'erg',
-              _isCycling: raw === 'cycling' || raw === 'bike' || raw === 'ride',
-              _fromDb: true,
-              _id: r.id,
-            };
-          });
-        setDbSessions(mapped);
-        setDbStatus('ok');
-      });
-  };
-  useEffect(() => {
-    fetchSessions();
-  }, []);
-  // The merged list every display + helper uses. DB sessions are newest,
-  // so they go first; the hardcoded seed follows.
-  const allSessions = [...dbSessions, ...sessionLog];
-
-  // ── PLANNED vs LOGGED SPLIT (reconciliation) ──────────────────
-  // Planned rows are forward-looking prescriptions and must NOT appear in the
-  // completed Log, the calendar's done-state, recent sessions, or analytics.
-  // null-status legacy rows count as actual/completed history.
-  const loggedSessions = allSessions.filter((e) => e.status !== 'planned');
-  const plannedSessions = allSessions.filter((e) => e.status === 'planned');
-  // A planned row is reconciled ("done") once an actual exists for the same
-  // date + type. v1 matches on normalized type + date (a planned_id link can
-  // come later). Keyed off loggedSessions only.
-  const loggedKeys = new Set(loggedSessions.map((e) => `${e.date}|${e.type}`));
+  const { loggedSessions, plannedSessions, loggedKeys, fetchSessions } =
+    useSessionLog();
 
   const loadData = calcTrainingLoad(DAILY_TSS);
   const latest = loadData[loadData.length - 1];

--- a/web/src/hooks/__tests__/useSessionLog.test.js
+++ b/web/src/hooks/__tests__/useSessionLog.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+const fromMock = vi.fn();
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: (...args) => fromMock(...args),
+  },
+}));
+
+import { useSessionLog } from '../useSessionLog.js';
+
+function mockQuery(data, error = null) {
+  const chain = {
+    select: () => chain,
+    order: () => Promise.resolve({ data, error }),
+  };
+  fromMock.mockReturnValue(chain);
+}
+
+beforeEach(() => {
+  fromMock.mockReset();
+});
+
+const ergRow = {
+  id: 1,
+  date: '06/13/26',
+  type: 'erg',
+  label: '10k steady',
+  duration: 45,
+  srpe: 6,
+  prs: null,
+  exercises: null,
+  coach_note: 'keep it easy',
+  status: 'completed',
+  distance_m: 10000,
+  avg_watts: 150,
+  avg_hr: 135,
+};
+
+describe('useSessionLog', () => {
+  it('maps rows, filters Test type, and sets dbStatus ok on success', async () => {
+    mockQuery([
+      ergRow,
+      { id: 2, date: '06/14/26', type: 'Test', label: 'CP test' },
+      {
+        id: 3,
+        date: '06/15/26',
+        type: 'cycling',
+        label: 'z2 spin',
+        status: null,
+      },
+    ]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    const sessions = result.current.allSessions;
+    expect(sessions).toHaveLength(2);
+    const erg = sessions[0];
+    expect(erg.type).toBe('Z2 Aerobic');
+    expect(erg.coachNote).toBe('keep it easy');
+    expect(erg.exercises).toBe(undefined);
+    expect(erg._isErg).toBe(true);
+    expect(erg._isCycling).toBe(false);
+    expect(erg._fromDb).toBe(true);
+    expect(erg._id).toBe(1);
+    const bike = sessions[1];
+    expect(bike._isErg).toBe(false);
+    expect(bike._isCycling).toBe(true);
+    expect(bike.status).toBe(null);
+  });
+
+  it('sets dbStatus error and falls back to the seed on supabase error', async () => {
+    mockQuery(null, { message: 'boom' });
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('error'));
+    expect(result.current.allSessions).toEqual([]);
+  });
+
+  it('splits planned vs logged and builds loggedKeys from logged only', async () => {
+    mockQuery([
+      {
+        id: 1,
+        date: '06/20/26',
+        type: 'erg',
+        label: 'plan',
+        status: 'planned',
+      },
+      {
+        id: 2,
+        date: '06/13/26',
+        type: 'erg',
+        label: 'done',
+        status: 'completed',
+      },
+      {
+        id: 3,
+        date: '06/12/26',
+        type: 'strength',
+        label: 'Upper A',
+        status: null,
+      },
+    ]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    expect(result.current.plannedSessions).toHaveLength(1);
+    expect(result.current.plannedSessions[0]._id).toBe(1);
+    expect(result.current.loggedSessions).toHaveLength(2);
+    expect(result.current.loggedKeys.has('06/13/26|Z2 Aerobic')).toBe(true);
+    expect(result.current.loggedKeys.has('06/12/26|Upper Strength')).toBe(true);
+    expect(result.current.loggedKeys.has('06/20/26|Z2 Aerobic')).toBe(false);
+  });
+
+  it('fetchSessions refetch updates state', async () => {
+    mockQuery([ergRow]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.allSessions).toHaveLength(1));
+    mockQuery([
+      ergRow,
+      { id: 4, date: '06/16/26', type: 'erg', label: 'new', status: 'logged' },
+    ]);
+    act(() => {
+      result.current.fetchSessions();
+    });
+    await waitFor(() => expect(result.current.allSessions).toHaveLength(2));
+    expect(result.current.allSessions[1]._id).toBe(4);
+  });
+});

--- a/web/src/hooks/useSessionLog.js
+++ b/web/src/hooks/useSessionLog.js
@@ -1,0 +1,84 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../supabaseClient.js';
+import { normType } from '../utils/formatting.js';
+
+// ── SESSION LOG (add entries here as block progresses) ──────────
+
+const sessionLog = []; // retired — sessions now live in Supabase (migrated)
+
+export function useSessionLog() {
+  // ── DATABASE SESSIONS (Supabase) — MERGED with hardcoded history ─
+  // Fetch sessions saved to the database on load. These MERGE with the
+  // hardcoded `sessionLog` seed: db sessions first (newest), then the
+  // baked-in history. The app never loses the seed history even if the
+  // DB is empty or unreachable — it just shows the seed alone.
+  const [dbSessions, setDbSessions] = useState([]);
+  const [dbStatus, setDbStatus] = useState('loading'); // loading | ok | error
+  const fetchSessions = () => {
+    supabase
+      .from('sessions')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .then(({ data, error }) => {
+        if (error) {
+          setDbStatus('error');
+          return;
+        }
+        const mapped = (data || [])
+          .filter((r) => r.type !== 'Test')
+          .map((r) => {
+            const raw = (r.type || '').toLowerCase();
+            return {
+              date: r.date,
+              type: normType(r.type, r.label),
+              label: r.label,
+              duration: r.duration,
+              srpe: r.srpe,
+              prs: r.prs,
+              exercises: r.exercises || undefined,
+              coachNote: r.coach_note || undefined,
+              // status drives planned-vs-actual reconciliation. null legacy rows
+              // are treated as actual (completed history) everywhere downstream.
+              status: r.status || null,
+              // flat erg metrics (the `splits` field was removed from the schema)
+              distance_m: r.distance_m,
+              avg_watts: r.avg_watts,
+              avg_hr: r.avg_hr,
+              // raw-type flags survive normType so the renderer can branch reliably
+              _isErg: raw === 'erg',
+              _isCycling: raw === 'cycling' || raw === 'bike' || raw === 'ride',
+              _fromDb: true,
+              _id: r.id,
+            };
+          });
+        setDbSessions(mapped);
+        setDbStatus('ok');
+      });
+  };
+  useEffect(() => {
+    fetchSessions();
+  }, []);
+  // The merged list every display + helper uses. DB sessions are newest,
+  // so they go first; the hardcoded seed follows.
+  const allSessions = [...dbSessions, ...sessionLog];
+
+  // ── PLANNED vs LOGGED SPLIT (reconciliation) ──────────────────
+  // Planned rows are forward-looking prescriptions and must NOT appear in the
+  // completed Log, the calendar's done-state, recent sessions, or analytics.
+  // null-status legacy rows count as actual/completed history.
+  const loggedSessions = allSessions.filter((e) => e.status !== 'planned');
+  const plannedSessions = allSessions.filter((e) => e.status === 'planned');
+  // A planned row is reconciled ("done") once an actual exists for the same
+  // date + type. v1 matches on normalized type + date (a planned_id link can
+  // come later). Keyed off loggedSessions only.
+  const loggedKeys = new Set(loggedSessions.map((e) => `${e.date}|${e.type}`));
+
+  return {
+    dbStatus,
+    allSessions,
+    loggedSessions,
+    plannedSessions,
+    loggedKeys,
+    fetchSessions,
+  };
+}


### PR DESCRIPTION
## What

"PR B" of the App Rename Sprint — the deferred half of PR #145's scope. Verbatim strangler-fig extraction of the Supabase sessions data block out of `App.jsx` into a hook.

## Changes

- **New `web/src/hooks/useSessionLog.js`** (86 lines) — moves, byte-identical: the retired `sessionLog` seed, the `dbSessions`/`dbStatus` state, `fetchSessions` (fetch + row mapping via `normType`), the mount effect, the db-first seed merge, the planned/logged split, and `loggedKeys`. Returns `{ dbStatus, allSessions, loggedSessions, plannedSessions, loggedKeys, fetchSessions }`.
- **`web/src/App.jsx`** — 515 → 447 lines; the block is replaced by one destructure (only the four names App still uses, keeping `no-unused-vars` green); unused `supabase`/`normType` imports removed. Zero other lines touched.
- **New `web/src/hooks/__tests__/useSessionLog.test.js`** — 4 tests: mapping/success path, error fallback, planned/logged split + `loggedKeys`, refetch.

### Why `useSessionLog`, not `useSessions`

`hooks/useSessions.js` already exists — the mobile React Query hook (PR #25) with three live consumers (`useCoach.js`, `MobileAnalytics.jsx`, `MobileSessionLog.jsx`). It and its consumers are untouched. A React Query conversion of the extracted block was explicitly deferred; this PR moves code verbatim.

## Verification

- `npm run build` PASS · `npm test` PASS (44 files, 390 tests) · `eslint src/` 0 errors · prettier clean on changed files.
- Coverage ratchet (#147 raises the floor to 68/67/64) is unaffected: the new hook ships with its tests.

## Noted, out of scope

The ESLint flat config (`web/eslint.config.js`) has no `files` pattern covering `.jsx`, so `eslint src/` doesn't actually lint any `.jsx` file — pre-existing gap, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
