### PR TITLE
fix: make the benchmark badge actually clear when the benchmark is done

### DIFF
--- a/web/src/hooks/__tests__/useBenchmarkStatuses.test.js
+++ b/web/src/hooks/__tests__/useBenchmarkStatuses.test.js
@@ -15,12 +15,26 @@ import { useBenchmarkStatuses } from '../useBenchmarkStatuses.js';
 import { EVENT_LADDER } from '../../constants/schedule.js';
 
 const TODAY = '2026-08-20';
-const LADDER = [EVENT_LADDER[1]]; // '~Mid Jul 26' · CP Test #2 (2nd duration)
+// The full ladder, not just entry 1. AC5 is the criterion the shipped defect
+// violated, and a one-entry ladder removes the entry that does the stealing —
+// this test was blind to its own bug. IDX is CP Test #2's position.
+const LADDER = EVENT_LADDER;
+const IDX = 1;
 
 const RETEST = {
   id: 61,
   date: '7/5/26',
   label: 'CP RETEST — 1min + 4min max (rested, fed)',
+};
+
+// CP Test #1, genuinely completed eight days early. Present in the live table,
+// so the full-ladder tests below must carry it: without it CP Test #1 has no
+// candidate of its own and legitimately competes for the retest.
+const CP1_DONE = {
+  id: 45,
+  date: '6/23/26',
+  label: 'CP Test - 4min MAX (GATED)',
+  status: 'completed',
 };
 
 let payload = { data: [], error: null };
