### PR TITLE
feat: migrate shared components to THEME tokens (design tokens slice 2b)

### DIFF
--- a/web/src/components/ErgTooltip.jsx
+++ b/web/src/components/ErgTooltip.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { THEME } from '../constants/theme.js';
 
 function fmtPace(secs) {
   const m = Math.floor(secs / 60);
@@ -12,8 +13,8 @@ export default function ErgTooltip({ active, payload }) {
   return (
     <div
       style={{
-        background: '#2a2a48',
-        border: '1px solid #4a4a68',
+        background: THEME.raised,
+        border: `1px solid ${THEME.border}`,
         borderRadius: 6,
         padding: '10px 12px',
         fontSize: 11,
@@ -22,7 +23,7 @@ export default function ErgTooltip({ active, payload }) {
     >
       <div
         style={{
-          color: '#7e7e9a',
+          color: THEME.muted,
           marginBottom: 4,
           fontSize: 9,
           letterSpacing: 2,
@@ -30,10 +31,10 @@ export default function ErgTooltip({ active, payload }) {
       >
         {d.date} · {d.dist}
       </div>
-      <div style={{ color: '#00d4ff', fontWeight: 700, fontSize: 14 }}>
-        {d.watts}W<span style={{ fontSize: 10, color: '#7e7e9a' }}> avg</span>
+      <div style={{ color: THEME.cyan, fontWeight: 700, fontSize: 14 }}>
+        {d.watts}W<span style={{ fontSize: 10, color: THEME.muted }}> avg</span>
       </div>
-      <div style={{ color: '#888', fontSize: 10, marginTop: 2 }}>
+      <div style={{ color: THEME.grey, fontSize: 10, marginTop: 2 }}>
         {fmtPace(d.pace)}/500m{d.hardPush ? ' · hard push' : ' · Z2'}
       </div>
     </div>

--- a/web/src/components/ErrorFallback.jsx
+++ b/web/src/components/ErrorFallback.jsx
@@ -1,5 +1,7 @@
 // Fallback UI rendered by the Sentry error boundary when a render crashes.
 // Kept dependency-free and self-contained so it can never itself throw.
+import { THEME } from '../constants/theme.js';
+
 export default function ErrorFallback({ resetError }) {
   return (
     <div
@@ -11,8 +13,8 @@ export default function ErrorFallback({ resetError }) {
         alignItems: 'center',
         justifyContent: 'center',
         gap: 14,
-        background: '#0a0a0f',
-        color: '#e8e8f0',
+        background: THEME.bg,
+        color: THEME.text,
         fontFamily: 'ui-sans-serif, system-ui, -apple-system, sans-serif',
         padding: 24,
         textAlign: 'center',
@@ -22,7 +24,7 @@ export default function ErrorFallback({ resetError }) {
         style={{
           fontSize: 15,
           fontWeight: 700,
-          color: '#ff2d55',
+          color: THEME.red,
           letterSpacing: 1,
         }}
       >
@@ -31,7 +33,7 @@ export default function ErrorFallback({ resetError }) {
       <div
         style={{
           fontSize: 12,
-          color: '#7e7e9a',
+          color: THEME.muted,
           lineHeight: 1.6,
           maxWidth: 320,
         }}
@@ -42,14 +44,14 @@ export default function ErrorFallback({ resetError }) {
       <button
         onClick={resetError}
         style={{
-          background: '#34d399',
+          background: THEME.green,
           border: 'none',
           borderRadius: 6,
           padding: '10px 16px',
           fontSize: 12,
           fontWeight: 700,
           letterSpacing: 1,
-          color: '#0a0a0f',
+          color: THEME.bg,
           cursor: 'pointer',
           fontFamily: 'inherit',
         }}

--- a/web/src/components/LiveMetric.jsx
+++ b/web/src/components/LiveMetric.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { THEME } from '../constants/theme.js';
 
 const SIZES = {
   large: { value: 52, label: 9, unit: 11, gap: 2 },
@@ -10,7 +11,7 @@ export default function LiveMetric({
   label,
   value,
   unit,
-  accent = '#00d4ff',
+  accent = THEME.cyan,
   size = 'normal',
   dimmed = false,
 }) {
@@ -29,7 +30,7 @@ export default function LiveMetric({
         style={{
           fontSize: s.label,
           letterSpacing: 2,
-          color: '#7e7e9a',
+          color: THEME.muted,
           fontWeight: 600,
           textTransform: 'uppercase',
         }}
@@ -49,7 +50,9 @@ export default function LiveMetric({
         {value ?? '--'}
       </div>
       {unit && (
-        <div style={{ fontSize: s.unit, color: '#4a4a68', letterSpacing: 1 }}>
+        <div
+          style={{ fontSize: s.unit, color: THEME.border, letterSpacing: 1 }}
+        >
           {unit}
         </div>
       )}

--- a/web/src/components/LoadTooltip.jsx
+++ b/web/src/components/LoadTooltip.jsx
@@ -1,21 +1,22 @@
 import React from 'react';
+import { THEME } from '../constants/theme.js';
 
 export default function LoadTooltip({ active, payload, label }) {
   if (!active || !payload?.length) return null;
   const d = payload[0].payload;
   const tsbColor =
     d.tsb > 10
-      ? '#34d399'
+      ? THEME.green
       : d.tsb > -10
-        ? '#ffd700'
+        ? THEME.gold
         : d.tsb > -30
-          ? '#ff6b35'
-          : '#ff2d55';
+          ? THEME.orange
+          : THEME.red;
   return (
     <div
       style={{
-        background: '#2a2a48',
-        border: '1px solid #4a4a68',
+        background: THEME.raised,
+        border: `1px solid ${THEME.border}`,
         borderRadius: 6,
         padding: '10px 12px',
         fontSize: 11,
@@ -25,7 +26,7 @@ export default function LoadTooltip({ active, payload, label }) {
     >
       <div
         style={{
-          color: '#7e7e9a',
+          color: THEME.muted,
           marginBottom: 6,
           fontSize: 9,
           letterSpacing: 2,
@@ -36,12 +37,12 @@ export default function LoadTooltip({ active, payload, label }) {
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
         <div>
-          <span style={{ color: '#00d4ff' }}>CTL </span>
-          <span style={{ color: '#fff', fontWeight: 700 }}>{d.ctl}</span>
+          <span style={{ color: THEME.cyan }}>CTL </span>
+          <span style={{ color: THEME.white, fontWeight: 700 }}>{d.ctl}</span>
         </div>
         <div>
-          <span style={{ color: '#ff6b35' }}>ATL </span>
-          <span style={{ color: '#fff', fontWeight: 700 }}>{d.atl}</span>
+          <span style={{ color: THEME.orange }}>ATL </span>
+          <span style={{ color: THEME.white, fontWeight: 700 }}>{d.atl}</span>
         </div>
         <div>
           <span style={{ color: tsbColor }}>TSB </span>
@@ -53,13 +54,13 @@ export default function LoadTooltip({ active, payload, label }) {
         {d.tss > 0 && (
           <div
             style={{
-              borderTop: '1px solid #4a4a68',
+              borderTop: `1px solid ${THEME.border}`,
               paddingTop: 3,
               marginTop: 3,
             }}
           >
-            <span style={{ color: '#7e7e9a' }}>TSS </span>
-            <span style={{ color: '#aaaacc' }}>{d.tss}</span>
+            <span style={{ color: THEME.muted }}>TSS </span>
+            <span style={{ color: THEME.textSubtle }}>{d.tss}</span>
           </div>
         )}
       </div>

--- a/web/src/components/LogEntry.jsx
+++ b/web/src/components/LogEntry.jsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { C, ICON } from '../constants/ui.js';
+import { THEME } from '../constants/theme.js';
 
 export default function LogEntry({ entry, done = false }) {
   const [open, setOpen] = useState(false);
-  const color = C[entry.type] || '#888';
+  const color = C[entry.type] || THEME.grey;
   const isErg = !!entry._isErg;
   const planned = entry.status === 'planned';
   // Flat erg metrics replaced the removed `splits` field. Planned erg rows
@@ -19,13 +20,13 @@ export default function LogEntry({ entry, done = false }) {
   return (
     <div
       style={{
-        borderTop: `1px solid ${open ? color + '50' : '#4a4a68'}`,
-        borderRight: `1px solid ${open ? color + '50' : '#4a4a68'}`,
-        borderBottom: `1px solid ${open ? color + '50' : '#4a4a68'}`,
+        borderTop: `1px solid ${open ? color + '50' : THEME.border}`,
+        borderRight: `1px solid ${open ? color + '50' : THEME.border}`,
+        borderBottom: `1px solid ${open ? color + '50' : THEME.border}`,
         borderLeft: `3px ${planned ? 'dashed' : 'solid'} ${color}`,
         borderRadius: 6,
         overflow: 'hidden',
-        background: open ? `${color}10` : '#2a2a48',
+        background: open ? `${color}10` : THEME.raised,
         opacity: done ? 0.5 : 1,
       }}
     >
@@ -57,7 +58,7 @@ export default function LogEntry({ entry, done = false }) {
               style={{
                 fontSize: 13,
                 fontWeight: 700,
-                color: '#fff',
+                color: THEME.white,
                 lineHeight: 1.3,
               }}
             >
@@ -69,8 +70,8 @@ export default function LogEntry({ entry, done = false }) {
                     fontSize: 8,
                     letterSpacing: 1.5,
                     fontWeight: 700,
-                    color: '#34d399',
-                    border: '1px solid #34d39966',
+                    color: THEME.green,
+                    border: `1px solid ${THEME.green}66`,
                     borderRadius: 3,
                     padding: '1px 5px',
                     verticalAlign: 'middle',
@@ -97,11 +98,11 @@ export default function LogEntry({ entry, done = false }) {
                 </span>
               )}
             </div>
-            <div style={{ fontSize: 11, color: '#7e7e9a' }}>
+            <div style={{ fontSize: 11, color: THEME.muted }}>
               {entry.date}
               {entry.duration ? ` · ${entry.duration}` : ''}
               {entry.srpe != null && (
-                <span style={{ color: '#ffd700' }}> · sRPE {entry.srpe}</span>
+                <span style={{ color: THEME.gold }}> · sRPE {entry.srpe}</span>
               )}
             </div>
           </div>
@@ -113,7 +114,7 @@ export default function LogEntry({ entry, done = false }) {
                 {entry.avg_watts}W
               </div>
             )}
-            <div style={{ fontSize: 10, color: '#7e7e9a' }}>
+            <div style={{ fontSize: 10, color: THEME.muted }}>
               {fmtDist(entry.distance_m)}
               {entry.avg_hr != null ? ` · ${entry.avg_hr}bpm` : ''}
             </div>
@@ -162,7 +163,7 @@ export default function LogEntry({ entry, done = false }) {
                   <div
                     key={k}
                     style={{
-                      background: '#08080d',
+                      background: THEME.bg,
                       borderRadius: 4,
                       padding: '7px 8px',
                     }}
@@ -170,7 +171,7 @@ export default function LogEntry({ entry, done = false }) {
                     <div
                       style={{
                         fontSize: 8,
-                        color: '#7e7e9a',
+                        color: THEME.muted,
                         letterSpacing: 2,
                         marginBottom: 2,
                       }}
@@ -187,7 +188,7 @@ export default function LogEntry({ entry, done = false }) {
               <div
                 style={{
                   fontSize: 10,
-                  color: '#7e7e9a',
+                  color: THEME.muted,
                   fontStyle: 'italic',
                   marginBottom: entry.coachNote ? 8 : 0,
                 }}
@@ -207,7 +208,7 @@ export default function LogEntry({ entry, done = false }) {
               }}
             >
               <thead>
-                <tr style={{ borderBottom: '1px solid #4a4a68' }}>
+                <tr style={{ borderBottom: `1px solid ${THEME.border}` }}>
                   {[
                     ['Exercise', '42%'],
                     ['Top Wt', '19%'],
@@ -218,7 +219,7 @@ export default function LogEntry({ entry, done = false }) {
                       key={h}
                       style={{
                         padding: '5px 4px',
-                        color: '#7e7e9a',
+                        color: THEME.muted,
                         fontSize: 9,
                         letterSpacing: 0.5,
                         width: w,
@@ -231,11 +232,14 @@ export default function LogEntry({ entry, done = false }) {
               </thead>
               <tbody>
                 {entry.exercises.map((ex, i) => (
-                  <tr key={i} style={{ borderBottom: '1px solid #1e1e30' }}>
+                  <tr
+                    key={i}
+                    style={{ borderBottom: `1px solid ${THEME.surfaceAlt}` }}
+                  >
                     <td
                       style={{
                         padding: '6px 4px',
-                        color: ex.pr ? '#ffd700' : '#aaaacc',
+                        color: ex.pr ? THEME.gold : THEME.textSubtle,
                         wordBreak: 'break-word',
                         lineHeight: 1.3,
                       }}
@@ -246,7 +250,7 @@ export default function LogEntry({ entry, done = false }) {
                     <td
                       style={{
                         padding: '6px 4px',
-                        color: '#e8e8f0',
+                        color: THEME.text,
                         fontWeight: ex.pr ? 700 : 400,
                         wordBreak: 'break-word',
                       }}
@@ -256,7 +260,7 @@ export default function LogEntry({ entry, done = false }) {
                     <td
                       style={{
                         padding: '6px 4px',
-                        color: '#aaaacc',
+                        color: THEME.textSubtle,
                         wordBreak: 'break-word',
                       }}
                     >
@@ -265,7 +269,7 @@ export default function LogEntry({ entry, done = false }) {
                     <td
                       style={{
                         padding: '6px 4px',
-                        color: '#aaaacc',
+                        color: THEME.textSubtle,
                         wordBreak: 'break-word',
                       }}
                     >
@@ -279,7 +283,7 @@ export default function LogEntry({ entry, done = false }) {
             <div
               style={{
                 fontSize: 10,
-                color: '#7e7e9a',
+                color: THEME.muted,
                 fontStyle: 'italic',
                 marginBottom: entry.coachNote ? 8 : 0,
               }}
@@ -295,7 +299,7 @@ export default function LogEntry({ entry, done = false }) {
             <div
               style={{
                 marginTop: 10,
-                background: '#08080d',
+                background: THEME.bg,
                 borderRadius: 4,
                 padding: '10px 12px',
                 fontSize: 11,

--- a/web/src/components/LogSessionForm.jsx
+++ b/web/src/components/LogSessionForm.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
+import { THEME } from '../constants/theme.js';
 
 export default function LogSessionForm({ onSaved }) {
   const queryClient = useQueryClient();
@@ -34,12 +35,12 @@ export default function LogSessionForm({ onSaved }) {
             : "max · can't talk";
   const srpeColor =
     srpe <= 4
-      ? '#34d399'
+      ? THEME.green
       : srpe <= 6
-        ? '#ffd700'
+        ? THEME.gold
         : srpe <= 8
-          ? '#ff6b35'
-          : '#ff2d55';
+          ? THEME.orange
+          : THEME.red;
 
   const setRow = (i, field, val) =>
     setRows(rows.map((r, j) => (j === i ? { ...r, [field]: val } : r)));
@@ -115,12 +116,12 @@ export default function LogSessionForm({ onSaved }) {
   };
 
   const inp = {
-    background: '#08080d',
-    border: '1px solid #4a4a68',
+    background: THEME.field,
+    border: `1px solid ${THEME.border}`,
     borderRadius: 4,
     padding: '7px 9px',
     fontSize: 11,
-    color: '#e8e8f0',
+    color: THEME.text,
     fontFamily: 'inherit',
     width: '100%',
     boxSizing: 'border-box',
@@ -128,7 +129,7 @@ export default function LogSessionForm({ onSaved }) {
   const lbl = {
     fontSize: 8,
     letterSpacing: 1,
-    color: '#7e7e9a',
+    color: THEME.muted,
     marginBottom: 3,
     display: 'block',
   };
@@ -139,14 +140,14 @@ export default function LogSessionForm({ onSaved }) {
         onClick={() => setOpen(true)}
         style={{
           width: '100%',
-          background: '#34d39915',
-          border: '1px solid #34d399',
+          background: `${THEME.green}15`,
+          border: `1px solid ${THEME.green}`,
           borderRadius: 6,
           padding: '12px',
           marginBottom: 14,
           fontSize: 12,
           fontWeight: 700,
-          color: '#34d399',
+          color: THEME.green,
           cursor: 'pointer',
           fontFamily: 'inherit',
           letterSpacing: 1,
@@ -160,8 +161,8 @@ export default function LogSessionForm({ onSaved }) {
   return (
     <div
       style={{
-        background: '#2a2a48',
-        border: '1px solid #34d399',
+        background: THEME.raised,
+        border: `1px solid ${THEME.green}`,
         borderRadius: 6,
         padding: '14px 16px',
         marginBottom: 14,
@@ -179,7 +180,7 @@ export default function LogSessionForm({ onSaved }) {
           style={{
             fontSize: 12,
             fontWeight: 700,
-            color: '#34d399',
+            color: THEME.green,
             letterSpacing: 1,
           }}
         >
@@ -193,7 +194,7 @@ export default function LogSessionForm({ onSaved }) {
           style={{
             background: 'none',
             border: 'none',
-            color: '#7e7e9a',
+            color: THEME.muted,
             fontSize: 16,
             cursor: 'pointer',
           }}
@@ -283,7 +284,7 @@ export default function LogSessionForm({ onSaved }) {
           <div
             key={i}
             style={{
-              background: '#08080d',
+              background: THEME.bg,
               borderRadius: 5,
               padding: '9px 10px',
             }}
@@ -299,9 +300,9 @@ export default function LogSessionForm({ onSaved }) {
                 onClick={() => removeRow(i)}
                 style={{
                   background: 'none',
-                  border: '1px solid #4a4a68',
+                  border: `1px solid ${THEME.border}`,
                   borderRadius: 4,
-                  color: '#7e7e9a',
+                  color: THEME.muted,
                   cursor: 'pointer',
                   padding: '0 9px',
                   fontSize: 12,
@@ -343,7 +344,7 @@ export default function LogSessionForm({ onSaved }) {
                 alignItems: 'center',
                 gap: 6,
                 fontSize: 10,
-                color: '#ffd700',
+                color: THEME.gold,
                 cursor: 'pointer',
               }}
             >
@@ -351,7 +352,7 @@ export default function LogSessionForm({ onSaved }) {
                 type="checkbox"
                 checked={r.pr}
                 onChange={(e) => setRow(i, 'pr', e.target.checked)}
-                style={{ accentColor: '#ffd700' }}
+                style={{ accentColor: THEME.gold }}
               />
               🏆 PR
             </label>
@@ -362,9 +363,9 @@ export default function LogSessionForm({ onSaved }) {
         onClick={addRow}
         style={{
           background: 'none',
-          border: '1px dashed #4a4a68',
+          border: `1px dashed ${THEME.border}`,
           borderRadius: 4,
-          color: '#7e7e9a',
+          color: THEME.muted,
           cursor: 'pointer',
           padding: '7px',
           width: '100%',
@@ -380,7 +381,7 @@ export default function LogSessionForm({ onSaved }) {
         <div
           style={{
             fontSize: 10,
-            color: msg.type === 'ok' ? '#34d399' : '#ff2d55',
+            color: msg.type === 'ok' ? THEME.green : THEME.red,
             marginBottom: 10,
             lineHeight: 1.5,
           }}
@@ -393,13 +394,13 @@ export default function LogSessionForm({ onSaved }) {
         disabled={saving}
         style={{
           width: '100%',
-          background: saving ? '#4a4a68' : '#34d399',
+          background: saving ? THEME.border : THEME.green,
           border: 'none',
           borderRadius: 6,
           padding: '12px',
           fontSize: 12,
           fontWeight: 700,
-          color: '#08080d',
+          color: THEME.bg,
           cursor: saving ? 'default' : 'pointer',
           fontFamily: 'inherit',
           letterSpacing: 1,

--- a/web/src/components/PaceTrendChart.jsx
+++ b/web/src/components/PaceTrendChart.jsx
@@ -8,6 +8,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { formatPace } from '../utils/pace.js';
+import { THEME } from '../constants/theme.js';
 
 export function PaceTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
@@ -15,8 +16,8 @@ export function PaceTooltip({ active, payload }) {
   return (
     <div
       style={{
-        background: '#2a2a48',
-        border: '1px solid #4a4a68',
+        background: THEME.raised,
+        border: `1px solid ${THEME.border}`,
         borderRadius: 6,
         padding: '10px 12px',
         fontSize: 11,
@@ -25,7 +26,7 @@ export function PaceTooltip({ active, payload }) {
     >
       <div
         style={{
-          color: '#7e7e9a',
+          color: THEME.muted,
           marginBottom: 4,
           fontSize: 9,
           letterSpacing: 2,
@@ -33,11 +34,11 @@ export function PaceTooltip({ active, payload }) {
       >
         {d.date_display}
       </div>
-      <div style={{ color: '#00d4ff', fontWeight: 700, fontSize: 14 }}>
+      <div style={{ color: THEME.cyan, fontWeight: 700, fontSize: 14 }}>
         {d.pace_500m_str}
-        <span style={{ fontSize: 10, color: '#7e7e9a' }}> /500m</span>
+        <span style={{ fontSize: 10, color: THEME.muted }}> /500m</span>
       </div>
-      <div style={{ color: '#888', fontSize: 10, marginTop: 2 }}>
+      <div style={{ color: THEME.grey, fontSize: 10, marginTop: 2 }}>
         {d.avg_watts != null ? `${d.avg_watts}W` : '—'}
         {d.zone ? ` · ${d.zone}` : ''}
       </div>

--- a/web/src/components/StrengthTooltip.jsx
+++ b/web/src/components/StrengthTooltip.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { THEME } from '../constants/theme.js';
 
 export default function StrengthTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
@@ -6,8 +7,8 @@ export default function StrengthTooltip({ active, payload }) {
   return (
     <div
       style={{
-        background: '#2a2a48',
-        border: '1px solid #4a4a68',
+        background: THEME.raised,
+        border: `1px solid ${THEME.border}`,
         borderRadius: 6,
         padding: '10px 12px',
         fontSize: 11,
@@ -16,7 +17,7 @@ export default function StrengthTooltip({ active, payload }) {
     >
       <div
         style={{
-          color: '#7e7e9a',
+          color: THEME.muted,
           marginBottom: 4,
           fontSize: 9,
           letterSpacing: 2,
@@ -25,7 +26,8 @@ export default function StrengthTooltip({ active, payload }) {
         {d.date}
       </div>
       <div style={{ color: payload[0].stroke, fontWeight: 700, fontSize: 14 }}>
-        {d.e1rm}kg<span style={{ fontSize: 10, color: '#7e7e9a' }}> e1RM</span>
+        {d.e1rm}kg
+        <span style={{ fontSize: 10, color: THEME.muted }}> e1RM</span>
       </div>
     </div>
   );

--- a/web/src/components/WorkoutItem.jsx
+++ b/web/src/components/WorkoutItem.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { workoutAccent } from '../utils/formatting.js';
+import { THEME } from '../constants/theme.js';
 
 export default function WorkoutItem({
   session,
@@ -8,13 +9,13 @@ export default function WorkoutItem({
   showRail = true,
 }) {
   const [open, setOpen] = useState(false);
-  const color = session ? workoutAccent(session.label) : '#3a3a4a';
+  const color = session ? workoutAccent(session.label) : THEME.neutral;
   const hasDetail = session && (session.note || session.fuel || session.meal);
   return (
     <div
       style={{
-        background: open || highlight ? '#00d4ff10' : '#2a2a48',
-        border: `1px solid ${open || highlight ? color + '50' : '#4a4a68'}`,
+        background: open || highlight ? `${THEME.cyan}10` : THEME.raised,
+        border: `1px solid ${open || highlight ? color + '50' : THEME.border}`,
         borderRadius: 6,
         overflow: 'hidden',
       }}
@@ -35,7 +36,7 @@ export default function WorkoutItem({
               width: 42,
               flexShrink: 0,
               textAlign: 'center',
-              borderRight: `1px solid ${showRail ? '#4a4a68' : 'transparent'}`,
+              borderRight: `1px solid ${showRail ? THEME.border : 'transparent'}`,
               paddingRight: 10,
             }}
           >
@@ -44,7 +45,7 @@ export default function WorkoutItem({
                 <div
                   style={{
                     fontSize: 9,
-                    color: highlight ? '#00d4ff' : '#7e7e9a',
+                    color: highlight ? THEME.cyan : THEME.muted,
                     letterSpacing: 1,
                     fontWeight: 700,
                   }}
@@ -56,7 +57,7 @@ export default function WorkoutItem({
                     style={{
                       fontSize: 17,
                       fontWeight: 700,
-                      color: highlight ? '#00d4ff' : '#e8e8f0',
+                      color: highlight ? THEME.cyan : THEME.text,
                       lineHeight: 1.1,
                     }}
                   >
@@ -64,7 +65,7 @@ export default function WorkoutItem({
                   </div>
                 )}
                 {rail.bottom && (
-                  <div style={{ fontSize: 7, color: '#6c6c88' }}>
+                  <div style={{ fontSize: 7, color: THEME.textFaint }}>
                     {rail.bottom}
                   </div>
                 )}
@@ -77,7 +78,7 @@ export default function WorkoutItem({
             <div
               style={{
                 fontSize: 7,
-                color: '#00d4ff',
+                color: THEME.cyan,
                 letterSpacing: 2,
                 marginBottom: 3,
               }}
@@ -90,7 +91,7 @@ export default function WorkoutItem({
               {session.done ? (
                 <span
                   style={{
-                    color: '#34d399',
+                    color: THEME.green,
                     flexShrink: 0,
                     fontSize: 12,
                     fontWeight: 700,
@@ -112,12 +113,12 @@ export default function WorkoutItem({
               <span
                 style={{
                   fontSize: 11,
-                  color: session.done ? '#7a9a8a' : '#e8e8f0',
+                  color: session.done ? '#7a9a8a' : THEME.text,
                   lineHeight: 1.4,
                 }}
               >
                 {session.slot && (
-                  <span style={{ color: '#888', fontWeight: 700 }}>
+                  <span style={{ color: THEME.grey, fontWeight: 700 }}>
                     {session.slot}{' '}
                   </span>
                 )}
@@ -125,7 +126,7 @@ export default function WorkoutItem({
               </span>
             </div>
           ) : (
-            <span style={{ fontSize: 11, color: '#6c6c88' }}>—</span>
+            <span style={{ fontSize: 11, color: THEME.textFaint }}>—</span>
           )}
         </div>
         {hasDetail && (
@@ -134,7 +135,7 @@ export default function WorkoutItem({
               flexShrink: 0,
               alignSelf: 'center',
               fontSize: 10,
-              color: '#7e7e9a',
+              color: THEME.muted,
             }}
           >
             {open ? '▲' : '▼'}
@@ -146,11 +147,11 @@ export default function WorkoutItem({
           {session.note && (
             <div
               style={{
-                background: '#08080d',
+                background: THEME.bg,
                 borderRadius: 5,
                 padding: '10px 12px',
                 fontSize: 11,
-                color: '#aaaacc',
+                color: THEME.textSubtle,
                 lineHeight: 1.6,
                 marginBottom: 6,
               }}
@@ -161,17 +162,17 @@ export default function WorkoutItem({
           {session.fuel && (
             <div
               style={{
-                background: '#08080d',
-                borderLeft: '2px solid #34d399',
+                background: THEME.bg,
+                borderLeft: `2px solid ${THEME.green}`,
                 borderRadius: 5,
                 padding: '10px 12px',
                 fontSize: 11,
-                color: '#aaaacc',
+                color: THEME.textSubtle,
                 lineHeight: 1.6,
                 marginBottom: session.meal ? 6 : 0,
               }}
             >
-              <span style={{ color: '#34d399', fontWeight: 700 }}>
+              <span style={{ color: THEME.green, fontWeight: 700 }}>
                 🍽 FUEL:{' '}
               </span>
               {session.fuel}
@@ -180,18 +181,18 @@ export default function WorkoutItem({
           {session.meal && (
             <div
               style={{
-                background: '#08080d',
-                borderLeft: '2px solid #ffd700',
+                background: THEME.bg,
+                borderLeft: `2px solid ${THEME.gold}`,
                 borderRadius: 5,
                 padding: '10px 12px',
                 fontSize: 11,
-                color: '#aaaacc',
+                color: THEME.textSubtle,
                 lineHeight: 1.6,
               }}
             >
               <div
                 style={{
-                  color: '#ffd700',
+                  color: THEME.gold,
                   fontWeight: 700,
                   fontSize: 9,
                   letterSpacing: 2,
@@ -202,7 +203,7 @@ export default function WorkoutItem({
               </div>
               {session.meal.pre && (
                 <div style={{ marginBottom: session.meal.post ? 5 : 0 }}>
-                  <span style={{ color: '#ffd700', fontWeight: 700 }}>
+                  <span style={{ color: THEME.gold, fontWeight: 700 }}>
                     Pre:{' '}
                   </span>
                   {session.meal.pre}
@@ -210,7 +211,7 @@ export default function WorkoutItem({
               )}
               {session.meal.post && (
                 <div>
-                  <span style={{ color: '#ffd700', fontWeight: 700 }}>
+                  <span style={{ color: THEME.gold, fontWeight: 700 }}>
                     Post:{' '}
                   </span>
                   {session.meal.post}

--- a/web/src/components/WorkoutTarget.jsx
+++ b/web/src/components/WorkoutTarget.jsx
@@ -78,7 +78,7 @@ export default function WorkoutTarget({ session }) {
               style={{
                 marginTop: 8,
                 fontSize: 11,
-                color: '#a0a0b8',
+                color: C.muted,
                 lineHeight: 1.6,
                 borderLeft: `2px solid ${C.accent}`,
                 paddingLeft: 10,

--- a/web/src/components/mobile/BottomTabBar.jsx
+++ b/web/src/components/mobile/BottomTabBar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { THEME } from '../../constants/theme.js';
 
 const TABS = [
   { id: 'analytics', label: 'Analytics', icon: '📊' },
@@ -24,8 +25,8 @@ export default function BottomTabBar({ activeTab, onTabChange }) {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'space-around',
-        background: '#2a2a48',
-        borderTop: '1px solid #4a4a68',
+        background: THEME.raised,
+        borderTop: `1px solid ${THEME.border}`,
       }}
     >
       {TABS.map(({ id, label, icon }) => (
@@ -53,7 +54,7 @@ export default function BottomTabBar({ activeTab, onTabChange }) {
               fontSize: 9,
               letterSpacing: 1,
               fontWeight: activeTab === id ? 700 : 400,
-              color: activeTab === id ? '#34d399' : '#7e7e9a',
+              color: activeTab === id ? THEME.green : THEME.muted,
             }}
           >
             {label}


### PR DESCRIPTION
## What

Second sub-slice of the inline-literal migration (follow-up to #148, builds on #153). Replaces ~60 inline hex literals with `THEME` token references across the 11 shared components:

LogEntry, WorkoutItem, LoadTooltip, LogSessionForm, ErgTooltip, StrengthTooltip, LiveMetric, WorkoutTarget, PaceTrendChart, mobile/BottomTabBar, ErrorFallback.

**Conventions applied (per the approved spec):**
- Alpha-suffixed literals → `` `${THEME.token}NN` `` template literals (8-hex shape preserved, never rgba()).
- Runtime-variable alpha bases (`${color}50`) untouched.
- Recharts/SVG bright-line: 8 attribute colors in PaceTrendChart deferred to the Recharts slice; only `style={{}}` colors migrated.
- Intentional survivors: `#ffaa44` (LogEntry coach-note) and `#7a9a8a` (WorkoutItem done-state) — no matching token; flagged for a future token decision rather than silently invented.

**Rendered-color changes (exactly two, both pre-approved drift folds):**
- `#0a0a0f` → `THEME.bg` `#08080d` (ErrorFallback ×2)
- `#a0a0b8` → `THEME.muted` `#7e7e9a` (WorkoutTarget)

All other swaps are visually identical (incl. `#888`/`#fff` shorthand → 6-digit expansion).

## Pipeline evidence

Factory chain build → verify → review + validate; Gate 3 approved by Scott.
- Tests: 43 files / 386 tests pass, exit 0. (One 5s timeout observed under concurrent local runs reproduced-away in isolation — documented Drive-checkout flake.)
- Coverage: verified **digit-for-digit identical** pre/post diff via stash-differential coverage runs; per-file 80/80/70 gates (ErrorFallback, WorkoutItem, LoadTooltip, LogEntry) all clear.
- Lint 0 errors; build exit 0.
- Judges: Code Reviewer **APPROVE**; Reality Checker **ship** (no Blockers/Should-fixes); Analyzer all criteria **MET**.

## Next

PR 2c — desktop views (~500 literals: OverviewView, ErgView, RecoveryView, JournalView, MobilityView, StrengthView, CalendarView, LogView, PlanView, ErgLiveView).

🤖 Generated with [Claude Code](https://claude.com/claude-code)