### PR TITLE
fix: live PM5 erg session save writes real schema columns and never loses a session

### DIFF
--- a/coach/SPRINT_BENCHMARK_INTEGRITY.md
+++ b/coach/SPRINT_BENCHMARK_INTEGRITY.md
@@ -1,0 +1,390 @@
+# Sprint Plan: Benchmark Integrity — 2026-08-18 → 2026-09-18 (re-timed)
+
+> **STATUS: GATE 1 — PROPOSED, AWAITING SCOTT'S APPROVAL.**
+> Originally produced 2026-07-16; re-timed 2026-08-18 after the original
+> window elapsed with the gate unanswered. All eight task findings were
+> re-verified against main @ `514520d` (2026-08-18) — every one still holds.
+> Nothing below is committed work: no spec, no code, no GitHub issues exist
+> yet. On approval, each task becomes an issue and runs through the full gated
+> pipeline (`/orchestrate`) individually.
+
+## What changed between 2026-07-16 and 2026-08-18
+
+- **The benchmarks slipped entirely.** The CP retest (session 61, 7/5) was
+  **cancelled**, never rescheduled. No 5k benchmark session exists in the DB.
+  The `anchors` table is untouched since 2026-07-01: `rowing_cp` still 205 W
+  provisional, `bike_ftp` still unvalidated, `current_block` still names the
+  July 8–21 block. A month of benchmark cadence was lost silently — exactly
+  the failure mode T2 below is designed to catch.
+- **The repo moved.** The App.jsx milestone landed (`erg-dashboard.jsx`
+  dissolved); #146/#147/#151/#154 merged (doc sweep, coverage ratchet to
+  68/67/64, `useSessionLog` extraction, THEME tokens); the `npm audit` CI
+  blocker was resolved and the dependabot backlog cleared (2 PRs remain, both
+  green with auto-merge armed). None of this touched the benchmark surface —
+  re-verified by grep on 2026-08-18 (see task list).
+- **Scheduling note (Coach's lane):** T7/T8 need a benchmark to actually
+  happen. Rescheduling the CP retest / 5k is a Coach prescription decision,
+  not a Code task — flagging it here so the dependency is visible.
+
+## Why this sprint, why now
+
+The one capability this app most needs — capturing and trusting a benchmark
+test result — is broken at the point of capture, invisible at the point of
+scheduling, and stale at the point of display:
+
+- **Capture (P1, DB-verified):** the live PM5 save path
+  (`ErgLiveView.jsx:490-491`) still inserts `watts`/`distance` and an ISO
+  date, but `sessions` has only `avg_watts`/`avg_hr`/`distance_m` with text
+  `MM/DD/YY` dates. Zero rows with `source='bluetooth'` or `status='logged'`
+  have ever landed; the offline queue re-inserts the same broken shape. A
+  benchmark rowed against the live view is silently lost.
+- **Scheduling:** no code flags a due/overdue benchmark — which is how the CP
+  retest vanished in July without a trace.
+- **Display:** `trainingConfig.js:148` still hardcodes `cpEstimate: 190`
+  against the live 205 provisional anchor, and `trainingConfig.js:326`
+  derives a static `PACE_ZONES` export from that stale 190. The
+  PENDING→MEASURED panel (`logs.js:454`, `JournalView.jsx:284`) still shows
+  June text; `ergTrend` (`ErgView.jsx:29`) is still a hardcoded array.
+
+This sprint does not touch training-load modeling, the ProgramView refactor
+(#77/#114), or Concept2 import (#56/#116). It is narrowly: **make the
+benchmark land in the database, make its schedule visible, and make its
+result trustworthy on screen.**
+
+## Sprint Goal
+
+By 2026-09-18, a benchmark test performed in the app (CP retest or the 5k)
+reliably reaches the `sessions` table in the correct shape, an
+overdue/upcoming benchmark is visible without Scott having to remember the
+date, and every screen showing a CP/FTP number agrees with the live `anchors`
+value instead of a stale hardcoded one.
+
+**Exit criteria**
+
+- [ ] A session logged via `ErgLiveView` (online or from the offline queue)
+      inserts successfully with correct column names and `MM/DD/YY` date
+      format — verified against the actual schema, with a passing regression
+      test that would have caught the current bug.
+- [ ] The app surfaces at least one visible "benchmark due/overdue" signal,
+      driven by real session/schedule state (not a static string), covering
+      both the cancelled CP retest and the still-unscheduled 5k.
+- [ ] No screen in the app displays a CP/FTP number that contradicts the live
+      `anchors.rowing_cp` value without explicit "as of" framing (includes
+      the static `PACE_ZONES` derivation at `trainingConfig.js:326`).
+- [ ] All capture/display fixes ship as independent PRs, each green on
+      Lint/Test/Build, each with tests co-located per convention, coverage
+      ratchet (now 68/67/64) unaffected or improved.
+- [ ] Nothing added this sprint writes to the `anchors` table from the app —
+      any task that would require that is flagged to Scott as a lane-change
+      decision rather than shipped silently.
+
+---
+
+## Task List
+
+### T1 — Fix live erg session capture (the P1 bug)
+
+**Size: M — Week 1 (no dependencies, ships first)**
+
+**Story:** As Scott, I want a session I complete on the live PM5 view to
+actually save to my training log, so that a rowed benchmark (or any live
+session) isn't silently lost.
+
+**Acceptance criteria:**
+
+1. Given a completed live PM5 session with network available, when I save it,
+   then a row is inserted into `sessions` using the real schema columns
+   (`avg_watts`, `avg_hr`, `distance_m`) — not `watts`/`distance` — and the
+   row appears in the session list within one query refresh.
+2. Given the same save, the `date` field is written as `MM/DD/YY` text,
+   matching every other row in `sessions`, not an ISO `YYYY-MM-DD` string.
+3. Given the device is offline at save time, when connectivity returns, then
+   the queued row drains into `sessions` with the same corrected shape (no
+   separate bug surface from the queue path).
+4. Given the insert fails for a reason other than being offline (e.g. RLS
+   rejection, missing `user_id`), then the row is queued rather than dropped,
+   and the UI communicates a "saved locally, will sync" state rather than
+   claiming success.
+5. Given `summary.avgWatts` or `summary.distance` is `null`/`undefined` (PM5
+   disconnected mid-session or a zero-duration save), then the insert
+   omits/null-safes those fields without throwing.
+6. A test exists asserting the exact row shape passed to
+   `supabase.from('sessions').insert(...)` matches the real column set —
+   regression-proofing this bug class.
+
+**Edge cases:** null PM5 summary fields; RLS rejection vs network failure;
+queue draining twice (idempotency); malformed rows already sitting in the
+local offline queue from before the fix (handle gracefully).
+
+**Out of scope:** Concept2 auto-import (#56), ErgLiveView UI redesign,
+backfilling historical bluetooth data (none exists — greenfield).
+
+---
+
+### T2 — Benchmark due/overdue indicator
+
+**Size: M — Week 1 (independent of T1)**
+
+**Story:** As Scott, I want the app to tell me when a scheduled benchmark test
+(CP retest, 5k, future 2k) is due or overdue, so that a test doesn't silently
+slip the way the CP retest did in July.
+
+**Acceptance criteria:**
+
+1. Given an `EVENT_LADDER` entry with `kind: 'benchmark'` whose date has
+   passed and whose linked calendar session (if any) is `planned`/`cancelled`
+   or has no linked session, a visible "overdue" signal appears (exact
+   surface — banner, Journal panel, or Erg tile — is a Stage 3 design
+   decision).
+2. Given a benchmark entry within the next 7 days, a visible "upcoming"
+   signal appears, distinct from "overdue."
+3. Given today (2026-08-18), the CP revalidation (last attempt cancelled 7/5,
+   anchor still provisional) and the end-of-base 5k (was due ~early Aug, never
+   logged) both show as overdue on first load — these are the concrete cases
+   that must work.
+4. Given a benchmark's linked session is later completed, the signal clears
+   via the normal query-invalidation pattern.
+5. Given `EVENT_LADDER` dates are free-text (`'~Early Aug 26'`), the indicator
+   degrades gracefully ("upcoming, exact date TBD") rather than crashing or
+   mis-flagging.
+
+**Edge cases:** unparseable/approximate dates; benchmark with no linked
+`sessions` row; a `cancelled` linked session must read as NOT done (the July
+retest is the proof case); `MM/DD/YY` text-date comparison; year-on-year
+repeated events — don't double-flag.
+
+**Out of scope:** writes to `anchors`; redesigning `EVENT_LADDER`/`ANNUAL_ARC`
+structures; the ProgramView split (#77/#114) — if the natural surface is
+`ProgramYear.jsx`, prefer a small standalone component to avoid colliding with
+the in-flight split.
+
+---
+
+### T3 — Reconcile displayed CP (190) with live anchor (205)
+
+**Size: S — Week 2**
+
+**Story:** As Scott, I want every screen that shows a CP/FTP number to match
+the current live anchor, so that I'm not making training decisions off a
+stale hardcoded estimate while a newer provisional number exists in the DB.
+
+**Acceptance criteria:**
+
+1. Static copy that currently contradicts the live anchor
+   (`CRITICAL_POWER.cpEstimate = 190` at `trainingConfig.js:148`, the static
+   `PACE_ZONES = derivePaceZones(CRITICAL_POWER.cpEstimate)` export at
+   `trainingConfig.js:326` and its consumers, the `CALIBRATION_STATUS` "190W
+   (untested)" row, `FTP_TEST`'s past-dated copy) is updated, made
+   live-anchor-driven, or explicitly marked historical/superseded.
+2. Given `useAnchors` is loading or unreachable, affected copy shows a neutral
+   "unavailable" state — never a silent fallback to 190.
+3. No new hardcoded numeric CP value is introduced — per the 2026-07-02 Coach
+   decision, CP is read live from `anchors`.
+4. Zero remaining instances of "190" presented as a current CP number in the
+   affected files (kept historical references explicitly labeled).
+
+**Edge cases:** React Query pending vs genuinely null anchor read differently;
+future `confirmed` vs `provisional` status displays correctly without new
+hardcoding; consumers of the static `PACE_ZONES` export must not silently
+diverge from the live `derivePaceZones(cp)` path used in `ErgView`.
+
+**Out of scope:** changing `useAnchors`; wiring CP into TSS/CTL/ATL (own
+decision, see "Not building"); bike FTP parallel cleanup only if trivially the
+same pattern.
+
+---
+
+### T4 — Refresh the Confidence Migration panel (JournalView)
+
+**Size: M — Week 2 (after T3 — same constants surface)**
+
+**Story:** As Scott, I want the PENDING→MEASURED calibration panel in my
+Journal to reflect what's actually true today, so that I stop seeing "CP test
+~Jun 25 PENDING" for a test whose provisional result already exists.
+
+**Acceptance criteria:**
+
+1. Given `rowing_cp` is `status='provisional'` (still true as of 2026-08-18),
+   the corresponding `CONFIDENCE_MIGRATION` entry reflects "provisional
+   result in, pending revalidation" rather than a flat past-dated "PENDING."
+2. The 5k benchmark is referenced by its actual/best-known date, not a
+   hardcoded past date.
+3. Given no anchor data is reachable, the panel falls back to a
+   clearly-labeled last-known state without breaking the render.
+4. `JournalView` tests cover the new live-driven states.
+
+**Edge cases:** unexpected anchor status values; partial freshness (CP updated
+but bike FTP still static — one anchor's freshness must not imply the
+other's).
+
+**Out of scope:** visual redesign of the panel; FTP/bike beyond trivial
+parity.
+
+---
+
+### T5 — Pre-benchmark prep checklist tied to the overdue engine
+
+**Size: S — Week 2/3 boundary (depends on T2)**
+
+**Story:** As Scott, I want the test protocol (fresh, fueled, DF 125, gate
+vitals, separate warmup) surfaced a few days before a benchmark, so that I
+don't invalidate the result by testing under the wrong conditions.
+
+**Acceptance criteria:**
+
+1. Given T2's "upcoming" window triggers (benchmark within 7 days), a protocol
+   checklist appears alongside it, sourced from existing protocol copy (e.g.
+   `FTP_TEST.prereq`, the cancelled session 61's coach_note protocol) — no
+   invented text.
+2. The checklist is dismissible/acknowledgeable (doesn't nag once seen).
+3. With no upcoming benchmark in the window, it doesn't render at all.
+
+**Edge cases:** persistence of dismissed state (simplest that doesn't nag);
+multiple benchmarks in the window at once (CP retest outstanding AND 5k
+approaching) — per-benchmark checklists, not one merged list.
+
+**Out of scope:** a general notifications system; push/out-of-app alerting.
+
+---
+
+### T6 — Wire ergTrend / HR130_POWER / deriveTargets off live data
+
+**Size: L — Week 3 (candidate to split: chart data PR, then target-derivation PR)**
+
+**Story:** As Scott, I want my aerobic trend chart and UT1/UT2 targets to
+reflect my actual logged sessions and the live CP anchor, so that the numbers
+I train against update as I log real data instead of staying frozen on a
+hardcoded snapshot (now three months old).
+
+**Acceptance criteria:**
+
+1. The `ergTrend` chart renders from live `useErgSessions()` data rather than
+   the hardcoded array at `ErgView.jsx:29`.
+2. `deriveTargets()` derives UT1/UT2 targets from live data (recent sessions
+   and/or `derivePaceZones(cp)`) — the two derivation paths must agree.
+3. With fewer than N live points, chart/targets show a labeled "insufficient
+   data" state rather than an empty or misleading render.
+4. Sessions with null `avg_watts`/`avg_hr` are excluded, not corrupting.
+5. `ErgView` and `analysis.js` tests cover live-driven behavior including
+   insufficient-data and null-field cases.
+
+**Edge cases:** sparse data (rowing largely paused since late July — the
+insufficient-data state will be the FIRST state users see, not an edge);
+mixed sources (`portal`, `coach`, `concept2`) with different field
+completeness; query windowing if volume grows.
+
+**Out of scope:** TSS/CTL/ATL model changes (stays sRPE-only this sprint); any
+write back to `anchors`.
+
+---
+
+### T7 — Populate `POWER_DURATION.actualW` from the landed benchmark
+
+**Size: M — Week 4 (depends on T1 + a logged benchmark session; Coach must
+schedule the test — flagged above)**
+
+**Story:** As Scott, I want my actual 5k result to show up next to the
+predicted-watts table, so that I can see the test versus the projection
+instead of a table whose "actual" column has always read null.
+
+**Acceptance criteria:**
+
+1. A completed session matching a `POWER_DURATION` format (label/distance/
+   duration heuristic, display-side only) populates that row's `actualW` from
+   logged `avg_watts`.
+2. Formats with no matching session keep showing null/dash — no fabricated
+   data.
+3. Ambiguous matches resolve deterministically (most recent wins), testably.
+4. Verified against a seeded fixture, not blocked on the real benchmark
+   happening on schedule (July proved slippage is the norm, not the
+   exception).
+
+**Edge cases:** no match at all (must not crash); multiple candidates;
+source-agnostic matching (`concept2`/`coach` rows count).
+
+**Out of scope:** writing results back to `anchors`/`sessions` — read-only
+display join. Auto-updating calibration from results = lane-change decision
+for Scott, raised explicitly, never assumed.
+
+---
+
+### T8 — Post-benchmark calibration tier upgrade pass (display only)
+
+**Size: M — Week 4 (depends on T3, T4, T7 — the capstone)**
+
+**Story:** As Scott, I want the calibration confidence panels to actually
+upgrade from PENDING to MEASURED once the 5k and CP revalidation land, so
+that the "upgrades as benchmarks land" promise in the UI is true instead of
+static copy.
+
+**Acceptance criteria:**
+
+1. Given a logged benchmark (via T1's fixed path) and/or a Coach-side anchor
+   status change (`provisional` → `confirmed`), the relevant
+   `CALIBRATION_STATUS` rows reflect the upgraded tier without a manual code
+   edit.
+2. With no benchmark landed, rows stay at their current accurate tier — no
+   premature upgrades.
+3. Unexpected anchor statuses fail safe to the lower-confidence display.
+4. No writes to `anchors` or `coach_log` — anchor status stays Coach/MCP-owned;
+   this only makes display logic responsive to what's already live.
+
+**Edge cases:** benchmark landed but anchor not yet updated by Coach (show
+partial progress, not all-or-nothing flip); late-sprint landing → verify
+against a seeded fixture like T7.
+
+**Out of scope:** changing who writes `anchors`; recalibrating TSS/CTL/ATL off
+new CP; mobile calibration surface parity (zero benchmark UI on mobile today —
+separate product decision).
+
+---
+
+## Sequencing Summary (weeks from 2026-08-18)
+
+| Week | Task | Size | Dependencies |
+|---|---|---|---|
+| 1 (Aug 18–24) | T1 — Fix live capture bug | M | none |
+| 1 (Aug 18–24) | T2 — Overdue/upcoming benchmark indicator | M | none |
+| 2 (Aug 25–31) | T3 — Reconcile 190 vs live 205 display | S | none |
+| 2 (Aug 25–31) | T4 — Refresh Confidence Migration panel | M | T3 |
+| 2/3 boundary | T5 — Pre-benchmark prep checklist | S | T2 |
+| 3 (Sep 1–7) | T6 — Live-wire ergTrend / HR130 / deriveTargets | L (splittable) | none |
+| 4 (Sep 8–18) | T7 — Populate actualW from landed benchmark | M | T1 + logged benchmark |
+| 4 (Sep 8–18) | T8 — Post-benchmark tier upgrade pass | M | T3, T4, T7 |
+
+**Reasoning:** T1 and T2 must be true before the next benchmark attempt — a
+broken capture path or an invisible schedule are the failure modes that lose
+the whole benchmark (July demonstrated the second one for real). T3–T5 are
+trust/visibility fixes that should also precede the test. T6–T8 land as real
+benchmark data starts flowing, with T8 last.
+
+## What This Sprint Is Not Building
+
+| Gap | Why deferred | Revisit condition |
+|---|---|---|
+| Concept2 auto-import | Scoped to Sprint 4 (#56/#116) | Sprint 4 kicks off |
+| ProgramView further split | Owned by #77/#114 | #114 sprint |
+| TSS/CTL/ATL incorporating CP | Load-model change, not display; needs its own decision | Scott asks for CP-driven load modeling |
+| App writing to `anchors` | Lane boundary — Coach/MCP owns anchor writes | Only on Scott's explicit lane-change authorization |
+| Mobile benchmark/calibration surface | Zero coverage today; real gap, undecided scope | Own opportunity assessment if Scott wants parity |
+| Rescheduling the CP retest / 5k | Coach's prescription lane, not a Code task | Scott + Coach set the date; T2/T5 then surface it |
+
+---
+
+## Key file references (re-verified on main @ 514520d, 2026-08-18)
+
+- `web/src/views/ErgLiveView.jsx:490-491` — the T1 bug (`watts`/`distance` +
+  ISO date)
+- `web/src/hooks/useOfflineQueue.js` — queue drain re-inserts the same shape
+- `web/src/hooks/useAnchors.js` — live anchor read (no write path, by design)
+- `web/src/constants/trainingConfig.js:148` — stale `cpEstimate: 190`;
+  `:326` — static `PACE_ZONES` derived from it; `:44-206` —
+  `CALIBRATION_STATUS`, `POWER_DURATION` (actualW always null), `FTP_TEST`
+- `web/src/views/ErgView.jsx:29` (hardcoded ergTrend), `:222-223` (live CP),
+  ~`:1083-1140` (calibration panel)
+- `web/src/views/JournalView.jsx:284` — Confidence Migration panel render
+- `web/src/constants/logs.js:454` — `CONFIDENCE_MIGRATION`
+- `web/src/constants/schedule.js:313-386` — `EVENT_LADDER`
+- `web/src/constants/program.js:347-411` — `ANNUAL_ARC`
+- `web/src/views/program/ProgramYear.jsx` — renders schedule verbatim
+  (mid-refactor, #77)

--- a/web/src/components/LogSessionForm.jsx
+++ b/web/src/components/LogSessionForm.jsx
@@ -2,17 +2,11 @@ import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
 import { THEME } from '../constants/theme.js';
+import { toLogDate } from '../utils/dateFormat.js';
 
 export default function LogSessionForm({ onSaved }) {
   const queryClient = useQueryClient();
-  const today = new Date();
-  const todayKey =
-    today.getMonth() +
-    1 +
-    '/' +
-    today.getDate() +
-    '/' +
-    String(today.getFullYear()).slice(-2);
+  const todayKey = toLogDate(new Date());
   const [open, setOpen] = useState(false);
   const [date, setDate] = useState(todayKey);
   const [label, setLabel] = useState('');

--- a/web/src/hooks/__tests__/useOfflineQueue.test.js
+++ b/web/src/hooks/__tests__/useOfflineQueue.test.js
@@ -12,11 +12,18 @@ vi.mock('../../supabaseClient', () => ({
   },
 }));
 
-import { enqueueSession, useOfflineQueue } from '../useOfflineQueue';
+import {
+  enqueueSession,
+  useOfflineQueue,
+  normalizeQueuedSession,
+} from '../useOfflineQueue';
 
 const QUEUE_KEY = 'erg_pending_sessions';
 
-beforeEach(() => {
+beforeEach(async () => {
+  // drainQueue holds a module-level in-flight guard; let any drain started by
+  // the previous test settle before resetting shared state.
+  await new Promise((resolve) => setTimeout(resolve, 0));
   localStorage.clear();
   insertMock.mockReset();
   getUserMock.mockReset();
@@ -70,7 +77,9 @@ describe('useOfflineQueue drainQueue user_id backfill', () => {
 
   it('retains rows that fail to insert so they can be retried', async () => {
     getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
-    insertMock.mockResolvedValue({ error: { message: 'network' } });
+    insertMock.mockResolvedValue({
+      error: { code: '08006', message: 'network' },
+    });
     enqueueSession({ date: '2026-06-25', type: 'erg' });
 
     renderHook(() => useOfflineQueue());
@@ -78,5 +87,151 @@ describe('useOfflineQueue drainQueue user_id backfill', () => {
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     const remaining = JSON.parse(localStorage.getItem(QUEUE_KEY));
     expect(remaining).toHaveLength(1);
+  });
+});
+
+describe('normalizeQueuedSession', () => {
+  it('renames legacy columns that do not exist on the sessions table', () => {
+    expect(
+      normalizeQueuedSession({
+        date: '2026-06-25',
+        watts: 180,
+        distance: 5000,
+        duration: 20,
+      })
+    ).toEqual({
+      date: '6/25/26',
+      avg_watts: 180,
+      distance_m: 5000,
+      duration: '20',
+    });
+  });
+
+  it('preserves _queuedAt and unknown keys', () => {
+    const out = normalizeQueuedSession({
+      _queuedAt: 1234,
+      srpe: 5,
+      somethingNew: 'keep me',
+      watts: 200,
+    });
+    expect(out._queuedAt).toBe(1234);
+    expect(out.srpe).toBe(5);
+    expect(out.somethingNew).toBe('keep me');
+    expect(out.avg_watts).toBe(200);
+  });
+
+  it('is idempotent', () => {
+    const once = normalizeQueuedSession({
+      date: '2026-06-25',
+      watts: 180,
+      distance: 5000,
+      duration: 20,
+    });
+    expect(normalizeQueuedSession(once)).toEqual(once);
+  });
+
+  it('does not clobber a modern value with the legacy one', () => {
+    const out = normalizeQueuedSession({
+      watts: 999,
+      avg_watts: 180,
+      distance: 999,
+      distance_m: 5000,
+    });
+    expect(out.avg_watts).toBe(180);
+    expect(out.distance_m).toBe(5000);
+    expect(out).not.toHaveProperty('watts');
+    expect(out).not.toHaveProperty('distance');
+  });
+
+  it('leaves a missing date alone rather than inventing today', () => {
+    expect(normalizeQueuedSession({ type: 'erg' })).toEqual({ type: 'erg' });
+  });
+});
+
+describe('useOfflineQueue legacy-row migration', () => {
+  it('drains a legacy-shaped row using the real sessions columns', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    enqueueSession({
+      date: '2026-06-25',
+      type: 'erg',
+      label: 'Erg Session',
+      watts: 180,
+      distance: 5000,
+    });
+
+    renderHook(() => useOfflineQueue());
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
+    const row = insertMock.mock.calls[0][0];
+    expect(row.avg_watts).toBe(180);
+    expect(row.distance_m).toBe(5000);
+    expect(row.date).toBe('6/25/26');
+    expect(row).not.toHaveProperty('watts');
+    expect(row).not.toHaveProperty('distance');
+  });
+
+  it('rewrites storage in the normalized shape when the drain fails', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    insertMock.mockResolvedValue({
+      error: { code: '08006', message: 'network' },
+    });
+    enqueueSession({
+      date: '2026-06-25',
+      type: 'erg',
+      watts: 180,
+      distance: 5000,
+    });
+
+    renderHook(() => useOfflineQueue());
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
+    const [remaining] = JSON.parse(localStorage.getItem(QUEUE_KEY));
+    expect(remaining.avg_watts).toBe(180);
+    expect(remaining.distance_m).toBe(5000);
+    expect(remaining.date).toBe('6/25/26');
+    expect(remaining).not.toHaveProperty('watts');
+    expect(remaining._queuedAt).toEqual(expect.any(Number));
+  });
+
+  it('drops a row the server rejects as a duplicate', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    insertMock.mockResolvedValue({
+      error: { code: '23505', message: 'duplicate key value violates …' },
+    });
+    enqueueSession({
+      date: '6/25/26',
+      type: 'erg',
+      label: 'Erg Session 07:15',
+    });
+
+    const { result } = renderHook(() => useOfflineQueue());
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.pending).toBe(0));
+    expect(localStorage.getItem(QUEUE_KEY)).toBe('[]');
+  });
+
+  it('inserts each row at most once when two drains race', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    let release;
+    insertMock.mockImplementation(
+      () => new Promise((resolve) => (release = () => resolve({ error: null })))
+    );
+    enqueueSession({
+      date: '6/25/26',
+      type: 'erg',
+      label: 'Erg Session 07:15',
+    });
+
+    renderHook(() => useOfflineQueue());
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
+
+    // A second trigger while the first drain is still awaiting the insert.
+    window.dispatchEvent(new window.Event('online'));
+    await Promise.resolve();
+    release();
+
+    await waitFor(() => expect(localStorage.getItem(QUEUE_KEY)).toBe('[]'));
+    expect(insertMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/hooks/__tests__/usePM5.test.js
+++ b/web/src/hooks/__tests__/usePM5.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock the BLE service so the real hook logic (buildSummary, finish, reset)
+// runs against controllable callbacks instead of hardware.
+let rowingStatusCallback = null;
+const connectToPM5Mock = vi.fn();
+const disconnectPM5Mock = vi.fn();
+
+vi.mock('../../services/pm5Bluetooth', async () => {
+  const actual = await vi.importActual('../../services/pm5Bluetooth');
+  return {
+    ...actual,
+    connectToPM5: (...args) => connectToPM5Mock(...args),
+    subscribeToRowingStatus: async (_char, cb) => {
+      rowingStatusCallback = cb;
+    },
+    subscribeToWorkoutEnd: async () => {},
+    disconnectPM5: (...args) => disconnectPM5Mock(...args),
+  };
+});
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: () => false },
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: { addListener: vi.fn() },
+}));
+
+import { usePM5 } from '../usePM5';
+import { WorkoutState } from '../../services/pm5Bluetooth';
+
+const fakeDevice = { addEventListener: vi.fn(), gatt: { connected: true } };
+
+function activeSample(overrides = {}) {
+  return {
+    workoutState: WorkoutState.ACTIVE,
+    watts: 200,
+    pace500: 12000,
+    strokeRate: 22,
+    elapsedTime: 600,
+    elapsedStr: '10:00',
+    distance: 2500,
+    calories: 90,
+    ...overrides,
+  };
+}
+
+async function connectedHook() {
+  const rendered = renderHook(() => usePM5());
+  connectToPM5Mock.mockResolvedValue({
+    device: fakeDevice,
+    chars: { rowingStatus: {}, workoutSummary: {} },
+  });
+  await act(async () => {
+    await rendered.result.current.connect();
+  });
+  return rendered;
+}
+
+beforeEach(() => {
+  rowingStatusCallback = null;
+  connectToPM5Mock.mockReset();
+  disconnectPM5Mock.mockReset();
+});
+
+describe('usePM5 finish() — manual END rescue', () => {
+  it('builds the summary from the last-known metrics instead of discarding the session', async () => {
+    const { result } = await connectedHook();
+
+    await act(async () => {
+      rowingStatusCallback(activeSample({ watts: 180, elapsedTime: 300 }));
+      rowingStatusCallback(
+        activeSample({ watts: 220, elapsedTime: 600, distance: 2600 })
+      );
+    });
+    expect(result.current.status).toBe('rowing');
+
+    await act(async () => {
+      result.current.finish();
+    });
+
+    expect(result.current.status).toBe('finished');
+    expect(result.current.summary).toEqual({
+      distance: 2600,
+      elapsedTime: 600,
+      elapsedStr: '10:00',
+      avgWatts: 200,
+      avgPace: 12000,
+      avgSpm: 22,
+      maxWatts: 220,
+      calories: 90,
+    });
+  });
+
+  it('null-safes a finish with no metrics ever received (PM5 dead before first packet)', async () => {
+    const { result } = await connectedHook();
+
+    await act(async () => {
+      result.current.finish();
+    });
+
+    expect(result.current.status).toBe('finished');
+    expect(result.current.summary).toEqual({
+      distance: 0,
+      elapsedTime: 0,
+      elapsedStr: '--:--',
+      avgWatts: 0,
+      avgPace: 0,
+      avgSpm: 0,
+      maxWatts: 0,
+      calories: 0,
+    });
+  });
+
+  it('a FINISHED status packet builds the same summary shape automatically', async () => {
+    const { result } = await connectedHook();
+
+    await act(async () => {
+      rowingStatusCallback(activeSample());
+      rowingStatusCallback(
+        activeSample({
+          workoutState: WorkoutState.FINISHED,
+          elapsedTime: 1200,
+          elapsedStr: '20:00',
+          distance: 5000,
+        })
+      );
+    });
+
+    expect(result.current.status).toBe('finished');
+    expect(result.current.summary.distance).toBe(5000);
+    expect(result.current.summary.elapsedTime).toBe(1200);
+  });
+
+  it('reset() clears the summary and disconnects', async () => {
+    const { result } = await connectedHook();
+
+    await act(async () => {
+      rowingStatusCallback(activeSample());
+      result.current.finish();
+    });
+    expect(result.current.summary).not.toBeNull();
+
+    await act(async () => {
+      result.current.reset();
+    });
+
+    expect(result.current.summary).toBeNull();
+    expect(result.current.status).toBe('idle');
+    expect(disconnectPM5Mock).toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useOfflineQueue.js
+++ b/web/src/hooks/useOfflineQueue.js
@@ -2,15 +2,45 @@ import { useState, useEffect } from 'react';
 import { Capacitor } from '@capacitor/core';
 import { Network } from '@capacitor/network';
 import { supabase } from '../supabaseClient';
+import { toLogDate } from '../utils/dateFormat.js';
 
 const QUEUE_KEY = 'erg_pending_sessions';
 
+// Rows queued by older builds carry column names that do not exist on
+// `sessions` (`watts`, `distance`) and ISO/numeric shapes the table rejects, so
+// every drain failed forever. Normalising on read means a stale queue heals
+// itself the first time it is drained, without a migration.
+export function normalizeQueuedSession(row) {
+  if (!row || typeof row !== 'object') return row;
+  const out = { ...row };
+
+  if ('watts' in out) {
+    if (!('avg_watts' in out)) out.avg_watts = out.watts;
+    delete out.watts;
+  }
+  if ('distance' in out) {
+    if (!('distance_m' in out)) out.distance_m = out.distance;
+    delete out.distance;
+  }
+  if (out.date) out.date = toLogDate(out.date);
+  if (typeof out.duration === 'number') out.duration = String(out.duration);
+
+  return out;
+}
+
 function readQueue() {
   try {
-    return JSON.parse(localStorage.getItem(QUEUE_KEY) || '[]');
+    const raw = JSON.parse(localStorage.getItem(QUEUE_KEY) || '[]');
+    return Array.isArray(raw) ? raw.map(normalizeQueuedSession) : [];
   } catch {
     return [];
   }
+}
+
+// Postgres unique_violation on sessions' UNIQUE(date, label): the row is
+// already in the table, so a retry can never succeed — treat it as delivered.
+function isDuplicate(error) {
+  return error?.code === '23505' || /duplicate key/i.test(error?.message || '');
 }
 
 function writeQueue(items) {
@@ -23,21 +53,31 @@ export function enqueueSession(session) {
   writeQueue(q);
 }
 
+// Both the `online` listener and the mount-time sync can fire in the same tick;
+// without this guard each row is inserted twice.
+let draining = false;
+
 async function drainQueue() {
-  const q = readQueue();
-  if (q.length === 0) return;
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  const failed = [];
-  for (const session of q) {
-    const { _queuedAt, ...rest } = session;
-    const row = { ...rest, user_id: rest.user_id ?? user?.id };
-    const { error } = await supabase.from('sessions').insert(row);
-    if (error) failed.push(session);
+  if (draining) return 0;
+  draining = true;
+  try {
+    const q = readQueue();
+    if (q.length === 0) return 0;
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const failed = [];
+    for (const session of q) {
+      const { _queuedAt, ...rest } = session;
+      const row = { ...rest, user_id: rest.user_id ?? user?.id };
+      const { error } = await supabase.from('sessions').insert(row);
+      if (error && !isDuplicate(error)) failed.push(session);
+    }
+    writeQueue(failed);
+    return q.length - failed.length;
+  } finally {
+    draining = false;
   }
-  writeQueue(failed);
-  return q.length - failed.length;
 }
 
 export function useOfflineQueue() {

--- a/web/src/hooks/usePM5.js
+++ b/web/src/hooks/usePM5.js
@@ -117,6 +117,12 @@ export function usePM5() {
     setStatus('finished');
   }
 
+  // Manual END: the PM5 never sends a FINISHED packet, so build the summary
+  // from the last metrics we saw rather than dropping the session on the floor.
+  function finish() {
+    buildSummary(metrics || {});
+  }
+
   const disconnect = useCallback(() => {
     disconnectPM5(deviceRef.current);
     deviceRef.current = null;
@@ -130,5 +136,14 @@ export function usePM5() {
     setError(null);
   }
 
-  return { status, metrics, summary, error, connect, disconnect, reset };
+  return {
+    status,
+    metrics,
+    summary,
+    error,
+    connect,
+    disconnect,
+    reset,
+    finish,
+  };
 }

--- a/web/src/utils/__tests__/dateFormat.test.js
+++ b/web/src/utils/__tests__/dateFormat.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { toISODate } from '../dateFormat.js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { toISODate, toLogDate } from '../dateFormat.js';
 
 describe('toISODate', () => {
   it('normalizes "7/9/26" to 2026-07-09', () => {
@@ -30,5 +30,66 @@ describe('toISODate', () => {
   it('produces ISO output that sorts correctly where raw text did not', () => {
     expect(toISODate('6/12/26') < toISODate('6/2/26')).toBe(false);
     expect(toISODate('6/2/26') < toISODate('6/12/26')).toBe(true);
+  });
+});
+
+function localISO(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate()
+  ).padStart(2, '0')}`;
+}
+
+describe('toLogDate', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    delete globalThis.process.env.TZ;
+  });
+
+  it('formats a Date as unpadded M/D/YY', () => {
+    expect(toLogDate(new Date(2026, 7, 18))).toBe('8/18/26');
+  });
+
+  it('does not zero-pad a two-digit month with a single-digit day', () => {
+    expect(toLogDate(new Date(2026, 11, 1))).toBe('12/1/26');
+  });
+
+  it('converts an ISO date string to M/D/YY', () => {
+    expect(toLogDate('2026-08-18')).toBe('8/18/26');
+    expect(toLogDate('2026-12-01')).toBe('12/1/26');
+  });
+
+  it('passes M/D/YY through unchanged and is idempotent', () => {
+    expect(toLogDate('8/18/26')).toBe('8/18/26');
+    expect(toLogDate(toLogDate('8/18/26'))).toBe('8/18/26');
+    expect(toLogDate(toLogDate(new Date(2026, 7, 18)))).toBe('8/18/26');
+  });
+
+  it('falls back to today for null, undefined and unparseable input', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 18, 9, 0));
+    expect(toLogDate(null)).toBe('8/18/26');
+    expect(toLogDate(undefined)).toBe('8/18/26');
+    expect(toLogDate('')).toBe('8/18/26');
+    expect(toLogDate('garbage')).toBe('8/18/26');
+    expect(toLogDate(new Date('nope'))).toBe('8/18/26');
+  });
+
+  it('round-trips through toISODate back to the local ISO date', () => {
+    for (const d of [
+      new Date(2026, 0, 1),
+      new Date(2026, 7, 18),
+      new Date(2026, 11, 31),
+    ]) {
+      expect(toISODate(toLogDate(d))).toBe(localISO(d));
+    }
+  });
+
+  it('uses the local calendar day, not the UTC one, late at night', () => {
+    globalThis.process.env.TZ = 'America/New_York';
+    // 2026-08-19T03:30Z is still 2026-08-18 23:30 in New York. A UTC-based
+    // implementation would file this session against the wrong day.
+    const lateNight = new Date(Date.UTC(2026, 7, 19, 3, 30));
+    expect(lateNight.toISOString().slice(0, 10)).toBe('2026-08-19');
+    expect(toLogDate(lateNight)).toBe('8/18/26');
   });
 });

--- a/web/src/utils/dateFormat.js
+++ b/web/src/utils/dateFormat.js
@@ -18,3 +18,33 @@ export function toISODate(value) {
 
   return '';
 }
+
+function localLogDate(d) {
+  return `${d.getMonth() + 1}/${d.getDate()}/${String(d.getFullYear()).slice(-2)}`;
+}
+
+// Inverse of toISODate: produces the unpadded "M/D/YY" text that sessions.date
+// stores (verified against production — 92/92 rows are unpadded). Accepts a
+// Date, an ISO "YYYY-MM-DD" string, or an already-"M/D/YY" string (idempotent);
+// anything unparseable falls back to today. Always reads LOCAL calendar fields
+// — toISOString() would shift the day either side of midnight in a non-UTC zone
+// and file the session against the wrong date.
+export function toLogDate(value) {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime())
+      ? localLogDate(new Date())
+      : localLogDate(value);
+  }
+
+  const s = value == null ? '' : String(value).trim();
+
+  if (/^\d{1,2}\/\d{1,2}\/\d{2}$/.test(s)) return s;
+
+  const iso = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (iso) {
+    const [, yyyy, mo, day] = iso;
+    return `${Number(mo)}/${Number(day)}/${yyyy.slice(2)}`;
+  }
+
+  return localLogDate(new Date());
+}

--- a/web/src/views/ErgLiveView.jsx
+++ b/web/src/views/ErgLiveView.jsx
@@ -687,7 +687,10 @@ export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
       <SummaryScreen
         summary={summary}
         onSave={saveSession}
-        onDiscard={reset}
+        onDiscard={() => {
+          setSaveState('idle');
+          reset();
+        }}
         onDone={done}
         saveState={saveState}
       />

--- a/web/src/views/ErgLiveView.jsx
+++ b/web/src/views/ErgLiveView.jsx
@@ -5,8 +5,9 @@ import { useOfflineQueue } from '../hooks/useOfflineQueue';
 import { supabase } from '../supabaseClient';
 import LiveMetric from '../components/LiveMetric';
 import WorkoutTarget from '../components/WorkoutTarget';
-import { parsePace } from '../services/pm5Bluetooth';
+import { parsePace, formatElapsed } from '../services/pm5Bluetooth';
 import { THEME } from '../constants/theme.js';
+import { toISODate, toLogDate } from '../utils/dateFormat.js';
 
 const C = {
   bg: THEME.bg,
@@ -34,7 +35,13 @@ const SRPE_GUIDE = [
 ];
 
 // ── SCREEN A: Connect ─────────────────────────────────────────────
-function ConnectScreen({ onConnect, connecting, error, todaySession }) {
+function ConnectScreen({
+  onConnect,
+  connecting,
+  error,
+  todaySession,
+  pending,
+}) {
   return (
     <div
       style={{
@@ -73,6 +80,21 @@ function ConnectScreen({ onConnect, connecting, error, todaySession }) {
       {todaySession && (
         <div style={{ width: '100%', maxWidth: 420 }}>
           <WorkoutTarget session={todaySession} />
+        </div>
+      )}
+
+      {pending > 0 && (
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: 2,
+            color: C.gold,
+            border: `1px solid ${C.gold}`,
+            borderRadius: 6,
+            padding: '6px 12px',
+          }}
+        >
+          {pending} PENDING SYNC
         </div>
       )}
 
@@ -275,11 +297,11 @@ function RowingScreen({ metrics, status, todaySession, onEnd }) {
 }
 
 // ── SCREEN C: Session Summary + Save ─────────────────────────────
-function SummaryScreen({ summary, onSave, onDiscard, saving }) {
+function SummaryScreen({ summary, onSave, onDiscard, onDone, saveState }) {
   const [srpe, setSrpe] = useState(5);
   const [notes, setNotes] = useState('');
-
-  const todayStr = new Date().toISOString().slice(0, 10);
+  const saving = saveState === 'saving';
+  const settled = saveState === 'saved' || saveState === 'queued';
 
   return (
     <div
@@ -422,91 +444,216 @@ function SummaryScreen({ summary, onSave, onDiscard, saving }) {
         />
       </div>
 
-      {/* Actions */}
-      <div style={{ display: 'flex', gap: 12 }}>
-        <button
-          onClick={() => onSave({ srpe, notes, date: todayStr })}
-          disabled={saving}
+      {/* Outcome — the session stays on screen until DONE is pressed, so a
+          failed save can never be mistaken for a successful one. */}
+      {saveState === 'saved' && (
+        <div
           style={{
-            flex: 1,
+            fontSize: 12,
+            letterSpacing: 2,
+            color: C.accent,
+            border: `1px solid ${C.accent}`,
+            borderRadius: 8,
+            padding: '12px 16px',
+            textAlign: 'center',
+          }}
+        >
+          SAVED TO LOG
+        </div>
+      )}
+      {saveState === 'queued' && (
+        <div
+          style={{
+            fontSize: 12,
+            letterSpacing: 2,
+            color: C.gold,
+            border: `1px solid ${C.gold}`,
+            borderRadius: 8,
+            padding: '12px 16px',
+            textAlign: 'center',
+          }}
+        >
+          SAVED LOCALLY — WILL SYNC
+        </div>
+      )}
+      {saveState === 'failed' && (
+        <div
+          style={{
+            fontSize: 12,
+            letterSpacing: 1,
+            color: C.err,
+            border: `1px solid ${C.err}`,
+            borderRadius: 8,
+            padding: '12px 16px',
+            textAlign: 'center',
+            lineHeight: 1.6,
+          }}
+        >
+          SAVE FAILED — NOT STORED
+          <br />
+          <span style={{ letterSpacing: 0, fontSize: 11 }}>
+            Device storage is full. Free some space, then tap SAVE SESSION
+            again.
+          </span>
+        </div>
+      )}
+
+      {/* Actions */}
+      {settled ? (
+        <button
+          onClick={onDone}
+          style={{
             padding: '14px',
             fontSize: 13,
             fontWeight: 700,
             letterSpacing: 1,
-            background: saving ? C.border : C.accent,
+            background: C.accent,
             color: C.bg,
             border: 'none',
             borderRadius: 8,
-            cursor: saving ? 'default' : 'pointer',
-            fontFamily: 'inherit',
-          }}
-        >
-          {saving ? 'SAVING…' : 'SAVE SESSION'}
-        </button>
-        <button
-          onClick={onDiscard}
-          style={{
-            padding: '14px 20px',
-            fontSize: 12,
-            letterSpacing: 1,
-            background: 'transparent',
-            border: `1px solid ${C.border}`,
-            borderRadius: 8,
-            color: C.muted,
             cursor: 'pointer',
             fontFamily: 'inherit',
           }}
         >
-          DISCARD
+          DONE
         </button>
-      </div>
+      ) : (
+        <div style={{ display: 'flex', gap: 12 }}>
+          <button
+            onClick={() => onSave({ srpe, notes })}
+            disabled={saving}
+            style={{
+              flex: 1,
+              padding: '14px',
+              fontSize: 13,
+              fontWeight: 700,
+              letterSpacing: 1,
+              background: saving ? C.border : C.accent,
+              color: C.bg,
+              border: 'none',
+              borderRadius: 8,
+              cursor: saving ? 'default' : 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            {saving ? 'SAVING…' : 'SAVE SESSION'}
+          </button>
+          <button
+            onClick={onDiscard}
+            style={{
+              padding: '14px 20px',
+              fontSize: 12,
+              letterSpacing: 1,
+              background: 'transparent',
+              border: `1px solid ${C.border}`,
+              borderRadius: 8,
+              color: C.muted,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            DISCARD
+          </button>
+        </div>
+      )}
     </div>
   );
 }
 
 // ── MAIN EXPORT ───────────────────────────────────────────────────
-export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
-  const { status, metrics, summary, error, connect, reset } = usePM5();
-  const { addToQueue } = useOfflineQueue();
-  const queryClient = useQueryClient();
-  const [saving, setSaving] = useState(false);
+// Postgres unique_violation on sessions' UNIQUE(date, label). The row is
+// already in the table, so this is a successful save, not a failure — queueing
+// it would guarantee a permanently undrainable entry.
+function isDuplicate(dbError) {
+  return (
+    dbError?.code === '23505' || /duplicate key/i.test(dbError?.message || '')
+  );
+}
 
-  const todayStr = new Date().toISOString().slice(0, 10);
+export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
+  const { status, metrics, summary, error, connect, reset, finish } = usePM5();
+  const { addToQueue, pending } = useOfflineQueue();
+  const queryClient = useQueryClient();
+  const [saveState, setSaveState] = useState('idle');
+  // idle | saving | saved | queued | failed
+
+  // sessions.date is text "M/D/YY", so both sides are normalised to ISO before
+  // comparing. `_isErg` is the raw-type flag from useSessionLog — `type` has
+  // already been through normType() by then and reads "Z2 Aerobic", never 'erg'.
+  const todayISO = toISODate(toLogDate(new Date()));
   const todaySession =
-    plannedSessions.find((s) => s.date === todayStr && s.type === 'erg') ||
+    plannedSessions.find((s) => s._isErg && toISODate(s.date) === todayISO) ||
     null;
 
-  async function saveSession({ srpe, notes, date }) {
-    setSaving(true);
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+  async function saveSession({ srpe, notes }) {
+    setSaveState('saving');
+
+    const now = new Date();
+    const hhmm = `${String(now.getHours()).padStart(2, '0')}:${String(
+      now.getMinutes()
+    ).padStart(2, '0')}`;
+
+    let user = null;
+    let authFailed = false;
+    try {
+      const { data } = await supabase.auth.getUser();
+      user = data?.user ?? null;
+    } catch {
+      authFailed = true;
+    }
+
     const row = {
-      date,
+      date: toLogDate(now),
       type: 'erg',
-      label: todaySession?.label ?? 'Erg Session',
-      duration: Math.round((summary.elapsedTime || 0) / 60),
+      // The time suffix keeps UNIQUE(date, label) satisfied for a second
+      // session on the same day. Computed once here so it stays stable if the
+      // row goes to the offline queue.
+      label: `${todaySession?.label ?? 'Erg Session'} ${hhmm}`,
+      duration: formatElapsed(summary.elapsedTime || 0),
       srpe,
-      watts: summary.avgWatts,
-      distance: summary.distance,
+      // `||` not `??` — the PM5 reports 0 when a field was never measured.
+      distance_m: summary.distance || null,
+      avg_watts: summary.avgWatts || null,
       status: 'logged',
       source: 'bluetooth',
       exercises: notes ? [{ name: 'Notes', notes }] : [],
       user_id: user?.id,
     };
 
-    if (navigator.onLine) {
-      const { error: dbError } = await supabase.from('sessions').insert(row);
-      if (dbError) {
+    const queue = () => {
+      try {
         addToQueue(row);
+        setSaveState('queued');
+      } catch {
+        // localStorage quota exceeded — the row is nowhere. Say so instead of
+        // claiming a save.
+        setSaveState('failed');
       }
-    } else {
-      addToQueue(row);
+    };
+
+    if (authFailed || !navigator.onLine) {
+      queue();
+      return;
     }
 
-    queryClient.invalidateQueries({ queryKey: ['sessions'] });
-    queryClient.invalidateQueries({ queryKey: ['erg-sessions'] });
-    setSaving(false);
+    let dbError;
+    try {
+      ({ error: dbError } = await supabase.from('sessions').insert(row));
+    } catch (err) {
+      dbError = err;
+    }
+
+    if (!dbError || isDuplicate(dbError)) {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      queryClient.invalidateQueries({ queryKey: ['erg-sessions'] });
+      setSaveState('saved');
+    } else {
+      queue();
+    }
+  }
+
+  function done() {
+    setSaveState('idle');
     reset();
     if (onSessionSaved) onSessionSaved();
   }
@@ -518,6 +665,7 @@ export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
         connecting={false}
         error={error}
         todaySession={todaySession}
+        pending={pending}
       />
     );
   }
@@ -529,6 +677,7 @@ export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
         connecting={true}
         error={null}
         todaySession={todaySession}
+        pending={pending}
       />
     );
   }
@@ -539,7 +688,8 @@ export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
         summary={summary}
         onSave={saveSession}
         onDiscard={reset}
-        saving={saving}
+        onDone={done}
+        saveState={saveState}
       />
     );
   }
@@ -549,12 +699,7 @@ export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
       metrics={metrics}
       status={status}
       todaySession={todaySession}
-      onEnd={() => {
-        // Manual end — build summary from last known metrics
-        if (metrics) {
-          reset();
-        }
-      }}
+      onEnd={finish}
     />
   );
 }

--- a/web/src/views/__tests__/ErgLiveView.test.jsx
+++ b/web/src/views/__tests__/ErgLiveView.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -7,8 +7,10 @@ const insertMock = vi.fn();
 const getUserMock = vi.fn();
 const addToQueueMock = vi.fn();
 const resetMock = vi.fn();
+const finishMock = vi.fn();
 
 let pm5State;
+let queueState;
 
 vi.mock('../../supabaseClient', () => ({
   supabase: {
@@ -22,7 +24,7 @@ vi.mock('../../hooks/usePM5', () => ({
 }));
 
 vi.mock('../../hooks/useOfflineQueue', () => ({
-  useOfflineQueue: () => ({ addToQueue: addToQueueMock }),
+  useOfflineQueue: () => queueState,
 }));
 
 import ErgLiveView from '../ErgLiveView.jsx';
@@ -50,11 +52,27 @@ function renderWithClient(ui, client) {
   );
 }
 
+function finished(extra = {}) {
+  pm5State = { ...pm5State, status: 'finished', summary: SUMMARY, ...extra };
+}
+
+async function save() {
+  fireEvent.click(screen.getByText('SAVE SESSION'));
+  await waitFor(() =>
+    expect(
+      insertMock.mock.calls.length + addToQueueMock.mock.calls.length
+    ).toBeGreaterThan(0)
+  );
+}
+
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(new Date(2026, 7, 18, 7, 15));
   insertMock.mockReset();
   getUserMock.mockReset();
   addToQueueMock.mockReset();
   resetMock.mockReset();
+  finishMock.mockReset();
   getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
   insertMock.mockResolvedValue({ error: null });
   Object.defineProperty(navigator, 'onLine', {
@@ -68,7 +86,13 @@ beforeEach(() => {
     error: null,
     connect: vi.fn(),
     reset: resetMock,
+    finish: finishMock,
   };
+  queueState = { addToQueue: addToQueueMock, pending: 0 };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('ErgLiveView', () => {
@@ -79,60 +103,345 @@ describe('ErgLiveView', () => {
   });
 
   it('renders the summary screen when a session is finished', () => {
-    pm5State = { ...pm5State, status: 'finished', summary: SUMMARY };
+    finished();
     renderWithClient(<ErgLiveView />, makeClient());
     expect(screen.getByText('SESSION COMPLETE')).toBeInTheDocument();
     expect(screen.getByText('SAVE SESSION')).toBeInTheDocument();
   });
 
-  it('saves an erg session and invalidates the sessions query on success', async () => {
-    pm5State = { ...pm5State, status: 'finished', summary: SUMMARY };
-    const client = makeClient();
-    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
-    const onSessionSaved = vi.fn();
-    renderWithClient(<ErgLiveView onSessionSaved={onSessionSaved} />, client);
-
-    fireEvent.click(screen.getByText('SAVE SESSION'));
-
-    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['erg-sessions'] });
-    expect(resetMock).toHaveBeenCalled();
-    expect(onSessionSaved).toHaveBeenCalledTimes(1);
-
-    const row = insertMock.mock.calls[0][0];
-    expect(row.type).toBe('erg');
-    expect(row.status).toBe('logged');
-    expect(row.distance).toBe(5000);
-    expect(row.user_id).toBe('user-123');
+  it('shows the pending-sync count on the connect screen', () => {
+    queueState = { ...queueState, pending: 3 };
+    renderWithClient(<ErgLiveView />, makeClient());
+    expect(screen.getByText('3 PENDING SYNC')).toBeInTheDocument();
   });
 
-  it('queues the row instead of failing when the insert errors', async () => {
-    insertMock.mockResolvedValue({ error: { message: 'db down' } });
-    pm5State = { ...pm5State, status: 'finished', summary: SUMMARY };
+  it('tolerates a queue hook that reports no pending count', () => {
+    queueState = { addToQueue: addToQueueMock };
+    renderWithClient(<ErgLiveView />, makeClient());
+    expect(screen.queryByText(/PENDING SYNC/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ErgLiveView save row', () => {
+  it('inserts exactly the columns the sessions table has', async () => {
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+
+    const row = insertMock.mock.calls[0][0];
+    expect(row).toEqual({
+      date: '8/18/26',
+      type: 'erg',
+      label: 'Erg Session 07:15',
+      duration: '20:00',
+      srpe: 5,
+      distance_m: 5000,
+      avg_watts: 180,
+      status: 'logged',
+      source: 'bluetooth',
+      exercises: [],
+      user_id: 'user-123',
+    });
+    // Columns that do not exist on `sessions` must never be sent — the insert
+    // is rejected wholesale if they are.
+    expect(row).not.toHaveProperty('watts');
+    expect(row).not.toHaveProperty('distance');
+    // The PM5 General Status packet carries no heart rate.
+    expect(row).not.toHaveProperty('avg_hr');
+  });
+
+  it('writes the date as unpadded M/D/YY text', async () => {
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+    expect(insertMock.mock.calls[0][0].date).toMatch(
+      /^\d{1,2}\/\d{1,2}\/\d{2}$/
+    );
+  });
+
+  it('writes duration as MM:SS text rather than a number of minutes', async () => {
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+    expect(insertMock.mock.calls[0][0].duration).toBe('20:00');
+  });
+
+  it('carries the notes through as an exercises entry', async () => {
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    fireEvent.change(screen.getByPlaceholderText(/How did it feel/), {
+      target: { value: 'legs felt good' },
+    });
+    await save();
+    expect(insertMock.mock.calls[0][0].exercises).toEqual([
+      { name: 'Notes', notes: 'legs felt good' },
+    ]);
+  });
+
+  it('nulls unmeasured metrics instead of writing zeroes, and survives no auth user', async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+    pm5State = {
+      ...pm5State,
+      status: 'finished',
+      summary: {
+        distance: 0,
+        elapsedTime: 0,
+        elapsedStr: '00:00',
+        avgWatts: 0,
+        avgPace: 0,
+        avgSpm: 0,
+        maxWatts: 0,
+        calories: 0,
+      },
+    };
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+
+    const row = insertMock.mock.calls[0][0];
+    expect(row.distance_m).toBeNull();
+    expect(row.avg_watts).toBeNull();
+    expect(row.duration).toBe('00:00');
+    expect(row.exercises).toEqual([]);
+    expect(row.user_id).toBeUndefined();
+  });
+});
+
+describe('ErgLiveView planned-session matching', () => {
+  const planned = {
+    date: '8/18/26',
+    _isErg: true,
+    type: 'Z2 Aerobic',
+    label: 'UT1 Steady 50min',
+    status: 'planned',
+  };
+
+  it("labels the row from today's planned erg session", async () => {
+    finished();
+    renderWithClient(<ErgLiveView plannedSessions={[planned]} />, makeClient());
+    await save();
+    expect(insertMock.mock.calls[0][0].label).toBe('UT1 Steady 50min 07:15');
+  });
+
+  it('ignores a planned session on another date', async () => {
+    finished();
+    renderWithClient(
+      <ErgLiveView plannedSessions={[{ ...planned, date: '8/17/26' }]} />,
+      makeClient()
+    );
+    await save();
+    expect(insertMock.mock.calls[0][0].label).toBe('Erg Session 07:15');
+  });
+
+  it('ignores a planned session for another modality', async () => {
+    finished();
+    renderWithClient(
+      <ErgLiveView
+        plannedSessions={[{ ...planned, _isErg: false, _isCycling: true }]}
+      />,
+      makeClient()
+    );
+    await save();
+    expect(insertMock.mock.calls[0][0].label).toBe('Erg Session 07:15');
+  });
+
+  it('gives two sessions on the same day distinct labels', async () => {
+    finished();
+    const first = renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+    first.unmount();
+
+    vi.setSystemTime(new Date(2026, 7, 18, 17, 40));
+    renderWithClient(<ErgLiveView />, makeClient());
+    await waitFor(() => expect(screen.getByText('SAVE SESSION')).toBeVisible());
+    fireEvent.click(screen.getByText('SAVE SESSION'));
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(2));
+
+    const [a, b] = insertMock.mock.calls.map(([row]) => row);
+    expect(a.date).toBe(b.date);
+    expect(a.label).not.toBe(b.label);
+    expect(b.label).toBe('Erg Session 17:40');
+  });
+});
+
+describe('ErgLiveView save outcomes', () => {
+  it('reports success, refreshes the log queries and does not queue', async () => {
+    finished();
     const client = makeClient();
     const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
     renderWithClient(<ErgLiveView />, client);
+    await save();
 
-    fireEvent.click(screen.getByText('SAVE SESSION'));
-
-    await waitFor(() => expect(addToQueueMock).toHaveBeenCalledTimes(1));
-    // mutationFn resolves (no throw), so success path still runs.
+    await waitFor(() =>
+      expect(screen.getByText('SAVED TO LOG')).toBeInTheDocument()
+    );
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['erg-sessions'] });
+    expect(addToQueueMock).not.toHaveBeenCalled();
   });
 
-  it('queues the row when offline without attempting an insert', async () => {
+  it('queues the row and says so when the insert is rejected', async () => {
+    insertMock.mockResolvedValue({
+      error: { code: '42501', message: 'permission denied' },
+    });
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+
+    expect(addToQueueMock).toHaveBeenCalledTimes(1);
+    expect(addToQueueMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        date: '8/18/26',
+        label: 'Erg Session 07:15',
+        duration: '20:00',
+        distance_m: 5000,
+        avg_watts: 180,
+        status: 'logged',
+      })
+    );
+    await waitFor(() =>
+      expect(screen.getByText('SAVED LOCALLY — WILL SYNC')).toBeInTheDocument()
+    );
+    expect(screen.queryByText('SAVED TO LOG')).not.toBeInTheDocument();
+  });
+
+  it('queues without attempting an insert when offline', async () => {
     Object.defineProperty(navigator, 'onLine', {
       value: false,
       configurable: true,
     });
-    pm5State = { ...pm5State, status: 'finished', summary: SUMMARY };
+    finished();
     renderWithClient(<ErgLiveView />, makeClient());
+    await save();
 
-    fireEvent.click(screen.getByText('SAVE SESSION'));
-
-    await waitFor(() => expect(addToQueueMock).toHaveBeenCalledTimes(1));
+    expect(addToQueueMock).toHaveBeenCalledTimes(1);
     expect(insertMock).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByText('SAVED LOCALLY — WILL SYNC')).toBeInTheDocument()
+    );
+  });
+
+  it('treats a duplicate-key rejection as saved rather than queueing it', async () => {
+    insertMock.mockResolvedValue({
+      error: {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint',
+      },
+    });
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+
+    expect(addToQueueMock).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByText('SAVED TO LOG')).toBeInTheDocument()
+    );
+  });
+
+  it('queues when the auth lookup itself rejects', async () => {
+    getUserMock.mockRejectedValue(new Error('no session'));
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(addToQueueMock).toHaveBeenCalledTimes(1);
+    expect(addToQueueMock.mock.calls[0][0].user_id).toBeUndefined();
+  });
+
+  it('surfaces a failure when the row cannot even be stored locally', async () => {
+    insertMock.mockResolvedValue({ error: { code: '42501', message: 'nope' } });
+    addToQueueMock.mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+
+    await waitFor(() =>
+      expect(screen.getByText(/SAVE FAILED/)).toBeInTheDocument()
+    );
+    expect(screen.queryByText('SAVED TO LOG')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('SAVED LOCALLY — WILL SYNC')
+    ).not.toBeInTheDocument();
+    // The session is still on screen, so the data is not lost — retry is possible.
+    expect(screen.getByText('SAVE SESSION')).toBeInTheDocument();
+  });
+});
+
+describe('ErgLiveView post-save flow', () => {
+  it('keeps the summary on screen until DONE is pressed', async () => {
+    finished();
+    const onSessionSaved = vi.fn();
+    renderWithClient(
+      <ErgLiveView onSessionSaved={onSessionSaved} />,
+      makeClient()
+    );
+    await save();
+
+    await waitFor(() =>
+      expect(screen.getByText('SAVED TO LOG')).toBeInTheDocument()
+    );
+    expect(resetMock).not.toHaveBeenCalled();
+    expect(onSessionSaved).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('DONE'));
+    expect(resetMock).toHaveBeenCalledTimes(1);
+    expect(onSessionSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers DONE after a queued save too', async () => {
+    Object.defineProperty(navigator, 'onLine', {
+      value: false,
+      configurable: true,
+    });
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+
+    await waitFor(() => expect(screen.getByText('DONE')).toBeInTheDocument());
+    expect(screen.queryByText('SAVE SESSION')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('DONE'));
+    expect(resetMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ErgLiveView manual end', () => {
+  it('routes END into the summary screen instead of discarding the session', () => {
+    pm5State = {
+      ...pm5State,
+      status: 'rowing',
+      metrics: {
+        watts: 180,
+        strokeRate: 24,
+        distance: 5000,
+        elapsedStr: '20:00',
+      },
+    };
+    const { rerender } = renderWithClient(<ErgLiveView />, makeClient());
+
+    fireEvent.click(screen.getByText('END'));
+    expect(finishMock).toHaveBeenCalledTimes(1);
+    expect(resetMock).not.toHaveBeenCalled();
+
+    // usePM5.finish() flips status to 'finished' with a summary.
+    finished();
+    const client = makeClient();
+    rerender(
+      <QueryClientProvider client={client}>
+        <ErgLiveView />
+      </QueryClientProvider>
+    );
+    expect(screen.getByText('SESSION COMPLETE')).toBeInTheDocument();
+  });
+
+  it('saves a manually-ended session through the same flow', async () => {
+    finished();
+    renderWithClient(<ErgLiveView />, makeClient());
+    await save();
+    await waitFor(() =>
+      expect(screen.getByText('SAVED TO LOG')).toBeInTheDocument()
+    );
+    expect(insertMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -109,6 +109,7 @@ export default defineConfig({
         // per-file as it lands. The global floor above ratchets toward this as
         // the monolith is decomposed and its exclusions fall away.
         'src/utils/sentry.js': { lines: 80, functions: 80, branches: 70 },
+        'src/utils/dateFormat.js': { lines: 80, functions: 80, branches: 70 },
         'src/components/ErrorFallback.jsx': {
           lines: 80,
           functions: 80,


### PR DESCRIPTION
Closes #174

## What changed and why

The live PM5 save path inserted columns that don't exist on `sessions` (`watts`/`distance`) with an ISO date, so no bluetooth session ever landed in production and failures were silently swallowed by an offline queue that retried the same broken shape forever — this fixes the row shape, makes the queue self-heal, rescues manually-ended sessions, and makes every save outcome visible (Sprint 5 · T1 · #182).

Details:
- Row now writes `avg_watts`/`distance_m`, unpadded `M/D/YY` local-time date via a new `toLogDate()` in `utils/dateFormat.js`, `duration` as `MM:SS`; `avg_hr` omitted (the PM5 General Status packet carries no HR)
- Fixed the `todaySession` matcher (ISO-vs-`M/D/YY` compare + `normType` mangling made it always null) and suffixed labels with end time so same-day sessions don't collide on `UNIQUE(date, label)`
- Offline queue normalizes legacy rows on read (storage self-heals on first drain), treats duplicate-key `23505` as delivered (lost-ack recovery), and guards against concurrent drains
- Save flow has observable states (`saving`/`saved`/`queued`/`failed`) with reset gated behind DONE; enqueue wrapped in a quota guard; pending-sync count on the connect screen
- Manual END builds a summary via `usePM5.finish()` instead of discarding the session
- Also carries the Sprint 5 plan doc (`coach/SPRINT_BENCHMARK_INTEGRITY.md`, approved at Gate 1)

Follow-up filed: #184 (pre-existing read-side date bugs that become visible once this list is non-empty).

## How to test manually

Covered by CI (38 new tests, 428 total). For a live check: connect a PM5 in the Erg Live view, row a piece, end it manually with END, save — the session should appear in the log with watts/distance populated; airplane-mode saves should show "SAVED LOCALLY — WILL SYNC" and drain on reconnect.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser