### PR TITLE
Add benchmark status resolver and calendar badges

### DIFF
--- a/web/src/components/BenchmarkBadge.jsx
+++ b/web/src/components/BenchmarkBadge.jsx
@@ -1,0 +1,46 @@
+// Presentational only — props in, no hooks, no data access.
+const COLOURS = { overdue: '#ff2d55', upcoming: '#ffd700' };
+
+export default function BenchmarkBadge({
+  status,
+  fuzzy = false,
+  daysOverdue = null,
+  daysUntilStart = null,
+}) {
+  const colour = COLOURS[status];
+  if (!colour) return null;
+
+  const parts = [];
+  if (status === 'overdue') {
+    parts.push('OVERDUE');
+    if (typeof daysOverdue === 'number' && daysOverdue > 0) {
+      parts.push(`${daysOverdue}d`);
+    }
+  } else {
+    parts.push('DUE');
+    if (typeof daysUntilStart === 'number') {
+      parts.push(daysUntilStart > 0 ? `${daysUntilStart}d` : 'NOW');
+    }
+    if (fuzzy) parts.push('exact date TBD');
+  }
+
+  return (
+    <span
+      style={{
+        fontSize: 8,
+        letterSpacing: 1,
+        fontWeight: 700,
+        padding: '1px 5px',
+        borderRadius: 3,
+        border: `1px solid ${colour}40`,
+        color: colour,
+        background: `${colour}15`,
+        whiteSpace: 'nowrap',
+        marginLeft: 6,
+        display: 'inline-block',
+      }}
+    >
+      {parts.join(' · ')}
+    </span>
+  );
+}

--- a/web/src/components/__tests__/BenchmarkBadge.test.jsx
+++ b/web/src/components/__tests__/BenchmarkBadge.test.jsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import BenchmarkBadge from '../BenchmarkBadge.jsx';
+
+describe('BenchmarkBadge', () => {
+  it('renders nothing for quiet and unknown', () => {
+    const { container, rerender } = render(<BenchmarkBadge status="quiet" />);
+    expect(container).toBeEmptyDOMElement();
+    rerender(<BenchmarkBadge status="unknown" />);
+    expect(container).toBeEmptyDOMElement();
+    rerender(<BenchmarkBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders OVERDUE with the elapsed day count', () => {
+    render(<BenchmarkBadge status="overdue" daysOverdue={31} />);
+    expect(screen.getByText('OVERDUE · 31d')).toBeInTheDocument();
+  });
+
+  it('omits the day count when it is not a positive number', () => {
+    const { rerender } = render(<BenchmarkBadge status="overdue" />);
+    expect(screen.getByText('OVERDUE')).toBeInTheDocument();
+    rerender(<BenchmarkBadge status="overdue" daysOverdue={0} />);
+    expect(screen.getByText('OVERDUE')).toBeInTheDocument();
+  });
+
+  it('renders DUE with the countdown when the window is ahead', () => {
+    render(<BenchmarkBadge status="upcoming" daysUntilStart={5} />);
+    expect(screen.getByText('DUE · 5d')).toBeInTheDocument();
+  });
+
+  it('renders NOW once the window has opened', () => {
+    render(<BenchmarkBadge status="upcoming" daysUntilStart={-2} />);
+    expect(screen.getByText('DUE · NOW')).toBeInTheDocument();
+  });
+
+  // AC2d
+  it('qualifies a fuzzy upcoming window with "exact date TBD"', () => {
+    render(<BenchmarkBadge status="upcoming" daysUntilStart={5} fuzzy />);
+    expect(screen.getByText('DUE · 5d · exact date TBD')).toBeInTheDocument();
+  });
+
+  it('does not qualify an exact upcoming window', () => {
+    render(<BenchmarkBadge status="upcoming" daysUntilStart={5} />);
+    expect(screen.queryByText(/exact date TBD/)).not.toBeInTheDocument();
+  });
+
+  it('colours overdue red and upcoming gold', () => {
+    const { container, rerender } = render(
+      <BenchmarkBadge status="overdue" daysOverdue={3} />
+    );
+    expect(container.firstChild).toHaveStyle({ color: '#ff2d55' });
+    rerender(<BenchmarkBadge status="upcoming" daysUntilStart={3} />);
+    expect(container.firstChild).toHaveStyle({ color: '#ffd700' });
+  });
+});

--- a/web/src/hooks/__tests__/useBenchmarkStatuses.test.js
+++ b/web/src/hooks/__tests__/useBenchmarkStatuses.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const fromMock = vi.fn();
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: (...args) => fromMock(...args),
+  },
+}));
+
+import { useBenchmarkStatuses } from '../useBenchmarkStatuses.js';
+import { EVENT_LADDER } from '../../constants/schedule.js';
+
+const TODAY = '2026-08-20';
+const LADDER = [EVENT_LADDER[1]]; // '~Mid Jul 26' · CP Test #2 (2nd duration)
+
+const RETEST = {
+  id: 61,
+  date: '7/5/26',
+  label: 'CP RETEST — 1min + 4min max (rested, fed)',
+};
+
+let payload = { data: [], error: null };
+
+function mockSessions() {
+  fromMock.mockImplementation(() => {
+    const chain = {
+      select: () => chain,
+      order: () => chain,
+      limit: () => Promise.resolve(payload),
+    };
+    return chain;
+  });
+}
+
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  }
+  const view = renderHook(
+    () => useBenchmarkStatuses(LADDER, { today: TODAY }),
+    { wrapper: Wrapper }
+  );
+  return { ...view, client };
+}
+
+beforeEach(() => {
+  fromMock.mockReset();
+  payload = { data: [], error: null };
+});
+
+describe('useBenchmarkStatuses', () => {
+  it('reports unknown while the sessions query is still pending', () => {
+    mockSessions();
+    const { result } = setup();
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].status).toBe('unknown');
+  });
+
+  it('L2 reports unknown when the sessions query errors', async () => {
+    payload = { data: null, error: { message: 'boom' } };
+    mockSessions();
+    const { result } = setup();
+    await waitFor(() => expect(fromMock).toHaveBeenCalled());
+    // The query never succeeds, so the ladder never fabricates an overdue.
+    await waitFor(() => expect(result.current[0].status).toBe('unknown'));
+    expect(result.current[0].done).toBe(false);
+  });
+
+  it('queries the sessions table scoped to the badge fields', async () => {
+    mockSessions();
+    setup();
+    await waitFor(() => expect(fromMock).toHaveBeenCalledWith('sessions'));
+  });
+
+  // AC5 — the badge clears once the session is logged, with no edit to the
+  // existing invalidateQueries({ queryKey: ['sessions'] }) call sites: the
+  // benchmark key is a prefix match of theirs.
+  it('AC5 flips from overdue to quiet when the cancelled retest is completed', async () => {
+    payload = { data: [{ ...RETEST, status: 'cancelled' }], error: null };
+    mockSessions();
+    const { result, client } = setup();
+    await waitFor(() => expect(result.current[0].status).toBe('overdue'));
+
+    payload = { data: [{ ...RETEST, status: 'logged' }], error: null };
+    await client.invalidateQueries({ queryKey: ['sessions'] });
+
+    await waitFor(() => expect(result.current[0].status).toBe('quiet'));
+    expect(result.current[0].matchedSessionId).toBe(61);
+  });
+
+  // D1 — the clearing row must survive the payload size, not just the first page.
+  it('D1 resolves a clearing session sitting deep in the payload', async () => {
+    const filler = Array.from({ length: 300 }, (_, i) => ({
+      id: 1000 + i,
+      date: '7/15/26',
+      label: 'UT2 40min recovery @ 130-142W',
+      status: 'completed',
+    }));
+    payload = {
+      data: [...filler, { ...RETEST, status: 'completed' }],
+      error: null,
+    };
+    mockSessions();
+    const { result } = setup();
+    await waitFor(() => expect(result.current[0].status).toBe('quiet'));
+    expect(result.current[0].matchedSessionId).toBe(61);
+  });
+
+  it('defaults to the full live ladder', async () => {
+    mockSessions();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    function Wrapper({ children }) {
+      return React.createElement(QueryClientProvider, { client }, children);
+    }
+    const { result } = renderHook(() => useBenchmarkStatuses(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() =>
+      expect(result.current).toHaveLength(EVENT_LADDER.length)
+    );
+  });
+});

