### PR TITLE
ci: path-filter docs-only changes, bundle-size PR comments, Playwright container

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -1,5 +1,11 @@
 name: CI — Web
 
+# Path filtering happens at the JOB level (via the `changes` job), never with
+# workflow-level `on.paths`/`paths-ignore`. Lint/Test/Build are REQUIRED status
+# checks on main: a workflow that never triggers reports nothing and leaves the
+# PR stuck on "Expected — waiting for status", whereas a job skipped by an
+# `if:` condition reports "skipped", which branch protection counts as passing.
+
 on:
   push:
     branches: [main]
@@ -14,9 +20,26 @@ defaults:
     working-directory: web
 
 jobs:
+  changes:
+    name: Detect web changes
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'web/**'
+              - '.github/workflows/ci-web.yml'
+
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -32,6 +55,8 @@ jobs:
   test:
     name: Test & Coverage
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -51,7 +76,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: test
+    needs: [changes, test]
+    if: needs.changes.outputs.web == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -61,5 +90,57 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - run: npm ci
       - run: npm run build
+      # The baseline is the bundle-size.json saved by the most recent push to
+      # main (see the save steps below); restore-keys falls back to the newest
+      # one when the exact base SHA has no cache entry.
+      - name: Restore bundle-size baseline
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v6
+        with:
+          path: web/.bundle-size-baseline.json
+          key: bundle-size-baseline-${{ github.event.pull_request.base.sha }}
+          restore-keys: bundle-size-baseline-
       - name: Bundle-size budget
         run: npm run size
