### PR TITLE
fix: erg session list read-side date handling, plus /daily brief and doc accuracy pass

### DIFF
--- a/.claude/skills/daily/SKILL.md
+++ b/.claude/skills/daily/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: daily
+description: Generate a short list of tasks that genuinely fit a 30-minute window, ranked from live repo and health state. Use when Scott has a gap and wants to know what to pick up without reading the backlog.
+argument-hint: (none)
+---
+
+Produce a list of 3–6 tasks that each land inside ~30 minutes, ranked from live
+state. Read-only — gather, rank, print. Write nothing to the repo or the DB.
+
+> Focus arrives in short, unpredictable windows. The cost of deciding what to
+> work on can exceed the window itself, so this skill makes the decision.
+
+## Usage
+
+```
+/daily
+```
+
+## Step 1 — Gather live state (run in parallel, all read-only)
+
+| Source | Query | Feeds |
+|---|---|---|
+| GitHub | `list_pull_requests` open, then `pull_request_read` `get_check_runs` on each | Green + mergeable PRs — always rank first |
+| GitHub | `list_issues` open, P1 first | Backlog candidates |
+| Supabase | `select key, value from anchors where superseded_at is null` | **Gates the health section — read this before writing anything** |
+| Supabase | `select * from vitals order by date desc limit 7` | Which health fields are going unrecorded |
+| Bash | `git branch --show-current`, `git status --porcelain` | Uncommitted work, wrong-branch warnings |
+| Bash | `ls web/node_modules \| head -1` | Whether deps are installed |
+
+Project id for Supabase is in `CLAUDE.md`. Never guess a task's scope — if the
+code hasn't been checked, spawn an `Explore` agent to size it, or label it
+"needs a look first" and give no estimate.
+
+## Step 2 — Rank
+
+Highest value-per-minute first:
+
+1. **Finished work awaiting one action** — a green, mergeable PR. The work is
+   already done; only the click is missing. Always the top candidate.
+2. **P1 bugs with a known fix path** — an existing helper to reuse, a shipped
+   precedent to copy, one file touched.
+3. **Zero-risk, zero-test tasks** — doc fixes, threshold bumps. Label these as
+   the low-energy option, explicitly.
+4. **One small test file** for an untested component or hook.
+5. **Health items** — at most two, always last, always an offer.
+
+## Step 3 — Print
+
+Open with a single **"If you only do one thing"** pick. Then the list, capped at
+six. Each item carries: what, why it matters in one line, where (exact file
+paths or PR number), an estimate, and the command to start it.
+
+Close with an explicit line that doing none of it is a fine outcome today. Mean
+it — do not follow it with a nudge.
+
+## Rules
+
+These are the difference between a useful brief and a harmful one.
+
+- **If `current_phase` is `maintenance`, never surface training adherence,
+  missed-session counts, CTL/ATL/TSB decline, streaks, or "days since last
+  session".** Under maintenance there is no adherence to be behind on. Declining
+  fitness numbers are expected and correct, not a finding. This is the most
+  important rule here — a nagging dashboard during a hard life period is worse
+  than no dashboard. The reasoning is in `coach_log`, tagged `phase-change`.
+- Health items are **offered, never prescribed**: "worth wearing the watch
+  tonight if it's easy", not "log your readiness". Two maximum.
+- Never invent an estimate. An unsized task says "needs a look first".
+- If `web/node_modules` is missing, state that `cd web && npm install` is step
+  zero on every code task — don't assume it.
+- Re-rank from scratch every run. Never carry a previous list forward.
+- Six items is the ceiling, not the target. Three good ones beat six padded.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,8 @@ coach/
 .claude/
   agents/       Agency agent library (232 agents, 16 divisions) — staffs the pipeline
   skills/       Pipeline definitions (/orchestrate, /feature, /refactor, /research),
-                erg-context.md spawn preamble, and domain knowledge docs
+                /daily task brief, erg-context.md spawn preamble, and domain
+                knowledge docs
   settings.json Hooks configuration (automation triggers)
 ```
 
@@ -251,6 +252,7 @@ approval gates. It never advances without explicit go-ahead.
 /orchestrate <idea>      →  the canonical pipeline
 /refactor <module>       →  strangler-fig extraction (Minimal Change Engineer)
 /research <topic>        →  research only (Trend Researcher)
+/daily                   →  today's 30-min task list (read-only, no pipeline)
 ```
 
 ### The canonical chain (stage → Agency agent)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ TrainingPeaks, Ergzone) with a unified, fully personalised training system.
 
 | Layer      | Technology                     | Purpose                              |
 |------------|--------------------------------|--------------------------------------|
-| UI         | React 18 + Vite                | Frontend single-page app             |
+| UI         | React 19 + Vite                | Frontend single-page app             |
 | Charts     | Recharts                       | Data visualisation                   |
 | Math       | mathjs                         | Linear regression for aerobic trend  |
 | Backend    | Supabase                       | Postgres DB, Auth, Edge Functions    |
@@ -45,12 +45,17 @@ web/                The app lives under web/ (Vite + Capacitor monorepo layout)
     hooks/          Custom React hooks (data fetching, derived state)
     utils/          Pure functions — analysis, formatting, scheduling
     components/     Shared UI components (LogEntry, WorkoutItem, charts)
+      mobile/       Mobile-only shared components (BottomTabBar)
+    services/       Device/native integrations (pm5Bluetooth.js)
     views/          Extracted dashboard tabs (desktop + mobile)