@@ -59,7 +73,7 @@ describe('useBenchmarkStatuses', () => {
   it('reports unknown while the sessions query is still pending', () => {
     mockSessions();
     const { result } = setup();
-    expect(result.current).toHaveLength(1);
+    expect(result.current).toHaveLength(EVENT_LADDER.length);
     expect(result.current[0].status).toBe('unknown');
   });
 
@@ -83,16 +97,23 @@ describe('useBenchmarkStatuses', () => {
   // existing invalidateQueries({ queryKey: ['sessions'] }) call sites: the
   // benchmark key is a prefix match of theirs.
   it('AC5 flips from overdue to quiet when the cancelled retest is completed', async () => {
-    payload = { data: [{ ...RETEST, status: 'cancelled' }], error: null };
+    payload = {
+      data: [{ ...RETEST, status: 'cancelled' }, CP1_DONE],
+      error: null,
+    };
     mockSessions();
     const { result, client } = setup();
-    await waitFor(() => expect(result.current[0].status).toBe('overdue'));
+    await waitFor(() => expect(result.current[IDX].status).toBe('overdue'));
 
-    payload = { data: [{ ...RETEST, status: 'logged' }], error: null };
+    payload = {
+      data: [{ ...RETEST, status: 'logged' }, CP1_DONE],
+      error: null,
+    };
     await client.invalidateQueries({ queryKey: ['sessions'] });
 
-    await waitFor(() => expect(result.current[0].status).toBe('quiet'));
-    expect(result.current[0].matchedSessionId).toBe(61);
+    await waitFor(() => expect(result.current[IDX].status).toBe('quiet'));
+    expect(result.current[IDX].matchedSessionId).toBe(61);
+    expect(result.current[0].matchedSessionId).toBe(45);
   });
 
   // D1 — the clearing row must survive the payload size, not just the first page.
@@ -104,13 +125,13 @@ describe('useBenchmarkStatuses', () => {
       status: 'completed',
     }));
     payload = {
-      data: [...filler, { ...RETEST, status: 'completed' }],
+      data: [...filler, { ...RETEST, status: 'completed' }, CP1_DONE],
       error: null,
     };
     mockSessions();
     const { result } = setup();
-    await waitFor(() => expect(result.current[0].status).toBe('quiet'));
-    expect(result.current[0].matchedSessionId).toBe(61);
+    await waitFor(() => expect(result.current[IDX].status).toBe('quiet'));
+    expect(result.current[IDX].matchedSessionId).toBe(61);
   });
 
   it('defaults to the full live ladder', async () => {

--- a/web/src/utils/__tests__/benchmarkStatus.test.js
+++ b/web/src/utils/__tests__/benchmarkStatus.test.js
@@ -337,6 +337,58 @@ describe('resolveLadderStatuses — non-benchmark and unparseable entries (AC6, 
 });
 
 describe('resolveLadderStatuses — matching precision (P4, P5, AC7)', () => {
+  // A ride row ends "<time>, 22.4km, 1,000m" and that last field is ELEVATION.
+  // Once commas stopped splitting digit groups it tokenises to '1000m', which
+  // is a keyword of the 1000m benchmark — so the comma rule that made '5,000m'
+  // work also opened this. The km token is what separates a ride from a row.
+  it("P6 does not let a ride's elevation satisfy a distance benchmark", () => {
+    const K1000 = EVENT_LADDER.find((e) => e.name.startsWith('1000m'));
+    const [s] = resolveLadderStatuses(
+      [K1000],
+      [
+        {
+          id: 500,
+          date: '1/20/27',
+          label: 'Zwift Alpe du Zwift — 1:12:30, 22.4km, 1,000m',
+          status: 'completed',
+        },
+      ],
+      { today: '2027-02-05', sessionsReady: true }
+    );
+    expect(s.status).toBe('overdue');
+    expect(s.matchedSessionId).toBeNull();
+  });
+
+  it('P6b still clears a rowed 5,000m, which carries no km token', () => {
+    const [s] = resolve(
+      [TT5K],
+      [{ id: 25, date: '8/5/26', label: 'PM — 5,000m', status: 'completed' }]
+    );
+    expect(s.status).toBe('quiet');
+    expect(s.matchedSessionId).toBe(25);
+  });
+
+  // Same-date rows are common here (7/20/26 -> 84/85/86), so the id tie-break
+  // is a live path, not a defensive one.
+  it('P7 breaks a same-date tie on the lower session id', () => {
+    const rows = [
+      {
+        id: 86,
+        date: '6/29/26',
+        label: 'CP test 4min max',
+        status: 'completed',
+      },
+      {
+        id: 84,
+        date: '6/29/26',
+        label: 'CP test 4min max',
+        status: 'completed',
+      },
+    ];
+    expect(resolve([CP1], rows)[0].matchedSessionId).toBe(84);
+    expect(resolve([CP1], [...rows].reverse())[0].matchedSessionId).toBe(84);
+  });
+
   it('P4 does not let a 40min recovery row satisfy a 4min CP test', () => {
     const [s] = resolve(
       [CP1],

--- a/web/src/utils/__tests__/benchmarkStatus.test.js
+++ b/web/src/utils/__tests__/benchmarkStatus.test.js
@@ -10,8 +10,8 @@ const CP2 = EVENT_LADDER[1]; // '~Mid Jul 26'    · CP Test #2 (2nd duration)
 const TT5K = EVENT_LADDER[2]; // '~Early Aug 26' · 5k Time Trial
 const TEST2K = EVENT_LADDER[5]; // '~Mid Jan 27' · 2k Test
 
-// Real rows, real labels — the five completed sessions that actually sit inside
-// the ~Mid Jul window. None of them is a CP test, which is exactly why
+// Real rows, real labels, verified field-by-field against the live DB — the five
+// completed sessions that actually sit inside the ~Mid Jul window. None of them is a CP test, which is exactly why
 // window-only matching (any session in the window ⇒ done) is disqualified.
 const MID_JUL_DONE = [
   {
@@ -28,17 +28,17 @@ const MID_JUL_DONE = [
   },
   {
     id: 91,
-    date: '7/15/26',
+    date: '7/14/26',
     label: 'UT1 Steady 50min @ 158W + 10min WU',
-    status: 'logged',
+    status: 'completed',
   },
   {
     id: 79,
-    date: '7/17/26',
+    date: '7/16/26',
     label: 'UT2 40min recovery @ 130-142W',
     status: 'completed',
   },
-  { id: 86, date: '7/20/26', label: 'Lower 1 (RDL-led)', status: 'actual' },
+  { id: 86, date: '7/20/26', label: 'Lower 1 (RDL-led)', status: 'completed' },
 ];
 
 // The only session that names the CP retest — and it was cancelled.
@@ -60,19 +60,19 @@ const SESSION_45 = {
 const EARLY_AUG_DONE = [
   {
     id: 97,
-    date: '8/1/26',
+    date: '8/2/26',
     label: 'UT1 45min Ramp SR — peaks 250W',
     status: 'completed',
   },
   {
     id: 98,
-    date: '8/5/26',
+    date: '8/4/26',
     label: '40min progressive build — final 10min @ 220W',
-    status: 'logged',
+    status: 'completed',
   },
   {
     id: 90,
-    date: '8/10/26',
+    date: '8/7/26',
     label: 'UT1 Steady 50min @ 164W (2:08.8/500) + 10min WU',
     status: 'completed',
   },
@@ -158,6 +158,106 @@ describe('resolveLadderStatuses — the real ladder today (AC3)', () => {
       ['5k Time Trial', 'overdue'],
     ]);
   });
+});
+
+// The defect that shipped: every test above resolves a ONE-ENTRY ladder, which
+// removes the entry that does the stealing. These resolve the WHOLE ladder, in
+// the payload order the server actually returns.
+describe('resolveLadderStatuses — the whole ladder, real payload order', () => {
+  // sessions.date is TEXT, so .order('date', {ascending:false}) puts '7/5/26'
+  // above '6/23/26'. Selecting the first eligible row in payload order let CP
+  // Test #1 — whose search range runs forward to today, fifty days past its own
+  // one-day window — consume session 61 and leave CP Test #2 permanently
+  // overdue. Best-fit selection assigns each session to the benchmark it
+  // belongs to regardless of how the rows arrive.
+  const TEXT_DESC_PAYLOAD = [
+    {
+      id: 61,
+      date: '7/5/26',
+      label: 'CP RETEST — 1min + 4min max (rested, fed)',
+      status: 'completed',
+    },
+    {
+      id: 45,
+      date: '6/23/26',
+      label: 'CP Test - 4min MAX (GATED)',
+      status: 'completed',
+    },
+  ];
+
+  it('does not let CP Test #1 steal the session belonging to CP Test #2', () => {
+    const [first, second] = resolve(EVENT_LADDER, TEXT_DESC_PAYLOAD);
+    expect([first.matchedSessionId, second.matchedSessionId]).toEqual([45, 61]);
+    expect([first.status, second.status]).toEqual(['quiet', 'quiet']);
+  });
+
+  it('assigns the same way when the payload arrives in ascending date order', () => {
+    const [first, second] = resolve(
+      EVENT_LADDER,
+      [...TEXT_DESC_PAYLOAD].reverse()
+    );
+    expect([first.matchedSessionId, second.matchedSessionId]).toEqual([45, 61]);
+  });
+
+  it('AC3c leaves CP Test #2 overdue when only session 45 exists', () => {
+    const [first, second] = resolve(EVENT_LADDER, [
+      SESSION_45,
+      CANCELLED_RETEST,
+    ]);
+    expect(first.status).toBe('quiet');
+    expect(first.matchedSessionId).toBe(45);
+    expect(second.status).toBe('overdue');
+    expect(second.matchedSessionId).toBeNull();
+  });
+
+  // AC4, as the story actually reads it: Scott does the missed retest today and
+  // the badge clears — with CP Test #1 already accounted for by session 45.
+  it('AC4 clears CP Test #2 when the retest is logged today', () => {
+    const loggedToday = {
+      id: 210,
+      date: '8/20/26',
+      label: 'CP RETEST — 1min + 4min max',
+      status: 'logged',
+    };
+    const states = resolve(EVENT_LADDER, [
+      loggedToday,
+      SESSION_45,
+      ...MID_JUL_DONE,
+      CANCELLED_RETEST,
+      ...EARLY_AUG_DONE,
+    ]);
+    expect(states[0].matchedSessionId).toBe(45);
+    expect(states[1].status).toBe('quiet');
+    expect(states[1].matchedSessionId).toBe(210);
+    const loud = states.filter((st) => st.status !== 'quiet');
+    expect(loud.map((st) => st.entry.name)).toEqual(['5k Time Trial']);
+  });
+});
+
+describe('resolveLadderStatuses — 5k naming (FIX 2)', () => {
+  const in5kWindow = (id, label) => [
+    { id, date: '8/3/26', label, status: 'completed' },
+  ];
+
+  it.each([['5,000m'], ['PM — 5,000m'], ['5000m Time Trial'], ['5k TT']])(
+    'clears the 5k benchmark from a session labelled %s',
+    (label) => {
+      const [st] = resolve([TT5K], in5kWindow(30, label));
+      expect(st.status).toBe('quiet');
+      expect(st.matchedSessionId).toBe(30);
+    }
+  );
+
+  // One character from a false clear: the comma fold must not turn '18.5km'
+  // into a '5k' token. A bike ride is not a 5k time trial.
+  it.each([['Zwift Loopin Lava — 35:45, 18.5km, 212m'], ['Erg Session 14:32']])(
+    'does not clear the 5k benchmark from %s',
+    (label) => {
+      const [st] = resolve([TT5K], in5kWindow(31, label));
+      expect(st.status).toBe('overdue');
+      expect(st.done).toBe(false);
+    }
+  );
 });
 
 describe('resolveLadderStatuses — what counts as done (AC4)', () => {

--- a/web/src/utils/__tests__/eventWindow.test.js
+++ b/web/src/utils/__tests__/eventWindow.test.js
@@ -91,11 +91,24 @@ describe('benchmarkKeywords', () => {
   it.each([
     ['CP Test #1 (4-min)', ['cp', '4min']],
     ['CP Test #2 (2nd duration)', ['cp']],
-    ['5k Time Trial', ['5k']],
-    ['2k Test', ['2k']],
-    ['1000m + 1-min tune-ups', ['1000m', '1min']],
+    ['5k Time Trial', ['5k', '5000m']],
+    ['2k Test', ['2k', '2000m']],
+    ['1000m + 1-min tune-ups', ['1000m', '1k', '1min']],
   ])('derives %s', (name, expected) => {
     expect(benchmarkKeywords(name)).toEqual(expected);
+  });
+
+  // Scott's real labels spell 5k both ways ('5,000m', 'PM — 5,000m' in the live
+  // table; '5k TT' in newer rows). Both spellings have to reach the same
+  // keyword set or the badge can never clear.
+  it('expands k-notation and metre-notation into each other', () => {
+    expect(benchmarkKeywords('10k Test')).toEqual(['10k', '10000m']);
+    expect(benchmarkKeywords('10000m Test')).toEqual(['10000m', '10k']);
+  });
+
+  it('leaves a distance it cannot round-trip alone', () => {
+    expect(benchmarkKeywords('500m Test')).toEqual(['500m']);
+    expect(benchmarkKeywords('6k5 Test')).toEqual(['6k5']);
   });
 
   it('returns an empty list when nothing identifies the benchmark', () => {
@@ -122,6 +135,36 @@ describe('tokenize', () => {
       '142w',
     ]);
     expect(tokenize('CP Test #1 (4-min)')).toEqual(['cp', 'test', '1', '4min']);
+  });
+
+  // A comma between digits is a thousands separator, not a separator between
+  // two tokens — Scott's real 5k rows are labelled '5,000m'.
+  it('keeps a digit-grouping comma inside one token', () => {
+    expect(tokenize('5,000m')).toEqual(['5000m']);
+    expect(tokenize('PM — 5,000m')).toEqual(['pm', '5000m']);
+    expect(tokenize('1,234,567m')).toEqual(['1234567m']);
+  });
+
+  it('still splits on a comma that is not between digits', () => {
+    expect(tokenize('Row, then bike')).toEqual(['row', 'then', 'bike']);
+    expect(tokenize('5, 000m')).toEqual(['5', '000m']);
+    expect(tokenize('Zwift Loopin Lava — 35:45, 18.5km, 212m')).toEqual([
+      'zwift',
+      'loopin',
+      'lava',
+      '35',
+      '45',
+      '18',
+      '5km',
+      '212m',
+    ]);
+  });
+
+  // The letter-then-digit hyphen must NOT fold: folding it turns 'Row-2k' into
+  // 'row2k' and destroys the token the 2k Test benchmark matches on.
+  it('keeps a digit token that follows a hyphenated word', () => {
+    expect(tokenize('Row-2k test')).toEqual(['row', '2k', 'test']);
+    expect(tokenize('PM-5000m')).toEqual(['pm', '5000m']);
   });
 
   it('returns an empty list for empty input', () => {

--- a/web/src/utils/benchmarkStatus.js
+++ b/web/src/utils/benchmarkStatus.js
@@ -30,17 +30,41 @@ function baseState(entry, index) {
   };
 }
 
-function findMatch(sessions, keywords, searchStart, searchEnd, consumed) {
+// Ranks two eligible candidates: a session dated inside the entry's own window
+// beats one only in the grace/forward slack, then the earlier date wins, then
+// the lower id. Never "nearest to the window" — session 61 (7/5, four days off
+// the 7/1 window) is nearer than session 45 (6/23, eight days), so nearest-first
+// leaves the steal in place.
+function betterFit(a, b) {
+  if (a.inWindow !== b.inWindow) return a.inWindow;
+  if (a.iso !== b.iso) return a.iso < b.iso;
+  return a.session.id < b.session.id;
+}
+
+// Deterministic best fit, NOT the first row in payload order. The payload is
+// ordered by the TEXT date column, so '7/5/26' sorts above '6/23/26'; combined
+// with a search range that runs forward to today, first-in-order let CP Test #1
+// consume the session that belongs to CP Test #2 and the later badge could
+// never clear. Choosing by date instead of position also makes the result
+// independent of how the server happened to sort the rows.
+function findMatch(sessions, keywords, searchStart, searchEnd, consumed, win) {
   if (keywords.length === 0) return null;
+  let best = null;
   for (const s of sessions) {
     if (!s || !COMPLETED_STATUSES.includes(s.status)) continue;
     if (consumed.has(s.id)) continue;
     const iso = toISODate(s.date);
     if (!iso || iso < searchStart || iso > searchEnd) continue;
     const tokens = tokenize(s.label);
-    if (tokens.some((t) => keywords.includes(t))) return s;
+    if (!tokens.some((t) => keywords.includes(t))) continue;
+    const cand = {
+      session: s,
+      iso,
+      inWindow: iso >= win.start && iso <= win.end,
+    };
+    if (best === null || betterFit(cand, best)) best = cand;
   }
-  return null;
+  return best === null ? null : best.session;
 }
 
 export function resolveLadderStatuses(ladder, sessions, options = {}) {
@@ -91,7 +115,14 @@ export function resolveLadderStatuses(ladder, sessions, options = {}) {
     const match =
       searchStart === null
         ? null
-        : findMatch(rows, st.keywords, searchStart, searchEnd, consumed);
+        : findMatch(
+            rows,
+            st.keywords,
+            searchStart,
+            searchEnd,
+            consumed,
+            st.window
+          );
     if (match) {
       consumed.add(match.id);
       st.done = true;

--- a/web/src/utils/benchmarkStatus.js
+++ b/web/src/utils/benchmarkStatus.js
@@ -30,6 +30,15 @@ function baseState(entry, index) {
   };
 }
 
+// A Zwift/bike row ends "<time>, 22.4km, 1,000m" — that trailing field is
+// ELEVATION, and once commas stopped splitting digit groups it tokenises to
+// '1000m' and satisfies the 1000m/2k rowing benchmarks. Scott's rowing labels
+// spell distance '5,000m' and never carry a km token; every ride row does, so
+// the km token separates the two cases exactly.
+function hasRideDistance(tokens) {
+  return tokens.some((t) => /^\d+(?:\.\d+)?km$/.test(t));
+}
+
 // Ranks two eligible candidates: a session dated inside the entry's own window
 // beats one only in the grace/forward slack, then the earlier date wins, then
 // the lower id. Never "nearest to the window" — session 61 (7/5, four days off
@@ -57,6 +66,7 @@ function findMatch(sessions, keywords, searchStart, searchEnd, consumed, win) {
     if (!iso || iso < searchStart || iso > searchEnd) continue;
     const tokens = tokenize(s.label);
     if (!tokens.some((t) => keywords.includes(t))) continue;
+    if (hasRideDistance(tokens)) continue;
     const cand = {
       session: s,
       iso,

--- a/web/src/utils/eventWindow.js
+++ b/web/src/utils/eventWindow.js
@@ -46,16 +46,21 @@ function daysInMonth(year, monthIndex) {
   return new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
 }
 
-// Lowercases, folds "4-min" to "4min" (a hyphen between a digit and a letter is
-// a spelling artefact, not a separator), then splits on every other
-// non-alphanumeric run. Whole tokens only — substring matching would let a
+// Lowercases, drops a comma acting as a digit-group separator ("5,000m" is one
+// token, not "5" and "000m"), folds "4-min" to "4min" (a hyphen between a digit
+// and a letter is a spelling artefact, not a separator), then splits on every
+// other non-alphanumeric run. Whole tokens only — substring matching would let a
 // "24min" recovery row satisfy a "4min" CP test.
+//
+// The letter-then-digit direction is deliberately NOT folded: it would turn
+// "Row-2k test" into "row2k" and destroy the "2k" token the 2k Test benchmark
+// depends on. Only digit-then-letter is a spelling artefact.
 export function tokenize(text) {
   if (!text) return [];
   return String(text)
     .toLowerCase()
+    .replace(/(\d),(?=\d)/g, '$1')
     .replace(/(\d)-(?=[a-z])/g, '$1')
-    .replace(/([a-z])-(?=\d)/g, '$1')
     .replace(/[^a-z0-9]+/g, ' ')
     .trim()
     .split(/\s+/)
@@ -66,14 +71,28 @@ export function tokenize(text) {
 // new ladder field, no per-entry map. A token qualifies when it carries a digit
 // without being a bare numeral or an ordinal ('4min', '5k', '1000m'), or when
 // it is an explicit benchmark term ('cp').
+// Scott logs the same distance either way — "5k TT" and "5,000m" are one
+// benchmark — so a k-notation keyword also matches its metre spelling and vice
+// versa. Derived from the pattern, not a lookup table, so 2k/10k work too.
+function distanceAliases(token) {
+  const k = token.match(/^(\d+)k$/);
+  if (k) return [`${k[1]}000m`];
+  const m = token.match(/^(\d+)000m$/);
+  if (m) return [`${m[1]}k`];
+  return [];
+}
+
 export function benchmarkKeywords(name) {
   const out = [];
+  const add = (t) => {
+    if (!out.includes(t)) out.push(t);
+  };
   for (const t of tokenize(name)) {
     const digitBearing =
       /\d/.test(t) && !/^\d+$/.test(t) && !/^\d+(st|nd|rd|th)$/.test(t);
-    if ((digitBearing || BENCHMARK_TERMS.includes(t)) && !out.includes(t)) {
-      out.push(t);
-    }
+    if (!digitBearing && !BENCHMARK_TERMS.includes(t)) continue;
+    add(t);
+    for (const alias of distanceAliases(t)) add(alias);
   }
   return out;
 }

--- a/web/src/views/__tests__/CalendarView.benchmark.test.jsx
+++ b/web/src/views/__tests__/CalendarView.benchmark.test.jsx
@@ -15,7 +15,8 @@ vi.mock('../../supabaseClient.js', () => ({
 
 import CalendarView from '../CalendarView.jsx';
 
-// Real rows, live labels. Session 61's date sorts ABOVE 45's under the text
+// Live ids and labels; session 61's status is the counterfactual under test
+// (it is cancelled in the table). Its date sorts ABOVE 45's under the text
 // ordering the server applies, so this is the payload order the app receives.
 const PAYLOAD = [
   {
@@ -99,16 +100,25 @@ describe('CalendarView + useBenchmarkStatuses (integration, unmocked hook)', () 
     expect(screen.getByText(/UPCOMING EVENTS/i)).toBeInTheDocument();
   });
 
-  it('clears the 5k badge when the trial is logged as 5,000m', async () => {
+  // Waits on a POSITIVE render before asserting the 5k's badge is gone. An
+  // absence assertion on its own satisfies on the first tick while the query is
+  // still pending — it passes against an empty payload and against the pre-fix
+  // code, which is the toothless shape this file exists to prevent. Leaving CP
+  // Test #2 overdue gives the wait something real to settle on: pre-fix, the 5k
+  // is still overdue too and the count is 2.
+  it('clears only the 5k badge when the trial is logged as 5,000m', async () => {
     mockSessions([
-      ...PAYLOAD,
+      { ...PAYLOAD[0], status: 'cancelled' },
+      PAYLOAD[1],
       { id: 25, date: '8/3/26', label: 'PM — 5,000m', status: 'completed' },
     ]);
     renderView();
 
-    await waitFor(() => expect(fromMock).toHaveBeenCalledWith('sessions'));
-    await waitFor(() =>
-      expect(screen.queryByText(/^OVERDUE/)).not.toBeInTheDocument()
-    );
+    const badges = await screen.findAllByText(/^OVERDUE/);
+    expect(badges).toHaveLength(1);
+    expect(badges[0].parentElement.textContent).toContain('CP Test #2');
+
+    const badged = badges.map((b) => b.parentElement.textContent).join('|');
+    expect(badged).not.toContain('5k Time Trial');
   });
 });

--- a/web/src/views/__tests__/CalendarView.benchmark.test.jsx
+++ b/web/src/views/__tests__/CalendarView.benchmark.test.jsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const fromMock = vi.fn();
+
+// Supabase is mocked at the module boundary and NOTHING ELSE is — the real
+// useBenchmarkStatuses, the real resolver and the real badge all run. The
+// sibling CalendarView.test.jsx mocks the hook to pin badge rendering against
+// hand-built states; this one proves the whole chain actually joins up, which
+// is the seam the shipped defect slipped through.
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: { from: (...args) => fromMock(...args) },
+}));
+
+import CalendarView from '../CalendarView.jsx';
+
+// Real rows, live labels. Session 61's date sorts ABOVE 45's under the text
+// ordering the server applies, so this is the payload order the app receives.
+const PAYLOAD = [
+  {
+    id: 61,
+    date: '7/5/26',
+    label: 'CP RETEST — 1min + 4min max (rested, fed)',
+    status: 'completed',
+  },
+  {
+    id: 45,
+    date: '6/23/26',
+    label: 'CP Test - 4min MAX (GATED)',
+    status: 'completed',
+  },
+];
+
+function mockSessions(data) {
+  fromMock.mockImplementation(() => {
+    const chain = {
+      select: () => chain,
+      order: () => chain,
+      limit: () => Promise.resolve({ data, error: null }),
+    };
+    return chain;
+  });
+}
+
+function renderView() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <CalendarView loggedSessions={[]} isWide={false} />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  fromMock.mockReset();
+});
+
+describe('CalendarView + useBenchmarkStatuses (integration, unmocked hook)', () => {
+  // Every ladder window below is in the past for any real "today" from
+  // 2026-08-20 on, so the outcome does not drift with the wall clock. The day
+  // count inside the badge does, hence the prefix match.
+  it('badges only the 5k Time Trial row once both CP tests are accounted for', async () => {
+    mockSessions(PAYLOAD);
+    renderView();
+
+    const badge = await screen.findByText(/^OVERDUE/);
+    expect(badge.parentElement.textContent).toContain('5k Time Trial');
+    expect(screen.getAllByText(/^OVERDUE/)).toHaveLength(1);
+  });
+
+  it('badges CP Test #2 as well when its retest was cancelled', async () => {
+    mockSessions([{ ...PAYLOAD[0], status: 'cancelled' }, PAYLOAD[1]]);
+    renderView();
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/^OVERDUE/)).toHaveLength(2)
+    );
+    const rows = screen
+      .getAllByText(/^OVERDUE/)
+      .map((b) => b.parentElement.textContent);
+    expect(rows[0]).toContain('CP Test #2 (2nd duration)');
+    expect(rows[1]).toContain('5k Time Trial');
+  });
+
+  it('shows no badge at all while the sessions query is still pending', () => {
+    fromMock.mockImplementation(() => {
+      const chain = {
+        select: () => chain,
+        order: () => chain,
+        limit: () => new Promise(() => {}),
+      };
+      return chain;
+    });
+    renderView();
+    expect(screen.queryByText(/OVERDUE/)).not.toBeInTheDocument();
+    expect(screen.getByText(/UPCOMING EVENTS/i)).toBeInTheDocument();
+  });
+
+  it('clears the 5k badge when the trial is logged as 5,000m', async () => {
+    mockSessions([
+      ...PAYLOAD,
+      { id: 25, date: '8/3/26', label: 'PM — 5,000m', status: 'completed' },
+    ]);
+    renderView();
+
+    await waitFor(() => expect(fromMock).toHaveBeenCalledWith('sessions'));
+    await waitFor(() =>
+      expect(screen.queryByText(/^OVERDUE/)).not.toBeInTheDocument()
+    );
+  });
+});


### PR DESCRIPTION
Closes #175

## What changed and why

The benchmark due/overdue indicator shipped in #189 with a deterministic defect: completing a benchmark did not clear its badge — the exact silent failure #175 exists to prevent, inverted. This fixes that, plus two further defects found while validating the fix.

**The defect.** `findMatch` returned the first eligible session in payload order, and the payload is ordered by the TEXT `M/D/YY` column, so `'7/5/26'` sorts above `'6/23/26'`. Combined with `searchEnd = max(window.end, today)`, CP Test #1's search range ran ~50 days past its own one-day window and consumed the retest belonging to CP Test #2:

```
before:  [0] quiet   claimed=61   <- CP Test #1 steals the retest
         [1] overdue claimed=null <- CP Test #2 never clears
after:   [0] quiet   claimed=45
         [1] quiet   claimed=61
```

Match selection is now deterministic and independent of payload order: prefer a session inside the entry's own window, then earliest date, tie-break on lowest id. Nearest-to-window was considered and rejected — session 61 (`7/5`) is *nearer* to the `7/1` window than session 45 (`6/23`), so the steal would have survived it. Choosing by date rather than position also removes this feature's exposure to the ordering bug in #187.

**A 5k logged the way it is actually logged now clears.** The keyword was `5k`; the real labels are `5,000m` and `PM — 5,000m`. A comma between digits no longer splits a token, and keywords expand k-notation to metre-notation, so `5,000m`, `PM — 5,000m`, `5000m Time Trial` and `5k TT` all clear.

**A ride's elevation no longer clears a rowing benchmark.** That comma rule also made a Zwift label's trailing elevation field match — `… 1:12:30, 22.4km, 1,000m` tokenised to `1000m` and satisfied the 1000m benchmark, and 2,000m of climbing satisfied the 2k. A rowed distance is written `5,000m` and never carries a `km` token; every ride row does, so a `km` token now disqualifies a candidate.

**`Row-2k` keeps its `2k` token.** Dropping the letter-hyphen-digit fold restores conformance with the approved spec, which only ever specified the digit-then-letter direction. `4-min` → `4min` still folds; `130-142W` still splits.

## Test changes, which are the point of this PR

Every test that could have caught the defect resolved a **one-entry ladder**, which removes the entry that does the stealing, and the view test mocked the hook outright. All 19 of those tests pass against the buggy code.

- Full-ladder regression tests for the steal, in real payload order.
- One integration test that mocks only Supabase, so hook, resolver and badge run for real.
- AC5 and D1 widened from one-entry ladders to the full `EVENT_LADDER`. AC5 owns the criterion the defect violated and was blind to its own bug.
- The first version of the integration test **could not fail** — asserting only a badge's absence satisfies on the first tick while the query is still pending, so it passed against an empty payload where three badges render. Rewritten to settle on a positive render first, then re-probed to confirm it fails (`expected 1, got 3`).
- Coverage for the id tie-break, which same-date rows make a live path.
- 8 fixture fields corrected to the live rows they claim to be.

New and changed tests were run against the pre-fix source: **12 fail**, including both regression tests.

## How to test manually

Open the calendar. The ladder should show exactly two OVERDUE badges — CP Test #2 and the 5k Time Trial. Logging a session whose label names a benchmark clears that badge on the next query refresh.

Note, no code change needed: the PM5 live-save writes `<planned label> HH:MM`, so rowing a 5k with no planned session for that day lands as `Erg Session 14:32` and will not clear the badge. It clears when the plan names the benchmark, or when the row is logged manually or by Coach.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

547 tests pass; coverage 79.56 lines / 77.00 functions / 74.28 branches against the 72/71/68 floor raised by #186. Rebased onto `428d37a`.

Follow-ups filed from this work: #187 (`sessions.date` text ordering) and #188 (a real ladder↔session link, which would delete the keyword matcher entirely).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCjTVArPxSSJZwSuViuspU)_