### PR TITLE
feat: add 8 THEME tokens for high-frequency untokenized colors (design tokens slice 2a)

### DIFF
--- a/web/src/constants/__tests__/theme.test.js
+++ b/web/src/constants/__tests__/theme.test.js
@@ -17,12 +17,20 @@ const EXPECTED_KEYS = [
   'purple',
   'pink',
   'teal',
+  'surfaceAlt',
+  'neutral',
+  'textSubtle',
+  'textFaint',
+  'textDim',
+  'divider',
+  'grey',
+  'white',
 ];
 
 describe('THEME', () => {
-  it('has exactly the 15 expected keys (no more, no fewer)', () => {
+  it('has exactly the 23 expected keys (no more, no fewer)', () => {
     const keys = Object.keys(THEME);
-    expect(keys).toHaveLength(15);
+    expect(keys).toHaveLength(23);
     expect(keys.sort()).toEqual([...EXPECTED_KEYS].sort());
   });
 
@@ -48,5 +56,13 @@ describe('THEME', () => {
     expect(THEME.purple).toBe('#a78bfa');
     expect(THEME.pink).toBe('#f472b6');
     expect(THEME.teal).toBe('#2dd4bf');
+    expect(THEME.surfaceAlt).toBe('#1e1e30');
+    expect(THEME.neutral).toBe('#3a3a4a');
+    expect(THEME.textSubtle).toBe('#aaaacc');
+    expect(THEME.textFaint).toBe('#6c6c88');
+    expect(THEME.textDim).toBe('#5a5a74');
+    expect(THEME.divider).toBe('#3e3e5a');
+    expect(THEME.grey).toBe('#888888');
+    expect(THEME.white).toBe('#ffffff');
   });
 });

--- a/web/src/constants/theme.js
+++ b/web/src/constants/theme.js
@@ -14,4 +14,12 @@ export const THEME = {
   purple: '#a78bfa',
   pink: '#f472b6',
   teal: '#2dd4bf',
+  surfaceAlt: '#1e1e30',
+  neutral: '#3a3a4a',
+  textSubtle: '#aaaacc',
+  textFaint: '#6c6c88',
+  textDim: '#5a5a74',
+  divider: '#3e3e5a',
+  grey: '#888888',
+  white: '#ffffff',
 };


### PR DESCRIPTION
## What

Tokens-first sub-slice of the inline-literal migration (follow-up to #148 / PR #149). Adds 8 tokens to `web/src/constants/theme.js` and extends `theme.test.js` to lock 23 keys/values. **No consumers migrated** — that's PRs 2b–2e.

| Token | Value | Role (verified frequency in-scope) |
|---|---|---|
| `surfaceAlt` | `#1e1e30` | panel shade / gradient-end stop (34×) — distinct from `surface`, folding would change pixels |
| `neutral` | `#3a3a4a` | "Rest" session-type accent — completes the workout-type palette |
| `textSubtle` | `#aaaacc` | secondary text (82×) |
| `textFaint` | `#6c6c88` | tertiary labels (49×) |
| `textDim` | `#5a5a74` | faintest sub-labels (~10×) |
| `divider` | `#3e3e5a` | hairline borders (11×) |
| `grey` | `#888888` | neutral fallback grey (26×, as `#888`) |
| `white` | `#ffffff` | pure white (21×, as `#fff`) — not folded into `text #e8e8f0` |

`cssVars()` iterates `Object.keys(THEME)`, so the new `--color-*` variables auto-generate — `themeCss.js` and `main.jsx` untouched.

## Pipeline evidence

Ran the full factory chain (research → story → spec → build → verify → review + validate), Gates 1–3 approved by Scott.
- Tests: 44 files / 390 tests pass, exit 0 (main-thread run). Two verifier agents saw 2 timeout flakes in **unrelated** view tests during concurrent local runs on the Drive-synced checkout — judged environmental by both; CI is the binding check.
- Coverage: 72.0/71.7/68.7 vs floors 52/50/48 (`constants/**` is coverage-excluded, so this diff is coverage-neutral by construction).
- Lint 0 errors; build ✓.
- Judges: Code Reviewer **APPROVE**; Reality Checker **ship** (no findings at any severity).

## Next

PRs 2b–2e migrate ~800 literals (components → desktop views → mobile + App.jsx → constants/utils) per the approved spec: alpha-suffix `` `${THEME.token}NN` `` convention, gradient template-literals, Recharts `prop="#hex"` deferred, drift folds (`#0a0a0f`→bg, `#3a3a5a`→neutral, `#a0a0b8`→muted) enumerated per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)