--- a/web/src/hooks/useBenchmarkSessions.js
+++ b/web/src/hooks/useBenchmarkSessions.js
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../supabaseClient.js';
+
+// Scoped read for the benchmark badges. The key is a CHILD of ['sessions'], so
+// the existing invalidateQueries({ queryKey: ['sessions'] }) calls in
+// LogSessionForm and ErgLiveView (neither passes `exact`) refetch it too and a
+// freshly-logged test clears its badge without any edit to those files.
+//
+// limit 500 rather than useSessions()' 50: sessions.date is TEXT, so the
+// server-side order is not chronological and a small limit truncates the wrong
+// rows. At ~92 rows today, 500 returns the whole table and set membership stops
+// depending on the broken sort. The resolver filters by date itself.
+export function useBenchmarkSessions() {
+  return useQuery({
+    queryKey: ['sessions', 'benchmark-window'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('sessions')
+        .select('id, date, label, status')
+        .order('date', { ascending: false })
+        .limit(500);
+      if (error) throw error;
+      return data ?? [];
+    },
+    staleTime: 60_000,
+  });
+}

--- a/web/src/hooks/useBenchmarkStatuses.js
+++ b/web/src/hooks/useBenchmarkStatuses.js
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { EVENT_LADDER } from '../constants/schedule.js';
+import { resolveLadderStatuses } from '../utils/benchmarkStatus.js';
+import { todayISO } from '../utils/eventWindow.js';
+import { useBenchmarkSessions } from './useBenchmarkSessions.js';
+
+// The only place in this feature that reads the clock. Everything below is pure
+// and takes `today` as an argument.
+export function useBenchmarkStatuses(ladder = EVENT_LADDER, options = {}) {
+  const { data, isPending, isError } = useBenchmarkSessions();
+  const sessionsReady = !isPending && !isError && Array.isArray(data);
+  const today = options.today ?? todayISO();
+
+  return useMemo(
+    () => resolveLadderStatuses(ladder, data, { today, sessionsReady }),
+    [ladder, data, today, sessionsReady]
+  );
+}