-    App.jsx         Entry shell/router (~515 lines) — the former erg-dashboard.jsx monolith
+      mobile/       Mobile tab views
+      program/      ProgramView split-out pieces (#77)
+    App.jsx         Entry shell/router (~447 lines) — the former erg-dashboard.jsx monolith
     StrengthLogger.jsx Large component, not yet extracted (~1,665 lines)
     main.jsx        Auth gate (Supabase email/password login)
 supabase/
-  functions/        Edge Functions (vitals-import from Google Health API)
+  functions/        Edge Functions (vitals-import, vitals-import-api,
+                    vitals-sync, coach-chat)
 coach/
   PROJECT_MANAGEMENT_ANALYSIS.md  PM/workflow analysis (2026-06-29)
   work-orders/      DEPRECATED — historical specs; tracking is now GitHub Issues
@@ -79,7 +84,7 @@ coach/
 ## Architecture: Strangler Fig Refactor
 
 The monolith decomposition is complete (#52, closed by PR #145 on 2026-07-11):
-the former `web/src/erg-dashboard.jsx` is now `web/src/App.jsx` — a ~515-line
+the former `web/src/erg-dashboard.jsx` is now `web/src/App.jsx` — a ~447-line
 shell/router that composes the extracted views. Remaining large files:
 `views/ProgramView.jsx` (~1,900 lines, being split into `views/program/*`, #77)
 and `StrengthLogger.jsx` (~1,665 lines, untested, #79). The migration order
@@ -220,8 +225,8 @@ Every PR is gated by three GitHub Actions jobs that must pass before merge:
 
 Coverage thresholds live in `web/vite.config.js` (`test.coverage.thresholds`) and
 **ratchet upward**. Scope is explicit — `coverage.all` + `include: ['src/**']`
-with the not-yet-extracted monolith, `StrengthLogger.jsx`, `main.jsx`, and
-pure-data `constants/**` excluded — so the gate measures real coverage instead of
+with `StrengthLogger.jsx`, `main.jsx`, `test-setup.js`, and pure-data
+`constants/**` excluded (the former monolith, now `App.jsx`, is fully included) — so the gate measures real coverage instead of
 passing by accident on whatever files a test happened to import. Each refactor
 extraction removes its file from `exclude` and lands tests in the **same** PR;
 the thresholds are then raised toward it. The numbers only go up. A PR comment

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ fully personalised app.
 [![CI — Web](https://github.com/skizzy1986/erg-dashboard/actions/workflows/ci-web.yml/badge.svg)](https://github.com/skizzy1986/erg-dashboard/actions/workflows/ci-web.yml)
 [![CI — Android](https://github.com/skizzy1986/erg-dashboard/actions/workflows/ci-android.yml/badge.svg)](https://github.com/skizzy1986/erg-dashboard/actions/workflows/ci-android.yml)
 
-**v1.3.0** · React 18 + Supabase + Capacitor Android · Deployed on Vercel
+**v1.3.0** · React 19 + Supabase + Capacitor Android · Deployed on Vercel
 
 ---
 
@@ -48,7 +48,7 @@ Recovery, Strength, Session Log, Coach. PWA installable on iOS/web.
 
 | Layer | Technology |
 |-------|-----------|
-| Frontend | React 18 + Vite |
+| Frontend | React 19 + Vite |
 | State / data fetching | TanStack React Query v5 |
 | Charts | Recharts |
 | Backend | Supabase (Postgres, Auth, Edge Functions on Deno) |
@@ -66,7 +66,7 @@ Recovery, Strength, Session Log, Coach. PWA installable on iOS/web.
 
 ```
 Browser / Android APK
-  └── React 18 SPA (web/src/)
+  └── React 19 SPA (web/src/)
         ├── views/          — one component per tab (10 desktop + 5 mobile)
         ├── hooks/          — data fetching (React Query + Supabase), derived state
         ├── components/     — shared UI (charts, forms, log entries)

--- a/web/src/hooks/__tests__/useErgSessions.test.js
+++ b/web/src/hooks/__tests__/useErgSessions.test.js
@@ -165,6 +165,66 @@ describe('useErgSessions', () => {
     expect(result.current.data[0].date_display).toBe('6/13');
   });
 
+  // sessions.date is TEXT "M/D/YY" in production — the fixtures above are ISO
+  // only because the read side used to assume it. These cover the live format.
+  it('formats date_display as M/D from the live M/D/YY text format', async () => {
+    mockQuery([{ id: 9, date: '8/7/26', type: 'erg', avg_watts: 150 }]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data[0].date_display).toBe('8/7');
+  });
+
+  it('strips the zero padding from a padded MM/DD/YY date', async () => {
+    mockQuery([{ id: 10, date: '06/09/26', type: 'erg', avg_watts: 150 }]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data[0].date_display).toBe('6/9');
+  });
+
+  it('falls back to the raw date string when it cannot be parsed', async () => {
+    mockQuery([{ id: 11, date: 'not-a-date', type: 'erg', avg_watts: 150 }]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data[0].date_display).toBe('not-a-date');
+  });
+
+  // Postgres sorts the TEXT date lexically, so it hands back "12/31/25" above
+  // "1/1/26". The hook must re-sort newest-first on the normalized key.
+  it('re-sorts newest-first across a year boundary', async () => {
+    mockQuery([
+      { id: 12, date: '12/31/25', type: 'erg', avg_watts: 150 },
+      { id: 13, date: '1/1/26', type: 'erg', avg_watts: 150 },
+      { id: 14, date: '2/14/26', type: 'erg', avg_watts: 150 },
+    ]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data.map((s) => s.date)).toEqual([
+      '2/14/26',
+      '1/1/26',
+      '12/31/25',
+    ]);
+  });
+
+  it('sorts ISO and M/D/YY dates into one correct order', async () => {
+    mockQuery([
+      { id: 15, date: '2026-06-13', type: 'erg', avg_watts: 150 },
+      { id: 16, date: '8/7/26', type: 'erg', avg_watts: 150 },
+    ]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data.map((s) => s.id)).toEqual([16, 15]);
+  });
+
   it('sets isError on supabase error', async () => {
     mockQuery(null, { message: 'boom' });
     const { result } = renderHook(() => useErgSessions(), {

--- a/web/src/hooks/useErgSessions.js
+++ b/web/src/hooks/useErgSessions.js
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
 import { wattsToPace500, formatPace, classifyZone } from '../utils/pace.js';
+import { toISODate } from '../utils/dateFormat.js';
 import { useAnchors } from './useAnchors.js';
 
 export function enrich(s, cp) {
@@ -12,7 +13,7 @@ export function enrich(s, cp) {
     const secs = parseFloat(s.duration) * 60;
     pace_500m = secs / (s.distance_m / 500);
   }
-  const [month, day] = (s.date || '').split('-').slice(1);
+  const [, month, day] = toISODate(s.date).split('-');
   return {
     ...s,
     pace_500m,
@@ -44,8 +45,19 @@ export function useErgSessions() {
     staleTime: 60_000,
   });
 
+  // sessions.date is TEXT "M/D/YY", so the server-side .order() above sorts it
+  // lexically ("12/31/25" lands above "1/1/26"). Re-sort on the normalized ISO
+  // key. The .limit(50) is still applied to that lexical order server-side, so
+  // past 50 rows this fetches the wrong 50 — see #184.
   const data = useMemo(
-    () => (query.data ?? []).map((s) => enrich(s, cp)),
+    () =>
+      (query.data ?? [])
+        .map((s) => enrich(s, cp))
+        .sort((a, b) => {
+          const ai = toISODate(a.date);
+          const bi = toISODate(b.date);
+          return ai < bi ? 1 : ai > bi ? -1 : 0;
+        }),
     [query.data, cp]
   );
 

--- a/web/src/views/ErgView.jsx
+++ b/web/src/views/ErgView.jsx
@@ -21,6 +21,7 @@ import {
   HR130_POWER,
 } from '../constants/trainingConfig.js';
 import { formatPace } from '../utils/pace.js';
+import { toISODate } from '../utils/dateFormat.js';
 import { useErgSessions } from '../hooks/useErgSessions.js';
 import { useAnchors } from '../hooks/useAnchors.js';
 
@@ -206,8 +207,9 @@ const statLabel = {
 };
 
 function withinLast7Days(dateStr) {
-  if (!dateStr) return false;
-  const d = new Date(dateStr + 'T00:00:00');
+  const iso = toISODate(dateStr);
+  if (!iso) return false;
+  const d = new Date(iso + 'T00:00:00');
   if (Number.isNaN(d.getTime())) return false;
   const now = new Date();
   const cutoff = new Date(now.getTime() - 7 * 86400000);

--- a/web/src/views/__tests__/ErgView.test.jsx
+++ b/web/src/views/__tests__/ErgView.test.jsx
@@ -155,4 +155,55 @@ describe('ErgView', () => {
     const { container } = renderView();
     expect(container).toBeTruthy();
   });
+
+  // withinLast7Days used to build a Date from the raw string, which is Invalid
+  // Date for the live "M/D/YY" format — so this counter always read 0.
+  it('counts a recent M/D/YY session in SESSIONS / WK', () => {
+    const d = new Date(Date.now() - 2 * 86400000);
+    const mdy = `${d.getMonth() + 1}/${d.getDate()}/${String(d.getFullYear()).slice(-2)}`;
+    useErgSessionsMock.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          date: mdy,
+          label: '60min UT1',
+          duration: 60,
+          srpe: 6,
+          avg_watts: 150,
+          avg_hr: 130,
+          distance_m: 13500,
+          pace_500m: 132.6,
+          pace_500m_str: '2:12.6',
+          zone: 'UT1',
+          hardPush: false,
+          date_display: '8/18',
+        },
+      ],
+      isLoading: false,
+    });
+    const { getByText } = renderView();
+    expect(getByText('SESSIONS / WK').nextSibling.textContent).toBe('1');
+  });
+
+  it('does not count a session older than 7 days in SESSIONS / WK', () => {
+    useErgSessionsMock.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          date: '1/2/26',
+          label: 'old row',
+          duration: 60,
+          avg_watts: 150,
+          pace_500m: 132.6,
+          pace_500m_str: '2:12.6',
+          zone: 'UT1',
+          hardPush: false,
+          date_display: '1/2',
+        },
+      ],
+      isLoading: false,
+    });
+    const { getByText } = renderView();
+    expect(getByText('SESSIONS / WK').nextSibling.textContent).toBe('0');
+  });
 });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -99,12 +99,12 @@ export default defineConfig({
       //   measured: lines 48.98 / functions 46.81 / branches 40.38
       thresholds: {
         // Global floor — ratcheted up as extractions land tests (measured
-        // lines 71.76 / functions 71.52 / branches 68.62 on 2026-07-11, after
-        // the App.jsx rename brought the former monolith into scope with its
-        // render test; ~4 points headroom for denominator drift).
-        lines: 68,
-        functions: 67,
-        branches: 64,
+        // lines 76.86 / functions 75.45 / branches 72.00 on 2026-08-20, after
+        // the PM5 save-path tests (#173) and the erg date-handling tests (#184)
+        // landed; ~4 points headroom for denominator drift).
+        lines: 72,
+        functions: 71,
+        branches: 68,
         // Commercial-baseline gate (80/80/70) for new/extracted code, applied
         // per-file as it lands. The global floor above ratchets toward this as
         // the monolith is decomposed and its exclusions fall away.


### PR DESCRIPTION
Closes #184

## What changed and why

Fixes the erg read path's ISO-date assumption against the live `M/D/YY` TEXT column (#184), adds a `/daily` skill that generates a 30-minute task list from live state, and corrects five stale claims in `CLAUDE.md` / `README.md`.

Three commits, independently reviewable:

**1. `feat(skills): add /daily`** — a read-only skill that reads open PRs and their CI status, the issue backlog, the `anchors` table and recent vitals, then returns 3–6 tasks that fit ~30 minutes, led by a single "if you only do one thing" pick. It writes nothing to the repo or DB. Gating rule: while `current_phase` is `maintenance`, the brief never surfaces training adherence, missed-session counts, CTL/ATL/TSB decline or streaks.

**2. `fix: erg session list read-side date handling (#184)`** — `sessions.date` is TEXT `M/D/YY` and the erg read path assumed ISO throughout:

- **Ordering** — the server-side `.order('date')` sorts the TEXT column lexically, so `"12/31/25"` ranks above `"1/1/26"`. The enriched list is re-sorted on the normalized ISO key via the existing `toISODate()` helper, matching the pattern already shipped in `views/mobile/MobileAnalytics.jsx`.
- **`date_display`** — `split('-')` only matched ISO, so on live `"6/13/26"` input both parts came back `undefined` and the chart axis silently fell back to the raw string.
- **`withinLast7Days`** in `ErgView` built a `Date` from the raw string, which is Invalid Date for `M/D/YY` — the SESSIONS / WK counter was permanently `0`.

Not fixed, deliberately: the `.limit(50)` is still applied to the lexical order server-side, so past 50 rows the wrong 50 are fetched. Noted in a comment at the call site. There are 0 rows matching this query today (`status='logged'` is written only by the PM5 save path, live as of #173), so the limit is far from binding; fixing it properly needs a server-side ordering expression.

Coverage floor ratcheted **68/67/64 → 72/71/68** (measured 76.86 / 75.45 / 72.00).

**3. `docs: correct stale claims`** — each verified against the repo rather than the prose: React 18 → 19 (4 occurrences, `package.json` pins `^19.2.8`); App.jsx is 447 lines not ~515 (2 occurrences); the coverage-exclude paragraph read as though the former monolith were excluded, which `vite.config.js` explicitly contradicts, and omitted `test-setup.js`; the structure block omitted `src/services/`, `src/components/mobile/`, `src/views/program/`; Edge Functions listed 1 of the 4 that exist. `ProgramView.jsx` and `StrengthLogger.jsx` line counts were checked and left alone — both already accurate.

## How to test manually

Covered by CI. The six new tests were each confirmed to **fail** against the unfixed source and pass with it, so they exercise the bug rather than the fix.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

---
_Generated by [Claude Code](https://claude.ai/code/session_015yFLjAqk4QqRTDNt96kQyH)_