+      # Report even when the budget gate fails — the delta is most useful then.
+      - name: Bundle-size report
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        run: |
+          node scripts/report-bundle-size.mjs .bundle-size-baseline.json > bundle-size-report.md
+          cat bundle-size-report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Comment bundle size on PR
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('web/bundle-size-report.md', 'utf8');
+            const marker = '<!-- bundle-size-report -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+      - name: Save bundle-size baseline (main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: cp dist/bundle-size.json .bundle-size-baseline.json
+      - name: Cache bundle-size baseline (main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v6
+        with:
+          path: web/.bundle-size-baseline.json
+          key: bundle-size-baseline-${{ github.sha }}

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -5,6 +5,14 @@ name: E2E — Web Smoke
 # it does not gate. The webServer in playwright.config.js builds the app with a
 # stub Supabase config; the auth gate is satisfied by a seeded localStorage
 # session, so no real backend is contacted.
+#
+# The job runs in the official Playwright container (browsers + OS deps baked
+# in) instead of `npx playwright install --with-deps` every run. The image tag
+# MUST match the @playwright/test version in web/package-lock.json — bump them
+# together (a version mismatch means untested browser builds).
+#
+# Path filtering is job-level (`changes` job + `if:`), not workflow-level
+# `on.paths` — see the note in ci-web.yml for why (required-check safety).
 
 on:
   push:
@@ -20,9 +28,28 @@ defaults:
     working-directory: web
 
 jobs:
+  changes:
+    name: Detect web changes
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'web/**'
+              - '.github/workflows/e2e-web.yml'
+
   e2e:
     name: Playwright Smoke
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -31,8 +58,11 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci
-      - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
+        env:
+          # Actions overrides HOME to /github/home inside containers; Playwright
+          # expects the image's root home for its browser installs.
+          HOME: /root
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,6 +9,13 @@ name: Lighthouse — Web
 # because CI-runner timing is noisier than the deterministic DOM audits.
 # NOTE: Lighthouse 12 removed the standalone PWA category, so it is not asserted
 # here; PWA installability is covered indirectly by best-practices + the build.
+#
+# lighthouserc.json lives at the REPO ROOT (not web/) on purpose: this workflow
+# has no `defaults.run.working-directory: web`, so the action resolves
+# `configPath` and `staticDistDir: web/dist` from the repo root.
+#
+# Path filtering is job-level (`changes` job + `if:`), not workflow-level
+# `on.paths` — see the note in ci-web.yml for why (required-check safety).
 
 on:
   push:
@@ -20,9 +27,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect web changes
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'web/**'
+              - 'lighthouserc.json'
+              - '.github/workflows/lighthouse.yml'
+
   lighthouse:
     name: Lighthouse
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6

--- a/web/scripts/check-bundle-size.mjs
+++ b/web/scripts/check-bundle-size.mjs
@@ -8,7 +8,7 @@
 // the monolith is finally code-split), never raise it without a deliberate
 // reason. Current build sits at ~360 KB gzipped; budget set with modest
 // headroom so a real regression trips it but normal noise does not.
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { gzipSync } from 'node:zlib';
 import { join } from 'node:path';
 
@@ -42,6 +42,14 @@ const assets = gzippedAssets(ASSET_DIR);
 const totalBytes = assets.reduce((sum, a) => sum + a.gzip, 0);
 const totalKb = totalBytes / 1024;
 const budgetBytes = MAX_GZIP_KB * 1024;
+
+// Machine-readable summary for CI reporting (report-bundle-size.mjs diffs it
+// against the main-branch baseline). Written before the budget check so the
+// PR comment still shows the delta when the gate fails.
+writeFileSync(
+  join(process.cwd(), 'dist', 'bundle-size.json'),
+  JSON.stringify({ budgetKb: MAX_GZIP_KB, total: totalBytes, assets }, null, 2)
+);
 
 const kb = (b) => `${(b / 1024).toFixed(1)} KB`;
 console.log('Bundle size (gzipped):');

--- a/web/scripts/report-bundle-size.mjs
+++ b/web/scripts/report-bundle-size.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Renders the CI bundle-size report as markdown on stdout: the current gzipped
+// total (dist/bundle-size.json, written by check-bundle-size.mjs) diffed
+// against the main-branch baseline restored by actions/cache. Reporting only —
+// the pass/fail gate stays in check-bundle-size.mjs.
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const current = JSON.parse(
+  readFileSync(join(process.cwd(), 'dist', 'bundle-size.json'), 'utf8')
+);
+const baselinePath = process.argv[2];
+
+const kb = (b) => `${(b / 1024).toFixed(1)} KB`;
+const signedKb = (b) => `${b >= 0 ? '+' : '−'}${kb(Math.abs(b))}`;
+
+const overBudget = current.total > current.budgetKb * 1024;
+const lines = [
+  '<!-- bundle-size-report -->',
+  '## Bundle size',
+  '',
+  `**${kb(current.total)}** gzipped — budget ${current.budgetKb} KB ${overBudget ? '❌ over budget' : '✅'}`,
+];
+
+if (baselinePath && existsSync(baselinePath)) {
+  const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+  const delta = current.total - baseline.total;
+  const noise = Math.abs(delta) < 512;
+  lines.push(
+    '',
+    `Δ vs main: **${noise ? '±0.0 KB' : signedKb(delta)}** (main baseline ${kb(baseline.total)})`
+  );
+} else {
+  lines.push('', '_No main-branch baseline available for comparison._');
+}
+
+lines.push(
+  '',
+  '<details><summary>Per-asset breakdown</summary>',
+  '',
+  '| Asset | Gzipped |',
+  '| --- | ---: |',
+  ...current.assets.map((a) => `| \`${a.file}\` | ${kb(a.gzip)} |`),
+  '',
+  '</details>'
+);
+
+console.log(lines.join('\n'));


### PR DESCRIPTION
## What changed and why

Research-driven CI/CD improvements (from `/research ci/cd benchmark improvements`): docs-only changes no longer run the full web pipeline, PRs get an inline bundle-size delta comment, and the e2e job stops re-downloading browsers every run.

- **Job-level path filtering** in `ci-web.yml`, `lighthouse.yml`, `e2e-web.yml` via a `changes` job (`dorny/paths-filter@v4`) — edits to `CLAUDE.md`, `coach/`, `.claude/`, etc. skip lint/test/build/lighthouse/e2e. Deliberately job-level, not workflow-level `on.paths`: skipped jobs report "skipped" (which branch protection counts as passing), while an untriggered workflow leaves PRs stuck on "Expected — waiting for status". Each workflow carries a comment explaining this.
- **Bundle-size PR comment**: `check-bundle-size.mjs` stays the gate and now also writes `dist/bundle-size.json`; new `web/scripts/report-bundle-size.mjs` diffs it against the main-branch baseline (persisted via `actions/cache`) and the Build job posts/updates a sticky PR comment + step summary. The report also runs when the budget gate fails. The first PR after merge will show "no baseline" — the baseline populates on the next push to `main`.
- **E2E in the official Playwright container** (`mcr.microsoft.com/playwright:v1.61.1-noble`, matched to the exact `@playwright/test` version in `web/package-lock.json`), replacing `npx playwright install --with-deps` on every run. Image tag and lockfile version must be bumped together (noted in the workflow).
- Documented why `lighthouserc.json` lives at the repo root.

## How to test manually

- This PR touches `web/**` and the workflows, so all jobs should run as usual — the bundle-size comment should appear below (with "no baseline" until the first post-merge main build).
- After merge, a docs-only PR should skip the heavy jobs while Lint/Test/Build still report (skipped) and the PR stays mergeable.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — CI-config + report-script change with no runtime app surface; the size gate itself is exercised on every build, and the report script was verified locally with and without a baseline
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no app code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1K24yCnW8hDJZ8NzWZbV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1K24yCnW8hDJZ8NzWZbV1)_