--- a/web/src/utils/__tests__/benchmarkStatus.test.js
+++ b/web/src/utils/__tests__/benchmarkStatus.test.js
@@ -1,0 +1,331 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLadderStatuses, selectUpcoming } from '../benchmarkStatus.js';
+import { COMPLETED_STATUSES } from '../../constants/sessionStatus.js';
+import { EVENT_LADDER } from '../../constants/schedule.js';
+
+const TODAY = '2026-08-20';
+
+const CP1 = EVENT_LADDER[0]; // 'Wed 1 Jul 26'   · CP Test #1 (4-min)
+const CP2 = EVENT_LADDER[1]; // '~Mid Jul 26'    · CP Test #2 (2nd duration)
+const TT5K = EVENT_LADDER[2]; // '~Early Aug 26' · 5k Time Trial
+const TEST2K = EVENT_LADDER[5]; // '~Mid Jan 27' · 2k Test
+
+// Real rows, real labels — the five completed sessions that actually sit inside
+// the ~Mid Jul window. None of them is a CP test, which is exactly why
+// window-only matching (any session in the window ⇒ done) is disqualified.
+const MID_JUL_DONE = [
+  {
+    id: 72,
+    date: '7/11/26',
+    label: 'UT1 55min steady @ 150-160W',
+    status: 'completed',
+  },
+  {
+    id: 74,
+    date: '7/13/26',
+    label: 'UT1 50min steady @ 148-158W',
+    status: 'completed',
+  },
+  {
+    id: 91,
+    date: '7/15/26',
+    label: 'UT1 Steady 50min @ 158W + 10min WU',
+    status: 'logged',
+  },
+  {
+    id: 79,
+    date: '7/17/26',
+    label: 'UT2 40min recovery @ 130-142W',
+    status: 'completed',
+  },
+  { id: 86, date: '7/20/26', label: 'Lower 1 (RDL-led)', status: 'actual' },
+];
+
+// The only session that names the CP retest — and it was cancelled.
+const CANCELLED_RETEST = {
+  id: 61,
+  date: '7/5/26',
+  label: 'CP RETEST — 1min + 4min max (rested, fed)',
+  status: 'cancelled',
+};
+
+// CP Test #1, genuinely done eight days early.
+const SESSION_45 = {
+  id: 45,
+  date: '6/23/26',
+  label: 'CP Test - 4min MAX (GATED)',
+  status: 'completed',
+};
+
+const EARLY_AUG_DONE = [
+  {
+    id: 97,
+    date: '8/1/26',
+    label: 'UT1 45min Ramp SR — peaks 250W',
+    status: 'completed',
+  },
+  {
+    id: 98,
+    date: '8/5/26',
+    label: '40min progressive build — final 10min @ 220W',
+    status: 'logged',
+  },
+  {
+    id: 90,
+    date: '8/10/26',
+    label: 'UT1 Steady 50min @ 164W (2:08.8/500) + 10min WU',
+    status: 'completed',
+  },
+];
+
+function resolve(ladder, sessions, today = TODAY) {
+  return resolveLadderStatuses(ladder, sessions, {
+    today,
+    sessionsReady: true,
+  });
+}
+
+describe('resolveLadderStatuses — due and overdue (AC1, AC2)', () => {
+  it('AC1 marks an elapsed benchmark with no matching session overdue', () => {
+    const [s] = resolve([CP2], []);
+    expect(s.status).toBe('overdue');
+    expect(s.daysOverdue).toBe(31);
+    expect(s.done).toBe(false);
+    expect(s.matchedSessionId).toBeNull();
+  });
+
+  it('AC2a marks a benchmark starting in 5 days upcoming', () => {
+    const entry = { date: '25 Aug 26', name: '2k Test', kind: 'benchmark' };
+    const [s] = resolve([entry], []);
+    expect(s.status).toBe('upcoming');
+    expect(s.daysUntilStart).toBe(5);
+    expect(s.daysOverdue).toBeNull();
+  });
+
+  it('AC2b keeps a started-but-not-ended window upcoming', () => {
+    const entry = { date: 'Mid Aug 26', name: '2k Test', kind: 'benchmark' };
+    const [s] = resolve([entry], []);
+    expect(s.status).toBe('upcoming');
+    expect(s.daysUntilStart).toBeLessThanOrEqual(0);
+  });
+
+  it('stays quiet while a benchmark is still more than a week away', () => {
+    const [s] = resolve([TEST2K], []);
+    expect(s.status).toBe('quiet');
+    expect(s.daysUntilStart).toBeNull();
+  });
+
+  it('carries the window, fuzzy flag, keywords, entry and index through', () => {
+    const [s] = resolve([CP2], []);
+    expect(s.window).toEqual({ start: '2026-07-11', end: '2026-07-20' });
+    expect(s.fuzzy).toBe(true);
+    expect(s.keywords).toEqual(['cp']);
+    expect(s.entry).toBe(CP2);
+    expect(s.index).toBe(0);
+  });
+});
+
+describe('resolveLadderStatuses — the real ladder today (AC3)', () => {
+  it('AC3a reports CP Test #2 overdue: the window is full of routine rows and the only CP session was cancelled', () => {
+    const [s] = resolve([CP2], [...MID_JUL_DONE, CANCELLED_RETEST]);
+    expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
+  });
+
+  it('AC3b reports the 5k Time Trial overdue although every session in its window is completed', () => {
+    const [s] = resolve([TT5K], EARLY_AUG_DONE);
+    expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
+  });
+
+  it('AC3c clears CP Test #1 from a session logged eight days before the window', () => {
+    const [s] = resolve([CP1], [SESSION_45]);
+    expect(s.status).toBe('quiet');
+    expect(s.done).toBe(true);
+    expect(s.matchedSessionId).toBe(45);
+  });
+
+  it('yields exactly two badges across the live ladder today', () => {
+    const states = resolve(EVENT_LADDER, [
+      SESSION_45,
+      ...MID_JUL_DONE,
+      CANCELLED_RETEST,
+      ...EARLY_AUG_DONE,
+    ]);
+    const loud = states.filter((s) => s.status !== 'quiet');
+    expect(loud.map((s) => [s.entry.name, s.status])).toEqual([
+      ['CP Test #2 (2nd duration)', 'overdue'],
+      ['5k Time Trial', 'overdue'],
+    ]);
+  });
+});
+
+describe('resolveLadderStatuses — what counts as done (AC4)', () => {
+  const labelled = (status) => [
+    { id: 1, date: '7/15/26', label: 'CP retest 4min max', status },
+  ];
+
+  it('AC4a does not count a cancelled session', () => {
+    expect(resolve([CP2], labelled('cancelled'))[0].status).toBe('overdue');
+  });
+
+  it('AC4b does not count a planned session', () => {
+    expect(resolve([CP2], labelled('planned'))[0].status).toBe('overdue');
+  });
+
+  it('AC4c reports overdue when there are no sessions at all', () => {
+    expect(resolve([CP2], [])[0].status).toBe('overdue');
+    expect(resolve([CP2], null)[0].status).toBe('overdue');
+    expect(resolve([CP2], undefined)[0].status).toBe('overdue');
+  });
+
+  it.each(COMPLETED_STATUSES)('AC4d counts a %s session as done', (status) => {
+    const [s] = resolve([CP2], labelled(status));
+    expect(s.status).toBe('quiet');
+    expect(s.done).toBe(true);
+    expect(s.matchedSessionId).toBe(1);
+  });
+});
+
+describe('resolveLadderStatuses — non-benchmark and unparseable entries (AC6, P2, L3)', () => {
+  it('AC6 leaves every competition, TARGET and optional entry quiet', () => {
+    const others = EVENT_LADDER.filter((e) => e.kind !== 'benchmark');
+    expect(others).toHaveLength(4);
+    const states = resolve(others, [], '2027-12-31');
+    expect(states.map((s) => s.status)).toEqual([
+      'quiet',
+      'quiet',
+      'quiet',
+      'quiet',
+    ]);
+    expect(states.every((s) => s.window === null)).toBe(true);
+  });
+
+  it('P2 leaves a benchmark with an unreadable date quiet rather than throwing', () => {
+    const entry = { date: 'someday', name: 'CP Test #3', kind: 'benchmark' };
+    const [s] = resolve([entry], [SESSION_45]);
+    expect(s.status).toBe('quiet');
+    expect(s.window).toBeNull();
+    expect(s.done).toBe(false);
+  });
+
+  it('never auto-clears a benchmark whose name yields no keywords', () => {
+    const entry = {
+      date: '~Mid Jul 26',
+      name: 'Critical Power retest',
+      kind: 'benchmark',
+    };
+    const [s] = resolve(
+      [entry],
+      [
+        {
+          id: 5,
+          date: '7/15/26',
+          label: 'Critical Power retest',
+          status: 'completed',
+        },
+      ]
+    );
+    expect(s.keywords).toEqual([]);
+    expect(s.status).toBe('overdue');
+  });
+
+  it('L3 returns an empty array for an empty ladder', () => {
+    expect(resolve([], [])).toEqual([]);
+    expect(resolve(null, [])).toEqual([]);
+  });
+});
+
+describe('resolveLadderStatuses — matching precision (P4, P5, AC7)', () => {
+  it('P4 does not let a 40min recovery row satisfy a 4min CP test', () => {
+    const [s] = resolve(
+      [CP1],
+      [
+        {
+          id: 79,
+          date: '7/1/26',
+          label: 'UT2 40min recovery @ 130-142W',
+          status: 'completed',
+        },
+      ]
+    );
+    expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
+  });
+
+  it('P5 lets only the earlier benchmark claim a shared CP session', () => {
+    const shared = {
+      id: 200,
+      date: '6/29/26',
+      label: 'CP test 4min max',
+      status: 'completed',
+    };
+    const [first, second] = resolve([CP1, CP2], [shared]);
+    expect(first.status).toBe('quiet');
+    expect(first.matchedSessionId).toBe(200);
+    expect(second.status).toBe('overdue');
+    expect(second.matchedSessionId).toBeNull();
+  });
+
+  it('AC7 keeps same-month benchmarks in different years independent', () => {
+    const lastYear = {
+      date: '~Mid Jan 26',
+      name: '2k Test',
+      kind: 'benchmark',
+    };
+    const states = resolve([lastYear, TEST2K], []);
+    expect(states[0].status).toBe('overdue');
+    expect(states[1].status).toBe('quiet');
+    expect(states[0].window.start).toBe('2026-01-11');
+    expect(states[1].window.start).toBe('2027-01-11');
+  });
+
+  it('returns states in ladder order even when claim order differs', () => {
+    const states = resolve([CP2, CP1], []);
+    expect(states.map((s) => s.entry)).toEqual([CP2, CP1]);
+    expect(states.map((s) => s.index)).toEqual([0, 1]);
+  });
+
+  it('honours a graceDays override', () => {
+    const tight = resolveLadderStatuses([CP1], [SESSION_45], {
+      today: TODAY,
+      sessionsReady: true,
+      graceDays: 3,
+    });
+    expect(tight[0].status).toBe('overdue');
+  });
+
+  it('ignores sessions with an unreadable date', () => {
+    const [s] = resolve(
+      [CP2],
+      [{ id: 9, date: 'sometime', label: 'CP retest', status: 'completed' }]
+    );
+    expect(s.status).toBe('overdue');
+  });
+});
+
+describe('resolveLadderStatuses — loading (L1) and selectUpcoming', () => {
+  it('L1 reports unknown for every entry until the sessions land', () => {
+    const states = resolveLadderStatuses(EVENT_LADDER, undefined, {
+      today: TODAY,
+      sessionsReady: false,
+    });
+    expect(states).toHaveLength(EVENT_LADDER.length);
+    expect(states.every((s) => s.status === 'unknown')).toBe(true);
+    expect(states.some((s) => s.status === 'overdue')).toBe(false);
+    expect(states.every((s) => s.done === false)).toBe(true);
+    expect(states.every((s) => s.window === null)).toBe(true);
+  });
+
+  it('reports unknown when today is missing', () => {
+    const states = resolveLadderStatuses([CP2], [], { sessionsReady: true });
+    expect(states[0].status).toBe('unknown');
+  });
+
+  it('selectUpcoming returns only the upcoming states', () => {
+    const entry = { date: '25 Aug 26', name: '2k Test', kind: 'benchmark' };
+    const states = resolve([CP2, entry], []);
+    expect(selectUpcoming(states).map((s) => s.entry)).toEqual([entry]);
+    expect(selectUpcoming(null)).toEqual([]);
+  });
+});

--- a/web/src/utils/__tests__/benchmarkStatus.test.js
+++ b/web/src/utils/__tests__/benchmarkStatus.test.js
@@ -253,6 +253,23 @@ describe('resolveLadderStatuses — matching precision (P4, P5, AC7)', () => {
     expect(s.done).toBe(false);
   });
 
+  // The discriminating case. '40min' above does not contain '4min' at all, so a
+  // naive label.includes(keyword) rejects it too and the test cannot tell the
+  // two implementations apart. '24min' does contain '4min', so substring
+  // matching would wrongly clear CP Test #1 here and whole-token must not.
+  it('P4 does not let a 24min row substring-match the 4min CP test', () => {
+    const label = 'UT2 24min recovery @ 130-142W';
+    expect(label.toLowerCase().includes('4min')).toBe(true);
+
+    const [s] = resolve(
+      [CP1],
+      [{ id: 80, date: '7/1/26', label, status: 'completed' }]
+    );
+    expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
+    expect(s.matchedSessionId).toBeNull();
+  });
+
   it('P5 lets only the earlier benchmark claim a shared CP session', () => {
     const shared = {
       id: 200,
@@ -265,6 +282,26 @@ describe('resolveLadderStatuses — matching precision (P4, P5, AC7)', () => {
     expect(first.matchedSessionId).toBe(200);
     expect(second.status).toBe('overdue');
     expect(second.matchedSessionId).toBeNull();
+  });
+
+  // Claim order falls back to ladder position when two benchmarks open on the
+  // same day; without the tie-break the winner would depend on sort stability.
+  it('P5b breaks a claim-order tie on ladder position', () => {
+    const shape = { kind: 'benchmark', phase: 'Base', serves: 'calibration' };
+    const a = { ...shape, date: '~Mid Jul 26', name: 'CP Test A (4-min)' };
+    const b = { ...shape, date: '~Mid Jul 26', name: 'CP Test B (4-min)' };
+    const shared = {
+      id: 201,
+      date: '7/12/26',
+      label: 'CP test 4min max',
+      status: 'completed',
+    };
+
+    const [first, second] = resolve([a, b], [shared]);
+    expect(first.window.start).toBe(second.window.start);
+    expect(first.matchedSessionId).toBe(201);
+    expect(second.matchedSessionId).toBeNull();
+    expect(second.status).toBe('overdue');
   });
 
   it('AC7 keeps same-month benchmarks in different years independent', () => {

--- a/web/src/utils/__tests__/eventWindow.test.js
+++ b/web/src/utils/__tests__/eventWindow.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { EVENT_LADDER } from '../../constants/schedule.js';
+import {
+  BENCHMARK_GRACE_DAYS,
+  addCalendarDays,
+  benchmarkKeywords,
+  diffCalendarDays,
+  parseEventWindow,
+  todayISO,
+  tokenize,
+} from '../eventWindow.js';
+
+describe('parseEventWindow', () => {
+  // P1 — every live EVENT_LADDER date string, including the en-dash range, the
+  // '~' fuzzy marker, the 🎯 emoji and the 'Wed' weekday prefix.
+  const LIVE = [
+    ['Wed 1 Jul 26', '2026-07-01', '2026-07-01', false],
+    ['~Mid Jul 26', '2026-07-11', '2026-07-20', true],
+    ['~Early Aug 26', '2026-08-01', '2026-08-10', true],
+    ['12 Sep–9 Oct 26', '2026-09-12', '2026-10-09', false],
+    ['Nov–Dec 26', '2026-11-01', '2026-12-31', true],
+    ['~Mid Jan 27', '2027-01-11', '2027-01-20', true],
+    ['Late Jan 27', '2027-01-21', '2027-01-31', true],
+    ['🎯 Late Feb 27', '2027-02-21', '2027-02-28', true],
+    ['Early Mar 27', '2027-03-01', '2027-03-10', true],
+  ];
+
+  it.each(LIVE)('parses %s', (input, start, end, fuzzy) => {
+    expect(parseEventWindow(input)).toEqual({ start, end, fuzzy });
+  });
+
+  it('covers every date string in the live ladder', () => {
+    for (const entry of EVENT_LADDER) {
+      expect(parseEventWindow(entry.date)).not.toBeNull();
+    }
+    expect(LIVE.map((l) => l[0])).toEqual(EVENT_LADDER.map((e) => e.date));
+  });
+
+  // AC2c — fuzzy source vs exact source.
+  it('marks a qualifier window fuzzy and an explicit day exact', () => {
+    expect(parseEventWindow('~Mid Jul 26').fuzzy).toBe(true);
+    expect(parseEventWindow('Wed 1 Jul 26').fuzzy).toBe(false);
+  });
+
+  it('rolls the start year back when the range crosses New Year', () => {
+    expect(parseEventWindow('Nov–Jan 27')).toEqual({
+      start: '2026-11-01',
+      end: '2027-01-31',
+      fuzzy: true,
+    });
+  });
+
+  it('honours a year carried by the first part of a range', () => {
+    expect(parseEventWindow('1 Dec 26–5 Jan 27')).toEqual({
+      start: '2026-12-01',
+      end: '2027-01-05',
+      fuzzy: false,
+    });
+  });
+
+  it('accepts long and 4-letter month spellings', () => {
+    expect(parseEventWindow('Sept 26').start).toBe('2026-09-01');
+    expect(parseEventWindow('September 26').end).toBe('2026-09-30');
+  });
+
+  it('uses the real last day of a leap February', () => {
+    expect(parseEventWindow('Late Feb 28').end).toBe('2028-02-29');
+  });
+
+  // P2 — unparseable input never throws and never guesses.
+  it.each([
+    ['', 'empty'],
+    [null, 'null'],
+    [undefined, 'undefined'],
+    ['someday', 'prose'],
+    ['31 Feb 27', 'impossible day'],
+    ['not a date', 'no month'],
+    ['   ', 'whitespace'],
+    [42, 'non-string'],
+    ['Jul-Aug-Sep 26', 'three parts'],
+    ['Mid Jul', 'no year'],
+    ['99 Jul 26', 'day out of range'],
+    ['1 Sep 26–1 Jul 26', 'end before start'],
+  ])('returns null for %s (%s)', (input) => {
+    expect(parseEventWindow(input)).toBeNull();
+  });
+});
+
+describe('benchmarkKeywords', () => {
+  // P3 — the exact keyword sets for the five real benchmarks.
+  it.each([
+    ['CP Test #1 (4-min)', ['cp', '4min']],
+    ['CP Test #2 (2nd duration)', ['cp']],
+    ['5k Time Trial', ['5k']],
+    ['2k Test', ['2k']],
+    ['1000m + 1-min tune-ups', ['1000m', '1min']],
+  ])('derives %s', (name, expected) => {
+    expect(benchmarkKeywords(name)).toEqual(expected);
+  });
+
+  it('returns an empty list when nothing identifies the benchmark', () => {
+    expect(benchmarkKeywords('Erg Power Series')).toEqual([]);
+    expect(benchmarkKeywords('')).toEqual([]);
+    expect(benchmarkKeywords(null)).toEqual([]);
+  });
+
+  it('dedupes repeated keywords', () => {
+    expect(benchmarkKeywords('CP test, CP retest (4-min / 4min)')).toEqual([
+      'cp',
+      '4min',
+    ]);
+  });
+});
+
+describe('tokenize', () => {
+  it('folds a digit-letter hyphen but keeps separate numbers apart', () => {
+    expect(tokenize('UT2 40min recovery @ 130-142W')).toEqual([
+      'ut2',
+      '40min',
+      'recovery',
+      '130',
+      '142w',
+    ]);
+    expect(tokenize('CP Test #1 (4-min)')).toEqual(['cp', 'test', '1', '4min']);
+  });
+
+  it('returns an empty list for empty input', () => {
+    expect(tokenize('')).toEqual([]);
+    expect(tokenize(null)).toEqual([]);
+  });
+});
+
+describe('calendar arithmetic', () => {
+  it('counts whole days between ISO dates', () => {
+    expect(diffCalendarDays('2026-07-20', '2026-08-20')).toBe(31);
+    expect(diffCalendarDays('2026-08-20', '2026-08-20')).toBe(0);
+    expect(diffCalendarDays('2026-08-20', '2026-08-11')).toBe(-9);
+  });
+
+  it('adds and subtracts days across month boundaries', () => {
+    expect(addCalendarDays('2026-07-11', -BENCHMARK_GRACE_DAYS)).toBe(
+      '2026-06-27'
+    );
+    expect(addCalendarDays('2026-02-28', 1)).toBe('2026-03-01');
+    expect(addCalendarDays('2028-02-28', 1)).toBe('2028-02-29');
+  });
+
+  it('returns null for malformed input', () => {
+    expect(diffCalendarDays('7/20/26', '2026-08-20')).toBeNull();
+    expect(diffCalendarDays('2026-08-20', null)).toBeNull();
+    expect(addCalendarDays('nope', 1)).toBeNull();
+    expect(addCalendarDays('2026-08-20', NaN)).toBeNull();
+  });
+});
+
+// TZ — the timezone boundary. todayISO() must report the LOCAL calendar day.
+describe('timezone safety', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    delete globalThis.process.env.TZ;
+  });
+
+  it('todayISO reports the local day, not the UTC one, past local midnight', () => {
+    globalThis.process.env.TZ = 'Australia/Perth';
+    vi.useFakeTimers();
+    // 2026-08-20T16:30Z is already 2026-08-21 00:30 in Perth (UTC+8).
+    vi.setSystemTime(new Date('2026-08-20T16:30:00Z'));
+    expect(new Date().toISOString().slice(0, 10)).toBe('2026-08-20');
+    expect(todayISO()).toBe('2026-08-21');
+  });
+
+  it('diffCalendarDays is identical either side of the date line', () => {
+    globalThis.process.env.TZ = 'Pacific/Kiritimati';
+    const east = diffCalendarDays('2026-07-20', '2026-08-20');
+    globalThis.process.env.TZ = 'Pacific/Niue';
+    const west = diffCalendarDays('2026-07-20', '2026-08-20');
+    expect(east).toBe(31);
+    expect(west).toBe(31);
+  });
+
+  it('parseEventWindow is unaffected by the host timezone', () => {
+    globalThis.process.env.TZ = 'Pacific/Kiritimati';
+    expect(parseEventWindow('~Mid Jul 26').start).toBe('2026-07-11');
+    globalThis.process.env.TZ = 'Pacific/Niue';
+    expect(parseEventWindow('~Mid Jul 26').start).toBe('2026-07-11');
+  });
+});

--- a/web/src/utils/benchmarkStatus.js
+++ b/web/src/utils/benchmarkStatus.js
@@ -1,0 +1,122 @@
+import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+import { toISODate } from './dateFormat.js';
+import {
+  BENCHMARK_GRACE_DAYS,
+  addCalendarDays,
+  benchmarkKeywords,
+  diffCalendarDays,
+  parseEventWindow,
+  tokenize,
+} from './eventWindow.js';
+
+// Pure resolver: given the event ladder and the session rows, decide which
+// benchmarks are overdue, due soon, or quiet. `today` is INJECTED — nothing
+// below the hook layer reads the clock, so every case is reproducible.
+
+const UPCOMING_WITHIN_DAYS = 7;
+
+function baseState(entry, index) {
+  return {
+    entry,
+    index,
+    status: 'unknown',
+    window: null,
+    fuzzy: false,
+    done: false,
+    matchedSessionId: null,
+    daysUntilStart: null,
+    daysOverdue: null,
+    keywords: [],
+  };
+}
+
+function findMatch(sessions, keywords, searchStart, searchEnd, consumed) {
+  if (keywords.length === 0) return null;
+  for (const s of sessions) {
+    if (!s || !COMPLETED_STATUSES.includes(s.status)) continue;
+    if (consumed.has(s.id)) continue;
+    const iso = toISODate(s.date);
+    if (!iso || iso < searchStart || iso > searchEnd) continue;
+    const tokens = tokenize(s.label);
+    if (tokens.some((t) => keywords.includes(t))) return s;
+  }
+  return null;
+}
+
+export function resolveLadderStatuses(ladder, sessions, options = {}) {
+  const entries = Array.isArray(ladder) ? ladder : [];
+  const {
+    today,
+    sessionsReady,
+    graceDays = BENCHMARK_GRACE_DAYS,
+  } = options ?? {};
+  const states = entries.map(baseState);
+
+  // Loading or errored data is never overdue and never done — the badge stays
+  // silent rather than fabricating a signal from an empty payload.
+  if (!sessionsReady || !today) return states;
+
+  const rows = Array.isArray(sessions) ? sessions : [];
+  const pending = [];
+  for (const st of states) {
+    if (!st.entry || st.entry.kind !== 'benchmark') {
+      st.status = 'quiet';
+      continue;
+    }
+    const win = parseEventWindow(st.entry.date);
+    if (!win) {
+      st.status = 'quiet';
+      continue;
+    }
+    st.window = { start: win.start, end: win.end };
+    st.fuzzy = win.fuzzy;
+    st.keywords = benchmarkKeywords(st.entry.name);
+    pending.push(st);
+  }
+
+  // Claim order is chronological: an earlier benchmark takes the session first,
+  // so one CP effort cannot silently clear two CP tests.
+  pending.sort((a, b) =>
+    a.window.start === b.window.start
+      ? a.index - b.index
+      : a.window.start < b.window.start
+        ? -1
+        : 1
+  );
+
+  const consumed = new Set();
+  for (const st of pending) {
+    const searchStart = addCalendarDays(st.window.start, -graceDays);
+    const searchEnd = st.window.end > today ? st.window.end : today;
+    const match =
+      searchStart === null
+        ? null
+        : findMatch(rows, st.keywords, searchStart, searchEnd, consumed);
+    if (match) {
+      consumed.add(match.id);
+      st.done = true;
+      st.matchedSessionId = match.id;
+    }
+
+    if (st.done) {
+      st.status = 'quiet';
+    } else if (today > st.window.end) {
+      st.status = 'overdue';
+      st.daysOverdue = diffCalendarDays(st.window.end, today);
+    } else {
+      const until = diffCalendarDays(today, st.window.start);
+      if (until !== null && until <= UPCOMING_WITHIN_DAYS) {
+        st.status = 'upcoming';
+        st.daysUntilStart = until;
+      } else {
+        st.status = 'quiet';
+      }
+    }
+  }
+
+  return states;
+}
+
+export function selectUpcoming(states) {
+  return (states ?? []).filter((s) => s && s.status === 'upcoming');
+}

--- a/web/src/utils/eventWindow.js
+++ b/web/src/utils/eventWindow.js
@@ -1,0 +1,208 @@
+// Interprets the human prose in EVENT_LADDER[].date ("~Mid Jul 26",
+// "12 Sep-9 Oct 26", "Wed 1 Jul 26") into a concrete calendar interval, plus
+// the keyword/token helpers that decide whether a logged session represents a
+// given benchmark. This is a PARSER, not a formatter — it never produces a
+// display string, so it introduces no second formatDate variant.
+//
+// Every date crosses a function boundary as an ISO 'YYYY-MM-DD' STRING, never a
+// Date object, so comparisons are zero-padded lexical compares and timezone
+// never enters them. todayISO() is the ONLY function here that reads the clock.
+
+// Days of slack allowed BEFORE a benchmark window opens when searching for the
+// session that satisfies it. Tests done early (or a slipped date logged against
+// the original plan) still clear the signal.
+export const BENCHMARK_GRACE_DAYS = 14;
+
+// Hand-seeded benchmark vocabulary. 'cp' is the sole benchmark identifier that
+// carries no digit, so the digit-bearing token rule below cannot derive it.
+export const BENCHMARK_TERMS = ['cp'];
+
+const MONTHS = [
+  'jan',
+  'feb',
+  'mar',
+  'apr',
+  'may',
+  'jun',
+  'jul',
+  'aug',
+  'sep',
+  'oct',
+  'nov',
+  'dec',
+];
+
+const WEEKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+const QUALIFIERS = { early: 'early', mid: 'mid', late: 'late' };
+
+const ISO_SHAPE = /^\d{4}-\d{2}-\d{2}$/;
+const MS_PER_DAY = 86400000;
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+function daysInMonth(year, monthIndex) {
+  return new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+}
+
+// Lowercases, folds "4-min" to "4min" (a hyphen between a digit and a letter is
+// a spelling artefact, not a separator), then splits on every other
+// non-alphanumeric run. Whole tokens only — substring matching would let a
+// "40min" recovery row satisfy a "4min" CP test.
+export function tokenize(text) {
+  if (!text) return [];
+  return String(text)
+    .toLowerCase()
+    .replace(/(\d)-(?=[a-z])/g, '$1')
+    .replace(/([a-z])-(?=\d)/g, '$1')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+// Derives the tokens that identify a benchmark from its ladder name alone — no
+// new ladder field, no per-entry map. A token qualifies when it carries a digit
+// without being a bare numeral or an ordinal ('4min', '5k', '1000m'), or when
+// it is an explicit benchmark term ('cp').
+export function benchmarkKeywords(name) {
+  const out = [];
+  for (const t of tokenize(name)) {
+    const digitBearing =
+      /\d/.test(t) && !/^\d+$/.test(t) && !/^\d+(st|nd|rd|th)$/.test(t);
+    if ((digitBearing || BENCHMARK_TERMS.includes(t)) && !out.includes(t)) {
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+// Local calendar day, zero-padded. NOT toISOString().slice(0,10): that reports
+// the UTC day, which in Australia/Perth (UTC+8) rolls over at 16:00 local and
+// would flip a benchmark to overdue a day early.
+export function todayISO() {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+function isoParts(iso) {
+  if (typeof iso !== 'string' || !ISO_SHAPE.test(iso)) return null;
+  const [y, m, d] = iso.split('-').map(Number);
+  return [y, m, d];
+}
+
+// Both instants are built with Date.UTC from the same (y,m,d) shape, so the
+// difference is an exact multiple of a day in every host timezone.
+export function diffCalendarDays(fromISO, toISO) {
+  const a = isoParts(fromISO);
+  const b = isoParts(toISO);
+  if (!a || !b) return null;
+  return (
+    (Date.UTC(b[0], b[1] - 1, b[2]) - Date.UTC(a[0], a[1] - 1, a[2])) /
+    MS_PER_DAY
+  );
+}
+
+export function addCalendarDays(iso, days) {
+  const a = isoParts(iso);
+  if (!a || !Number.isFinite(days)) return null;
+  const d = new Date(Date.UTC(a[0], a[1] - 1, a[2]) + days * MS_PER_DAY);
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+}
+
+function parsePart(raw) {
+  let tokens = raw
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((t) => t.replace(/\.$/, ''));
+  if (tokens.length === 0) return null;
+
+  if (WEEKDAYS.includes(tokens[0].toLowerCase())) tokens = tokens.slice(1);
+
+  let year = null;
+  const last = tokens[tokens.length - 1];
+  if (tokens.length > 1 && /^\d{2}$/.test(last)) {
+    year = 2000 + Number(last);
+    tokens = tokens.slice(0, -1);
+  }
+
+  let qualifier = null;
+  let day = null;
+  let monthIndex = null;
+  for (const t of tokens) {
+    const lower = t.toLowerCase();
+    if (QUALIFIERS[lower]) {
+      qualifier = QUALIFIERS[lower];
+      continue;
+    }
+    if (/^\d{1,2}$/.test(lower)) {
+      const n = Number(lower);
+      if (n < 1 || n > 31) return null;
+      day = n;
+      continue;
+    }
+    const idx = MONTHS.indexOf(lower.slice(0, 3));
+    if (idx !== -1) monthIndex = idx;
+  }
+
+  if (monthIndex === null) return null;
+  return { qualifier, day, monthIndex, year };
+}
+
+function resolvePart(part, year) {
+  const lastDay = daysInMonth(year, part.monthIndex);
+  if (part.qualifier === 'early') return { first: 1, last: 10, fuzzy: true };
+  if (part.qualifier === 'mid') return { first: 11, last: 20, fuzzy: true };
+  if (part.qualifier === 'late')
+    return { first: 21, last: lastDay, fuzzy: true };
+  if (part.day !== null) {
+    if (part.day > lastDay) return null;
+    return { first: part.day, last: part.day, fuzzy: false };
+  }
+  return { first: 1, last: lastDay, fuzzy: true };
+}
+
+// '~Mid Jul 26' -> { start: '2026-07-11', end: '2026-07-20', fuzzy: true }
+// Returns null for anything it cannot read — the caller treats that as "no
+// window", never as "the window is today".
+export function parseEventWindow(dateText) {
+  if (typeof dateText !== 'string' || dateText.trim() === '') return null;
+
+  const normalised = dateText
+    .replace(/[–—]/g, '-')
+    .replace(/[^\x20-\x7E]/g, '')
+    .replace(/~/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (normalised === '') return null;
+
+  const rawParts = normalised.split('-');
+  if (rawParts.length > 2) return null;
+
+  const parts = rawParts.map(parsePart);
+  if (parts.some((p) => p === null)) return null;
+
+  const lastPart = parts[parts.length - 1];
+  const endYear = lastPart.year;
+  if (endYear === null) return null;
+
+  const firstPart = parts[0];
+  let startYear = firstPart.year;
+  if (startYear === null) {
+    startYear =
+      firstPart.monthIndex > lastPart.monthIndex ? endYear - 1 : endYear;
+  }
+
+  const startRange = resolvePart(firstPart, startYear);
+  const endRange =
+    parts.length === 1 ? startRange : resolvePart(lastPart, endYear);
+  if (!startRange || !endRange) return null;
+
+  const start = `${startYear}-${pad2(firstPart.monthIndex + 1)}-${pad2(startRange.first)}`;
+  const end = `${endYear}-${pad2(lastPart.monthIndex + 1)}-${pad2(endRange.last)}`;
+  if (start > end) return null;
+
+  return { start, end, fuzzy: startRange.fuzzy || endRange.fuzzy };
+}

--- a/web/src/utils/eventWindow.js
+++ b/web/src/utils/eventWindow.js
@@ -49,7 +49,7 @@ function daysInMonth(year, monthIndex) {
 // Lowercases, folds "4-min" to "4min" (a hyphen between a digit and a letter is
 // a spelling artefact, not a separator), then splits on every other
 // non-alphanumeric run. Whole tokens only — substring matching would let a
-// "40min" recovery row satisfy a "4min" CP test.
+// "24min" recovery row satisfy a "4min" CP test.
 export function tokenize(text) {
   if (!text) return [];
   return String(text)

--- a/web/src/views/CalendarView.jsx
+++ b/web/src/views/CalendarView.jsx
@@ -1,4 +1,6 @@
 import WorkoutItem from '../components/WorkoutItem.jsx';
+import BenchmarkBadge from '../components/BenchmarkBadge.jsx';
+import { useBenchmarkStatuses } from '../hooks/useBenchmarkStatuses.js';
 import {
   getRosterMode,
   resolveDay,
@@ -13,6 +15,9 @@ import {
 
 // ── CALENDAR VIEW ──
 export default function CalendarView({ loggedSessions, isWide }) {
+  // Resolved once for the FULL ladder; the panel below indexes into it
+  // positionally, so the badges stay aligned if the slice is ever widened.
+  const benchmarkStatuses = useBenchmarkStatuses();
   const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   const monthNames = [
     'Jan',
@@ -198,6 +203,7 @@ export default function CalendarView({ loggedSessions, isWide }) {
           UPCOMING EVENTS · SEASON 1 LADDER
         </div>
         {EVENT_LADDER.slice(0, 5).map((e, i) => {
+          const bench = benchmarkStatuses[i];
           const col =
             e.kind === 'TARGET'
               ? '#ff2d55'
@@ -237,6 +243,14 @@ export default function CalendarView({ loggedSessions, isWide }) {
                 }}
               >
                 {e.name}
+                {bench && (
+                  <BenchmarkBadge
+                    status={bench.status}
+                    fuzzy={bench.fuzzy}
+                    daysOverdue={bench.daysOverdue}
+                    daysUntilStart={bench.daysUntilStart}
+                  />
+                )}
               </div>
             </div>
           );

--- a/web/src/views/__tests__/CalendarView.test.jsx
+++ b/web/src/views/__tests__/CalendarView.test.jsx
@@ -1,13 +1,105 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EVENT_LADDER } from '../../constants/schedule.js';
+
+const statusesMock = vi.fn();
+
+// Mocked at the module boundary so the view test stays free of Supabase and of
+// the wall clock; the resolver itself is covered in benchmarkStatus.test.js.
+vi.mock('../../hooks/useBenchmarkStatuses.js', () => ({
+  useBenchmarkStatuses: (...args) => statusesMock(...args),
+}));
+
 import CalendarView from '../CalendarView.jsx';
+
+function quietStates() {
+  return EVENT_LADDER.map((entry, index) => ({
+    entry,
+    index,
+    status: 'quiet',
+    window: null,
+    fuzzy: false,
+    done: false,
+    matchedSessionId: null,
+    daysUntilStart: null,
+    daysOverdue: null,
+    keywords: [],
+  }));
+}
+
+// CalendarView now calls a useQuery-backed hook, so the render needs a client
+// even though the hook is mocked here (main.jsx already wraps <App>).
+function renderView() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <CalendarView loggedSessions={[]} isWide={false} />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  statusesMock.mockReset();
+  statusesMock.mockReturnValue(quietStates());
+});
 
 describe('CalendarView', () => {
   it('renders the week strip header and the upcoming events ladder', () => {
-    render(<CalendarView loggedSessions={[]} isWide={false} />);
+    renderView();
     expect(screen.getByText(/YOUR WEEKS/i)).toBeInTheDocument();
     expect(
       screen.getByText(/UPCOMING EVENTS · SEASON 1 LADDER/i)
     ).toBeInTheDocument();
+  });
+
+  it('shows no benchmark badges when every entry is quiet', () => {
+    renderView();
+    expect(screen.queryByText(/OVERDUE/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^DUE/)).not.toBeInTheDocument();
+  });
+
+  // R1 — the AC-3 signal actually reaches the surface Scott looks at.
+  it('renders an OVERDUE badge against the 5k Time Trial row', () => {
+    const states = quietStates();
+    states[2] = {
+      ...states[2],
+      status: 'overdue',
+      window: { start: '2026-08-01', end: '2026-08-10' },
+      fuzzy: true,
+      daysOverdue: 10,
+    };
+    statusesMock.mockReturnValue(states);
+    renderView();
+
+    const badge = screen.getByText('OVERDUE · 10d');
+    expect(badge).toBeInTheDocument();
+    expect(badge.parentElement.textContent).toContain('5k Time Trial');
+    expect(screen.getAllByText(/OVERDUE/)).toHaveLength(1);
+  });
+
+  it('renders a DUE badge with the fuzzy qualifier', () => {
+    const states = quietStates();
+    states[1] = {
+      ...states[1],
+      status: 'upcoming',
+      fuzzy: true,
+      daysUntilStart: 3,
+    };
+    statusesMock.mockReturnValue(states);
+    renderView();
+
+    const badge = screen.getByText('DUE · 3d · exact date TBD');
+    expect(badge.parentElement.textContent).toContain(
+      'CP Test #2 (2nd duration)'
+    );
+  });
+
+  it('resolves the full ladder once, not per row', () => {
+    renderView();
+    expect(statusesMock).toHaveBeenCalledTimes(1);
+    expect(statusesMock).toHaveBeenCalledWith();
   });
 });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -109,6 +109,22 @@ export default defineConfig({
         // per-file as it lands. The global floor above ratchets toward this as
         // the monolith is decomposed and its exclusions fall away.
         'src/utils/sentry.js': { lines: 80, functions: 80, branches: 70 },
+        'src/utils/eventWindow.js': { lines: 80, functions: 80, branches: 70 },
+        'src/utils/benchmarkStatus.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/hooks/useBenchmarkStatuses.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/components/BenchmarkBadge.jsx': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
         'src/utils/dateFormat.js': { lines: 80, functions: 80, branches: 70 },
         'src/components/ErrorFallback.jsx': {
           lines: 80,


### PR DESCRIPTION
Closes #175

## What changed and why

Scheduled benchmark tests were slipping silently. The CP retest was cancelled on 7/5 and never rescheduled (session 61), the end-of-base 5k never happened at all, and `anchors` has been untouched since 7/1. The event ladder rendered as static text, so neither gap surfaced anywhere in the app.

This adds an `OVERDUE` / `DUE` badge to the ladder panel in `CalendarView`. On today's data it produces exactly two badges — CP Test #2 and the 5k Time Trial — which are precisely the two tests that slipped.

**New files**

| File | Layer | Purpose |
| --- | --- | --- |
| `utils/eventWindow.js` | utils | Parses fuzzy ladder dates (`~Mid Jul 26`, `12 Sep–9 Oct 26`) into calendar windows; keyword derivation; timezone-safe day arithmetic |
| `utils/benchmarkStatus.js` | utils | Pure resolver: ladder + sessions → per-entry status, with grace window and claim-once |
| `hooks/useBenchmarkSessions.js` | hooks | Scoped query, key `['sessions','benchmark-window']` |
| `hooks/useBenchmarkStatuses.js` | hooks | Composes query + resolver; the only clock read in the feature |
| `components/BenchmarkBadge.jsx` | components | Presentational pill, inline styles, no data access |

`views/CalendarView.jsx` gains two imports, one hook call, and one JSX element (+14 lines).

## Design decisions worth reviewing

`EVENT_LADDER` entries carry **no link to a `sessions` row** — no id, no label key, no date join. So "was this benchmark done?" is answered heuristically, and the details matter:

- **Whole-token keyword matching**, not substring. Under substring matching a `24min` recovery row would satisfy the `4min` CP test.
- **14-day backward grace.** Not cosmetic — session 61, the only row representing the CP retest, is dated six days *before* its own window opens, so a strict in-window search could never clear it. It also prevents a false overdue on CP Test #1, genuinely completed eight days early.
- **Claim-once.** CP tests #1 and #2 share the `cp` keyword with overlapping grace ranges; without this, one session clears both and masks a genuinely missed test.
- **`cancelled` and `planned` read as NOT done.** `COMPLETED_STATUSES` is imported, never redefined. The `loggedSessions` prop is deliberately unused here — `useSessionLog`'s `status !== 'planned'` filter puts cancelled rows into it, which would invert the whole feature.
- **`today` is injected**, never read inside the pure modules, and uses local calendar fields rather than UTC so a benchmark doesn't flip overdue a day early east of UTC.
- **Query key is prefix-matched** by the existing `invalidateQueries({ queryKey: ['sessions'] })` calls, so completing a session clears the badge with no new wiring.

Keyword matching is the weak point. It is bounded by tests that assert its known failure modes in both directions, and the durable fix — a real ladder↔session link — is filed as #188.

`views/program/ProgramYear.jsx` is untouched; it is mid-split per #77/#114.

## Follow-ups filed

- **#187** — `sessions.date` text ordering plus `limit(50)` silently drops 21 of 63 recent sessions from three live consumers. This PR sidesteps it with a scoped 500-row query rather than fixing it.
- **#188** — replace keyword matching with a structural ladder↔session link.

## How to test manually

1. Open the calendar view. The UPCOMING EVENTS ladder should show `OVERDUE` against **CP Test #2 (2nd duration)** and **5k Time Trial**, and nothing against CP Test #1 (completed early, session 45).
2. Log a session whose label contains a benchmark keyword inside the window — the badge clears on the next query refresh, with no manual reload.

## Checklist

- [x] Tests cover the change — 89 new tests across 4 files; full suite 518 passing
- [x] `npm run lint` — 0 errors (4 pre-existing warnings, none in new files)
- [x] `npm run format:check` — clean
- [x] `npm run build` — passes
- [x] Coverage — new files at 100% lines/functions, 94–100% branches, each pinned at 80/80/70; no threshold lowered
- [ ] CI green — the PR-title check is currently failing (title is not Conventional Commits); see the note below

> The whole-token guard originally shipped with a test that could not fail: `40min` does not contain `4min` as a substring, so the naive implementation the guard exists to exclude passed it too. Replaced with a `24min` case and verified by mutation — swapping the resolver to substring matching now fails it.

https://claude.ai/code/session_01PCjTVArPxSSJZwSuViuspU