### PR TITLE
feat: benchmark due/overdue indicator (Sprint 5 · T2)

### DIFF
--- a/web/src/components/BenchmarkStatusBanner.jsx
+++ b/web/src/components/BenchmarkStatusBanner.jsx
@@ -22,15 +22,58 @@ function shortDate(date) {
   return `${date.getDate()} ${MONTH_LABELS[date.getMonth()]}`;
 }
 
-// Two visible states only: OVERDUE and UPCOMING. There is deliberately no
+function containerStyle(compact) {
+  return {
+    background: THEME.surfaceAlt,
+    border: `1px solid ${THEME.divider}`,
+    borderRadius: 6,
+    padding: compact ? '8px 10px' : '12px 14px',
+    marginTop: 14,
+  };
+}
+
+function Heading() {
+  return (
+    <div
+      style={{
+        fontSize: 9,
+        letterSpacing: 2,
+        color: THEME.gold,
+        marginBottom: 8,
+      }}
+    >
+      BENCHMARKS
+    </div>
+  );
+}
+
+// Two signal states only: OVERDUE and UPCOMING. There is deliberately no
 // affirmative "all clear" state — with nothing to say the component renders
 // null, so an in-flight or failed session query cannot flash a false "done".
+// The one non-signal state, BENCHMARK STATUS UNAVAILABLE, is a negative
+// statement about the DATA and asserts nothing about the benchmarks.
 export default function BenchmarkStatusBanner({
   entries = EVENT_LADDER,
   today,
   compact = false,
 }) {
   const { data, isLoading, isError } = useBenchmarkSessions();
+
+  // Evaluated before derivation, so exactly one code path reaches the
+  // unavailable state and it can never co-render with a signal row. React
+  // Query v5 sets isError only when the query holds no successful data, so a
+  // background refetch failure cannot blank an already-correct banner.
+  if (isError) {
+    return (
+      <div style={containerStyle(compact)}>
+        {!compact && <Heading />}
+        <div style={{ fontSize: 9, letterSpacing: 2, color: THEME.muted }}>
+          BENCHMARK STATUS UNAVAILABLE
+        </div>
+      </div>
+    );
+  }
+
   const rows = deriveBenchmarkStatuses(entries, data ?? [], {
     today,
     sessionsReady: !isLoading && !isError,
@@ -42,27 +85,8 @@ export default function BenchmarkStatusBanner({
   if (visible.length === 0) return null;
 
   return (
-    <div
-      style={{
-        background: THEME.surfaceAlt,
-        border: `1px solid ${THEME.divider}`,
-        borderRadius: 6,
-        padding: compact ? '8px 10px' : '12px 14px',
-        marginTop: 14,
-      }}
-    >
-      {!compact && (
-        <div
-          style={{
-            fontSize: 9,
-            letterSpacing: 2,
-            color: THEME.gold,
-            marginBottom: 8,
-          }}
-        >
-          BENCHMARKS
-        </div>
-      )}
+    <div style={containerStyle(compact)}>
+      {!compact && <Heading />}
       {visible.map((r, i) => {
         const overdue = r.status === 'overdue';
         const accent = overdue ? THEME.orange : THEME.gold;

--- a/web/src/components/BenchmarkStatusBanner.jsx
+++ b/web/src/components/BenchmarkStatusBanner.jsx
@@ -1,0 +1,120 @@
+import { EVENT_LADDER } from '../constants/schedule.js';
+import { THEME } from '../constants/theme.js';
+import { useBenchmarkSessions } from '../hooks/useBenchmarkSessions.js';
+import { deriveBenchmarkStatuses } from '../utils/benchmarkStatus.js';
+
+const MONTH_LABELS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+function shortDate(date) {
+  return `${date.getDate()} ${MONTH_LABELS[date.getMonth()]}`;
+}
+
+// Two visible states only: OVERDUE and UPCOMING. There is deliberately no
+// affirmative "all clear" state — with nothing to say the component renders
+// null, so an in-flight or failed session query cannot flash a false "done".
+export default function BenchmarkStatusBanner({
+  entries = EVENT_LADDER,
+  today,
+  compact = false,
+}) {
+  const { data, isLoading, isError } = useBenchmarkSessions();
+  const rows = deriveBenchmarkStatuses(entries, data ?? [], {
+    today,
+    sessionsReady: !isLoading && !isError,
+  });
+  const visible = rows.filter(
+    (r) => r.status === 'overdue' || r.status === 'upcoming'
+  );
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        background: THEME.surfaceAlt,
+        border: `1px solid ${THEME.divider}`,
+        borderRadius: 6,
+        padding: compact ? '8px 10px' : '12px 14px',
+        marginTop: 14,
+      }}
+    >
+      {!compact && (
+        <div
+          style={{
+            fontSize: 9,
+            letterSpacing: 2,
+            color: THEME.gold,
+            marginBottom: 8,
+          }}
+        >
+          BENCHMARKS
+        </div>
+      )}
+      {visible.map((r, i) => {
+        const overdue = r.status === 'overdue';
+        const accent = overdue ? THEME.orange : THEME.gold;
+        return (
+          <div key={r.entry.name}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                gap: 8,
+                background: overdue ? `${THEME.orange}18` : `${THEME.gold}14`,
+                border: overdue
+                  ? `1px solid ${THEME.orange}55`
+                  : `1px solid ${THEME.gold}44`,
+                borderRadius: 4,
+                padding: '6px 8px',
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 9,
+                  fontWeight: 700,
+                  letterSpacing: 1,
+                  color: accent,
+                }}
+              >
+                {overdue ? '⚠ OVERDUE' : `● DUE IN ${r.daysUntil}d`}
+              </span>
+              <span style={{ fontSize: 11, fontWeight: 700, color: accent }}>
+                {r.entry.name}
+              </span>
+              <span style={{ fontSize: 10, color: THEME.text }}>
+                {r.entry.date}
+              </span>
+              <span style={{ fontSize: 9, color: THEME.textSubtle }}>
+                {overdue
+                  ? `was due ${shortDate(r.window.overdueAfter)} · ${r.daysOverdue}d ago`
+                  : `window opens ${shortDate(r.window.start)}`}
+              </span>
+            </div>
+            {i < visible.length - 1 && (
+              <div
+                style={{
+                  borderBottom: `1px solid ${THEME.divider}`,
+                  margin: '6px 0',
+                }}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/LogSessionForm.jsx
+++ b/web/src/components/LogSessionForm.jsx
@@ -83,6 +83,7 @@ export default function LogSessionForm({ onSaved }) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      queryClient.invalidateQueries({ queryKey: ['benchmark-sessions'] });
       setMsg({ type: 'ok', text: 'Saved! Session added to your log.' });
       reset();
       if (onSaved) onSaved();

--- a/web/src/components/__tests__/BenchmarkStatusBanner.test.jsx
+++ b/web/src/components/__tests__/BenchmarkStatusBanner.test.jsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { THEME } from '../../constants/theme.js';
+import { EVENT_LADDER } from '../../constants/schedule.js';
+
+const useBenchmarkSessionsMock = vi.fn();
+
+vi.mock('../../hooks/useBenchmarkSessions.js', () => ({
+  useBenchmarkSessions: (...args) => useBenchmarkSessionsMock(...args),
+}));
+
+import BenchmarkStatusBanner from '../BenchmarkStatusBanner.jsx';
+
+const SESSIONS = [
+  {
+    id: 45,
+    date: '6/23/26',
+    label: 'CP Test - 4min MAX (GATED)',
+    status: 'completed',
+  },
+  {
+    id: 61,
+    date: '7/5/26',
+    label: 'CP RETEST — 1min + 4min max (rested, fed)',
+    status: 'cancelled',
+  },
+];
+
+function renderView(props = {}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    React.createElement(
+      QueryClientProvider,
+      { client },
+      React.createElement(BenchmarkStatusBanner, props)
+    )
+  );
+}
+
+function rgb(hex) {
+  const n = parseInt(hex.slice(1), 16);
+  return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
+}
+
+const upcomingEntry = {
+  date: '~Early Aug 26',
+  name: 'Fixture Upcoming Test',
+  kind: 'benchmark',
+  windowStart: '2026-08-01',
+  windowEnd: '2026-08-10',
+  matchTerms: ['fixture'],
+};
+
+beforeEach(() => {
+  useBenchmarkSessionsMock.mockReset();
+  useBenchmarkSessionsMock.mockReturnValue({
+    data: SESSIONS,
+    isLoading: false,
+    isError: false,
+  });
+});
+
+describe('BenchmarkStatusBanner', () => {
+  it('renders nothing while the sessions query is in flight, with no all-clear copy', () => {
+    useBenchmarkSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    const { container } = renderView({ today: new Date(2026, 7, 20) });
+    expect(container.firstChild).toBeNull();
+    expect(container.textContent).not.toMatch(/DONE/i);
+    expect(container.textContent).not.toMatch(/UP TO DATE/i);
+    expect(container.textContent).not.toMatch(/ALL CLEAR/i);
+  });
+
+  it('renders nothing when the sessions query fails', () => {
+    useBenchmarkSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    const { container } = renderView({ today: new Date(2026, 7, 20) });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when no benchmark is due', () => {
+    const { container } = renderView({
+      entries: [upcomingEntry],
+      today: new Date(2026, 0, 1),
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the three overdue benchmarks on 2026-08-20', () => {
+    renderView({ today: new Date(2026, 7, 20) });
+    expect(screen.getByText('BENCHMARKS')).toBeInTheDocument();
+    expect(screen.getAllByText('⚠ OVERDUE').length).toBe(3);
+    for (const name of [
+      'CP Test #1 (4-min)',
+      'CP Test #2 (2nd duration)',
+      '5k Time Trial',
+    ]) {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    }
+    expect(screen.getByText(/was due 10 Aug · 10d ago/)).toBeInTheDocument();
+  });
+
+  it('never surfaces a competition, TARGET or optional entry', () => {
+    const { container } = renderView({ today: new Date(2026, 7, 20) });
+    const nonBenchmarks = EVENT_LADDER.filter((e) => e.kind !== 'benchmark');
+    expect(nonBenchmarks.length).toBe(4);
+    for (const e of nonBenchmarks) {
+      expect(container.textContent).not.toContain(e.name);
+    }
+  });
+
+  it('shows an upcoming benchmark with its countdown', () => {
+    renderView({ entries: [upcomingEntry], today: new Date(2026, 6, 28) });
+    expect(screen.getByText('● DUE IN 4d')).toBeInTheDocument();
+    expect(screen.getByText('Fixture Upcoming Test')).toBeInTheDocument();
+    expect(screen.queryByText('⚠ OVERDUE')).not.toBeInTheDocument();
+  });
+
+  it('distinguishes overdue from upcoming by colour, glyph and copy', () => {
+    const overdueView = renderView({ today: new Date(2026, 7, 20) });
+    const overdueBadge = overdueView.getAllByText('⚠ OVERDUE')[0];
+    expect(overdueBadge.style.color).toBe(rgb(THEME.orange));
+
+    const upcomingView = renderView({
+      entries: [upcomingEntry],
+      today: new Date(2026, 6, 28),
+    });
+    const upcomingBadge = upcomingView.getByText('● DUE IN 4d');
+    expect(upcomingBadge.style.color).toBe(rgb(THEME.gold));
+    expect(upcomingBadge.style.color).not.toBe(overdueBadge.style.color);
+  });
+
+  it('drops the section heading in compact mode', () => {
+    const { container } = renderView({
+      today: new Date(2026, 7, 20),
+      compact: true,
+    });
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.queryByText('BENCHMARKS')).not.toBeInTheDocument();
+    expect(screen.getAllByText('⚠ OVERDUE').length).toBe(3);
+  });
+
+  it('uses only THEME colours — no hard-coded literals in the inline styles', () => {
+    const { container } = renderView({ today: new Date(2026, 7, 20) });
+    const known = new Set(Object.values(THEME).map((v) => rgb(v.slice(0, 7))));
+    const markup = container.innerHTML;
+
+    // jsdom normalises every colour it understands to rgb()/rgba(), so any
+    // surviving hex would be a value it could not parse at all.
+    expect(markup).not.toMatch(/#[0-9a-f]{3,8}/i);
+
+    const colours = markup.match(/rgba?\([^)]*\)/g) ?? [];
+    expect(colours.length).toBeGreaterThan(0);
+    for (const colour of colours) {
+      const [r, g, b] = colour.match(/[\d.]+/g);
+      expect(known, `${colour} is not a THEME token`).toContain(
+        `rgb(${r}, ${g}, ${b})`
+      );
+    }
+  });
+});

--- a/web/src/components/__tests__/BenchmarkStatusBanner.test.jsx
+++ b/web/src/components/__tests__/BenchmarkStatusBanner.test.jsx
@@ -78,14 +78,63 @@ describe('BenchmarkStatusBanner', () => {
     expect(container.textContent).not.toMatch(/ALL CLEAR/i);
   });
 
-  it('renders nothing when the sessions query fails', () => {
+  it('states the status is unavailable when the sessions query fails, with no signal row', () => {
     useBenchmarkSessionsMock.mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: true,
     });
     const { container } = renderView({ today: new Date(2026, 7, 20) });
+    expect(
+      screen.getByText('BENCHMARK STATUS UNAVAILABLE')
+    ).toBeInTheDocument();
+    // A negative statement about the data — never an affirmative all-clear,
+    // and never dressed as a signal.
+    expect(container.textContent).not.toMatch(/OVERDUE/);
+    expect(container.textContent).not.toMatch(/DUE IN/);
+    expect(container.textContent).not.toContain('\u26a0');
+    expect(container.textContent).not.toContain('\u25cf');
+    expect(container.textContent).not.toMatch(/DONE/i);
+    expect(container.textContent).not.toMatch(/UP TO DATE/i);
+    expect(container.textContent).not.toMatch(/ALL CLEAR/i);
+  });
+
+  it('never shows the unavailable line while the query is still loading', () => {
+    useBenchmarkSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    const { container } = renderView({ today: new Date(2026, 7, 20) });
     expect(container.firstChild).toBeNull();
+    expect(container.textContent).not.toContain('UNAVAILABLE');
+  });
+
+  it('keeps the unavailable line but drops the heading in compact mode', () => {
+    useBenchmarkSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    renderView({ today: new Date(2026, 7, 20), compact: true });
+    expect(
+      screen.getByText('BENCHMARK STATUS UNAVAILABLE')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('BENCHMARKS')).not.toBeInTheDocument();
+  });
+
+  it('renders the unavailable line in the recessive muted token, never a signal colour', () => {
+    useBenchmarkSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    renderView({ today: new Date(2026, 7, 20) });
+    const line = screen.getByText('BENCHMARK STATUS UNAVAILABLE');
+    expect(line.style.color).toBe(rgb(THEME.muted));
+    for (const signal of [THEME.orange, THEME.gold, THEME.red]) {
+      expect(line.style.color).not.toBe(rgb(signal));
+    }
   });
 
   it('renders nothing when no benchmark is due', () => {

--- a/web/src/constants/schedule.js
+++ b/web/src/constants/schedule.js
@@ -315,6 +315,9 @@ export const EVENT_LADDER = [
     date: 'Wed 1 Jul 26',
     name: 'CP Test #1 (4-min)',
     kind: 'benchmark',
+    windowStart: '2026-07-01',
+    windowEnd: '2026-07-01',
+    matchTerms: ['cp test', 'cp retest'],
     phase: 'Base',
     serves:
       'Keystone pt 1 — first clean rowing-test anchor on fresh legs (post-FIFO taper). 4-min all-out (C2 protocol, pace-able, on the ranking). Sets a trustworthy threshold anchor; CP+W′ model completed by test #2 next home week. Unlocks %CP pacing + Power Guide.',
@@ -323,6 +326,9 @@ export const EVENT_LADDER = [
     date: '~Mid Jul 26',
     name: 'CP Test #2 (2nd duration)',
     kind: 'benchmark',
+    windowStart: '2026-07-11',
+    windowEnd: '2026-07-20',
+    matchTerms: ['cp test', 'cp retest'],
     phase: 'Base',
     serves:
       'Keystone pt 2 — second maximal effort at a different duration (e.g. 1-min + the 4-min, or a longer 7-10min piece) to complete the 2-point power-duration model. More reliable than any single all-out test. Builds CP + W′ properly.',
@@ -331,6 +337,9 @@ export const EVENT_LADDER = [
     date: '~Early Aug 26',
     name: '5k Time Trial',
     kind: 'benchmark',
+    windowStart: '2026-08-01',
+    windowEnd: '2026-08-10',
+    matchTerms: ['5k', '5000m', 'time trial'],
     phase: 'Base end',
     serves:
       'First real read on the 5000m format + what base built. Do fresh, low-stakes.',
@@ -355,6 +364,9 @@ export const EVENT_LADDER = [
     date: '~Mid Jan 27',
     name: '2k Test',
     kind: 'benchmark',
+    windowStart: '2027-01-11',
+    windowEnd: '2027-01-20',
+    matchTerms: ['2k', '2000m'],
     phase: 'Peak lead-in',
     serves:
       'Universal rowing benchmark — best single fitness measure, predicts across all distances. Pre-peak data.',
@@ -363,6 +375,9 @@ export const EVENT_LADDER = [
     date: 'Late Jan 27',
     name: '1000m + 1-min tune-ups',
     kind: 'benchmark',
+    windowStart: '2027-01-21',
+    windowEnd: '2027-01-31',
+    matchTerms: ['1000m', '1-min', 'tune-up'],
     phase: 'Peak',
     serves:
       'Race-specific rehearsals at Worlds distances, ~3-4wk out. Dial pacing, not compete.',

--- a/web/src/constants/schedule.js
+++ b/web/src/constants/schedule.js
@@ -377,7 +377,7 @@ export const EVENT_LADDER = [
     kind: 'benchmark',
     windowStart: '2027-01-21',
     windowEnd: '2027-01-31',
-    matchTerms: ['1000m', '1-min', 'tune-up'],
+    matchTerms: ['1000m', 'tune-up'],
     phase: 'Peak',
     serves:
       'Race-specific rehearsals at Worlds distances, ~3-4wk out. Dial pacing, not compete.',

--- a/web/src/hooks/__tests__/useBenchmarkSessions.test.js
+++ b/web/src/hooks/__tests__/useBenchmarkSessions.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const fromMock = vi.fn();
+const selectMock = vi.fn();
+const inMock = vi.fn();
+const orderMock = vi.fn();
+const limitMock = vi.fn();
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: (...args) => fromMock(...args),
+  },
+}));
+
+import { useBenchmarkSessions } from '../useBenchmarkSessions.js';
+
+let client;
+
+function makeWrapper() {
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  }
+  return Wrapper;
+}
+
+function mockQuery(data, error = null) {
+  const chain = {
+    select: (...args) => {
+      selectMock(...args);
+      return chain;
+    },
+    in: (...args) => {
+      inMock(...args);
+      return chain;
+    },
+    limit: (...args) => {
+      limitMock(...args);
+      return chain;
+    },
+    order: (...args) => {
+      orderMock(...args);
+      return Promise.resolve({ data, error });
+    },
+  };
+  fromMock.mockReturnValue(chain);
+}
+
+beforeEach(() => {
+  for (const m of [fromMock, selectMock, inMock, orderMock, limitMock]) {
+    m.mockReset();
+  }
+});
+
+async function renderQuery() {
+  const { result } = renderHook(() => useBenchmarkSessions(), {
+    wrapper: makeWrapper(),
+  });
+  return result;
+}
+
+describe('useBenchmarkSessions', () => {
+  it('caches under the ["benchmark-sessions"] query key', async () => {
+    mockQuery([]);
+    const result = await renderQuery();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(
+      client.getQueryCache().find({ queryKey: ['benchmark-sessions'] })
+    ).toBeDefined();
+  });
+
+  it("filters on .in('status', ['actual', 'completed', 'logged'])", async () => {
+    mockQuery([]);
+    const result = await renderQuery();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(inMock).toHaveBeenCalledWith('status', [
+      'actual',
+      'completed',
+      'logged',
+    ]);
+  });
+
+  it('selects id, date, label and status from sessions', async () => {
+    mockQuery([]);
+    const result = await renderQuery();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fromMock).toHaveBeenCalledWith('sessions');
+    const selected = selectMock.mock.calls[0][0];
+    for (const col of ['id', 'date', 'label', 'status']) {
+      expect(selected).toContain(col);
+    }
+  });
+
+  it('never applies a .limit() — a truncated page would fake an OVERDUE', async () => {
+    mockQuery([]);
+    const result = await renderQuery();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(limitMock).not.toHaveBeenCalled();
+    expect(orderMock).toHaveBeenCalledWith('id', { ascending: true });
+  });
+
+  it('rejects rather than returning [] when supabase errors', async () => {
+    mockQuery(null, { message: 'network error' });
+    const result = await renderQuery();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('returns [] when supabase returns null data', async () => {
+    mockQuery(null);
+    const result = await renderQuery();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('passes rows through unchanged', async () => {
+    const rows = [
+      { id: 1, date: '8/5/26', label: '5000m Time Trial', status: 'logged' },
+    ];
+    mockQuery(rows);
+    const result = await renderQuery();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(rows);
+  });
+});

--- a/web/src/hooks/useBenchmarkSessions.js
+++ b/web/src/hooks/useBenchmarkSessions.js
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../supabaseClient.js';
+import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+
+// No .limit() — deliberately. useSessions() pairs .limit(50) with an
+// .order('date', desc) on a TEXT MM/DD/YY column, which sorts lexically
+// ('12/1/26' < '7/1/26'), so its 50 rows are effectively arbitrary. A
+// benchmark session outside that slice would produce a false OVERDUE — the
+// exact failure this feature exists to prevent. The status filter keeps the
+// full result to a few kB.
+export function useBenchmarkSessions() {
+  return useQuery({
+    queryKey: ['benchmark-sessions'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('sessions')
+        .select('id, date, label, status')
+        .in('status', COMPLETED_STATUSES)
+        .order('id', { ascending: true });
+      if (error) throw error;
+      return data ?? [];
+    },
+    staleTime: 60_000,
+  });
+}

--- a/web/src/utils/__tests__/benchmarkStatus.test.js
+++ b/web/src/utils/__tests__/benchmarkStatus.test.js
@@ -2,10 +2,13 @@ import { describe, it, expect } from 'vitest';
 import {
   deriveBenchmarkStatuses,
   matchBenchmarkSession,
+  labelMatchesTerms,
+  normaliseLabel,
   BENCHMARK_MATCH_TOLERANCE_BEFORE_DAYS,
   BENCHMARK_MATCH_TOLERANCE_AFTER_DAYS,
   UPCOMING_WINDOW_DAYS,
 } from '../benchmarkStatus.js';
+import SOURCE from '../benchmarkStatus.js?raw';
 import { resolveEventWindow } from '../eventLadderDates.js';
 import { EVENT_LADDER } from '../../constants/schedule.js';
 
@@ -346,5 +349,213 @@ describe('matchBenchmarkSession details', () => {
 
   it('tolerates a non-array entries argument', () => {
     expect(deriveBenchmarkStatuses(null, [], { today: TODAY })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B1 + S1 delta. Real matchTerms straight off EVENT_LADDER — a test that
+// invents its own terms would not notice a term regressing in the constant.
+// ---------------------------------------------------------------------------
+
+const TERMS = {
+  cp: entryNamed('CP Test #1 (4-min)').matchTerms,
+  fiveK: entryNamed('5k Time Trial').matchTerms,
+  twoK: entryNamed('2k Test').matchTerms,
+  thousand: entryNamed('1000m + 1-min tune-ups').matchTerms,
+};
+
+const BENCHMARK_ENTRIES = EVENT_LADDER.filter((e) => e.kind === 'benchmark');
+const ALL_TERMS = BENCHMARK_ENTRIES.flatMap((e) => e.matchTerms);
+
+// Vite's `?raw` import gives the module's own source text — no fs, no
+// path juggling, and it tracks the file if it ever moves.
+
+describe('labelMatchesTerms — boundary (B1)', () => {
+  it('T5.1 does not read 18.5km as a 5k (live session 92)', () => {
+    // The decimal-point trap: `\b` would accept this, because the `.` before
+    // the `5` is itself a word boundary.
+    const label = 'Zwift Loopin Lava — 35:45, 18.5km, 212m';
+    expect(labelMatchesTerms(label, TERMS.fiveK)).toBe(false);
+    expect(labelMatchesTerms(label, ALL_TERMS)).toBe(false);
+  });
+
+  it('T5.2 does not read 22km as a 2k', () => {
+    const label = 'Zwift Alpe — 1:12:00, 22km, 1035m';
+    expect(labelMatchesTerms(label, TERMS.twoK)).toBe(false);
+    expect(labelMatchesTerms(label, ALL_TERMS)).toBe(false);
+  });
+
+  it('T5.3 does not read 12km as a 2k', () => {
+    const label = 'Bike Z2 45min — 12km';
+    expect(labelMatchesTerms(label, TERMS.twoK)).toBe(false);
+    expect(labelMatchesTerms(label, ALL_TERMS)).toBe(false);
+  });
+
+  it('T5.4 does not read 21000m as a 1000m', () => {
+    const label = 'Zwift Tempus — 41:00, 21000m';
+    expect(labelMatchesTerms(label, TERMS.thousand)).toBe(false);
+    expect(labelMatchesTerms(label, ALL_TERMS)).toBe(false);
+  });
+
+  it('T5.5 does not read a 1-min warm-up as the tune-ups benchmark', () => {
+    const label = 'Warm-up 1-min bursts x5';
+    expect(labelMatchesTerms(label, TERMS.thousand)).toBe(false);
+    expect(labelMatchesTerms(label, ALL_TERMS)).toBe(false);
+  });
+
+  it('T5.6 does not read 3x1-min bursts as the tune-ups benchmark', () => {
+    const label = '3x1-min bursts';
+    expect(labelMatchesTerms(label, TERMS.thousand)).toBe(false);
+    expect(labelMatchesTerms(label, ALL_TERMS)).toBe(false);
+  });
+
+  it('T5.7 rejects the decimal-bearing live labels 88 and 90', () => {
+    for (const label of [
+      'Off-program 10187m/45:00 @ ~150W (2:12.5/500)',
+      'UT1 Steady 50min @ 164W (2:08.8/500) + 10min WU',
+    ]) {
+      expect(labelMatchesTerms(label, TERMS.fiveK), label).toBe(false);
+      expect(labelMatchesTerms(label, TERMS.twoK), label).toBe(false);
+      expect(labelMatchesTerms(label, ALL_TERMS), label).toBe(false);
+    }
+  });
+
+  it('T5.8 rejects km distances and leading-digit forms', () => {
+    expect(labelMatchesTerms('Zwift ride 5km climb', TERMS.fiveK)).toBe(false);
+    expect(labelMatchesTerms('15000m long row', TERMS.fiveK)).toBe(false);
+    expect(labelMatchesTerms('21000m', TERMS.thousand)).toBe(false);
+    for (const label of ['Zwift ride 5km climb', '15000m long row', '21000m']) {
+      expect(labelMatchesTerms(label, ALL_TERMS), label).toBe(false);
+    }
+  });
+
+  it('T5.9 still matches the plural tune-ups on the singular term', () => {
+    expect(labelMatchesTerms('1000m + 1-min tune-ups', ['tune-up'])).toBe(true);
+    expect(labelMatchesTerms('1,000m tune-ups', ['tune-up'])).toBe(true);
+    expect(labelMatchesTerms('1000m tune-up rehearsal', ['tune-up'])).toBe(
+      true
+    );
+    for (const label of [
+      '1000m + 1-min tune-ups',
+      '1,000m tune-ups',
+      '1000m tune-up rehearsal',
+    ]) {
+      expect(labelMatchesTerms(label, TERMS.thousand), label).toBe(true);
+    }
+  });
+
+  it('T5.10 still matches the live CP test labels (45 and 61)', () => {
+    for (const label of [
+      'CP Test - 4min MAX (GATED)',
+      'CP RETEST — 1min + 4min max (rested, fed)',
+    ]) {
+      expect(labelMatchesTerms(label, TERMS.cp), label).toBe(true);
+    }
+  });
+
+  it('T5.11 still matches the plausible time-trial and 2k labels', () => {
+    for (const label of ['5k TT', '5K Time Trial (rested)', '5000m Time Trial'])
+      expect(labelMatchesTerms(label, TERMS.fiveK), label).toBe(true);
+    for (const label of ['2k Test', '2,000m Test'])
+      expect(labelMatchesTerms(label, TERMS.twoK), label).toBe(true);
+  });
+
+  it('T5.12 uses no regex lookbehind anywhere (iOS Safari < 16.4)', () => {
+    expect(SOURCE).toContain('labelMatchesTerms');
+    expect(SOURCE).not.toContain('(?<');
+  });
+
+  it('holds end-to-end: no MUST-NOT-MATCH label clears a benchmark', () => {
+    const traps = [
+      'Zwift Loopin Lava — 35:45, 18.5km, 212m',
+      'Zwift Alpe — 1:12:00, 22km, 1035m',
+      'Bike Z2 45min — 12km',
+      'Zwift Tempus — 41:00, 21000m',
+      'Warm-up 1-min bursts x5',
+      '3x1-min bursts',
+      'Baseline 10,000m',
+      'Long Row — 10,000m',
+      'AM — Long Row 10,000m',
+      '60min Row — 12,957m',
+      'Zwift ride 5km climb',
+      '15000m long row',
+      '21000m',
+    ];
+    // Dated inside every benchmark's match reach and marked completed, so
+    // only the label test can reject them.
+    const rows = run([
+      ...SESSIONS,
+      ...traps.map((label, i) => ({
+        id: 600 + i,
+        date: '8/5/26',
+        label,
+        status: 'completed',
+      })),
+    ]);
+    expect(rows.filter((r) => r.status === 'done').length).toBe(0);
+    expect(rows.filter((r) => r.status === 'overdue').length).toBe(3);
+  });
+});
+
+describe('normaliseLabel — thousands separators (S1)', () => {
+  it('T5.13 matches the comma form of 5,000m (live 19, 20, 25)', () => {
+    expect(normaliseLabel('5,000m')).toBe('5000m');
+    for (const label of ['5,000m', 'PM — 5,000m'])
+      expect(labelMatchesTerms(label, TERMS.fiveK), label).toBe(true);
+  });
+
+  it('T5.14 matches the comma form of 2,000m', () => {
+    expect(labelMatchesTerms('2,000m Test', TERMS.twoK)).toBe(true);
+  });
+
+  it('T5.15 adds no new hit for the 10,000m long rows (live 27, 21, 24, 29)', () => {
+    for (const label of [
+      'Baseline 10,000m',
+      'Long Row — 10,000m',
+      'AM — Long Row 10,000m',
+    ]) {
+      expect(labelMatchesTerms(label, TERMS.fiveK), label).toBe(false);
+      expect(labelMatchesTerms(label, TERMS.thousand), label).toBe(false);
+      expect(labelMatchesTerms(label, ALL_TERMS), label).toBe(false);
+    }
+  });
+
+  it('T5.16 adds no new hit for 12,957m (live 37)', () => {
+    expect(labelMatchesTerms('60min Row — 12,957m', ALL_TERMS)).toBe(false);
+  });
+
+  it('T5.17 strips every separator in one pass and still rejects 1,000,000m', () => {
+    expect(normaliseLabel('1,000,000m')).toBe('1000000m');
+    expect(labelMatchesTerms('1,000,000m', TERMS.thousand)).toBe(false);
+  });
+
+  it('lower-cases and tolerates a null label', () => {
+    expect(normaliseLabel('5K Time Trial')).toBe('5k time trial');
+    expect(normaliseLabel(null)).toBe('');
+    expect(normaliseLabel(undefined)).toBe('');
+    expect(labelMatchesTerms(null, TERMS.fiveK)).toBe(false);
+  });
+
+  it('ignores falsy terms and a non-array terms argument', () => {
+    expect(labelMatchesTerms('5k TT', ['', null, undefined])).toBe(false);
+    expect(labelMatchesTerms('5k TT', null)).toBe(false);
+  });
+
+  it('escapes regex metacharacters in a term instead of interpreting them', () => {
+    expect(labelMatchesTerms('a+b test', ['a+b'])).toBe(true);
+    expect(labelMatchesTerms('aab test', ['a+b'])).toBe(false);
+  });
+});
+
+describe('EVENT_LADDER matchTerms', () => {
+  it("T5.18 no benchmark carries '1-min', and the tune-ups entry is exactly ['1000m','tune-up']", () => {
+    expect(BENCHMARK_ENTRIES.length).toBe(5);
+    for (const e of BENCHMARK_ENTRIES) {
+      expect(e.matchTerms, e.name).not.toContain('1-min');
+    }
+    expect(entryNamed('1000m + 1-min tune-ups').matchTerms).toEqual([
+      '1000m',
+      'tune-up',
+    ]);
   });
 });

--- a/web/src/utils/__tests__/benchmarkStatus.test.js
+++ b/web/src/utils/__tests__/benchmarkStatus.test.js
@@ -1,0 +1,350 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveBenchmarkStatuses,
+  matchBenchmarkSession,
+  BENCHMARK_MATCH_TOLERANCE_BEFORE_DAYS,
+  BENCHMARK_MATCH_TOLERANCE_AFTER_DAYS,
+  UPCOMING_WINDOW_DAYS,
+} from '../benchmarkStatus.js';
+import { resolveEventWindow } from '../eventLadderDates.js';
+import { EVENT_LADDER } from '../../constants/schedule.js';
+
+// FIXTURE A — the AC9 truth table. Real production rows.
+const SESSIONS = [
+  {
+    id: 45,
+    date: '6/23/26',
+    label: 'CP Test - 4min MAX (GATED)',
+    status: 'completed',
+  },
+  {
+    id: 61,
+    date: '7/5/26',
+    label: 'CP RETEST — 1min + 4min max (rested, fed)',
+    status: 'cancelled',
+  },
+  {
+    id: 79,
+    date: '7/16/26',
+    label: 'UT2 40min recovery @ 130-142W',
+    status: 'completed',
+  },
+  {
+    id: 97,
+    date: '8/2/26',
+    label: 'UT1 45min Ramp SR — peaks 250W',
+    status: 'completed',
+  },
+  {
+    id: 90,
+    date: '8/7/26',
+    label: 'UT1 Steady 50min @ 164W (2:08.8/500) + 10min WU',
+    status: 'completed',
+  },
+];
+
+const TODAY = new Date(2026, 7, 20);
+
+function run(sessions = SESSIONS, options = {}) {
+  return deriveBenchmarkStatuses(EVENT_LADDER, sessions, {
+    today: TODAY,
+    ...options,
+  });
+}
+
+function byName(rows, name) {
+  return rows.find((r) => r.entry.name === name);
+}
+
+function entryNamed(name) {
+  return EVENT_LADDER.find((e) => e.name === name);
+}
+
+function fixtureEntry(windowStart, windowEnd, extra = {}) {
+  return {
+    date: 'unparseable-on-purpose',
+    name: 'Fixture Benchmark',
+    kind: 'benchmark',
+    windowStart,
+    windowEnd,
+    matchTerms: ['fixture'],
+    ...extra,
+  };
+}
+
+describe('deriveBenchmarkStatuses — AC9 truth table on 2026-08-20', () => {
+  it('signals exactly 3 overdue, 0 upcoming and 6 silent entries', () => {
+    const rows = run();
+    expect(rows.length).toBe(EVENT_LADDER.length);
+    expect(rows.filter((r) => r.status === 'overdue').length).toBe(3);
+    expect(rows.filter((r) => r.status === 'upcoming').length).toBe(0);
+    expect(
+      rows.filter((r) => r.status !== 'overdue' && r.status !== 'upcoming')
+        .length
+    ).toBe(6);
+  });
+
+  it('marks CP Test #1, CP Test #2 and the 5k Time Trial overdue', () => {
+    const rows = run();
+    for (const name of [
+      'CP Test #1 (4-min)',
+      'CP Test #2 (2nd duration)',
+      '5k Time Trial',
+    ]) {
+      expect(byName(rows, name).status, name).toBe('overdue');
+      expect(byName(rows, name).daysOverdue).toBeGreaterThan(0);
+    }
+  });
+
+  it('never resolves a window for non-benchmark entries (rule 1 short-circuits)', () => {
+    const rows = run();
+    const nonBenchmarks = rows.filter((r) => r.entry.kind !== 'benchmark');
+    expect(nonBenchmarks.length).toBe(4);
+    for (const r of nonBenchmarks) {
+      expect(r.status, r.entry.name).toBe('none');
+      expect(r.window, r.entry.name).toBeNull();
+      expect(r.matchedSession).toBeNull();
+    }
+  });
+
+  it('stays silent for benchmarks more than 7 days out', () => {
+    const rows = run();
+    expect(byName(rows, '2k Test').status).toBe('none');
+    expect(byName(rows, '1000m + 1-min tune-ups').status).toBe('none');
+    // resolved, just not signalling
+    expect(byName(rows, '2k Test').window).not.toBeNull();
+  });
+
+  it('reports the 5k as 10 days overdue (from overdueAfter 2026-08-10)', () => {
+    expect(byName(run(), '5k Time Trial').daysOverdue).toBe(10);
+  });
+});
+
+describe('the completed-status gate (AC4)', () => {
+  it('does not let cancelled session 61 clear CP Test #1', () => {
+    const cp1 = byName(run(), 'CP Test #1 (4-min)');
+    expect(cp1.status).toBe('overdue');
+    expect(cp1.matchedSession).toBeNull();
+
+    // Session 61 is inside the window's +7 tolerance and its label hits
+    // 'cp retest' — only the status gate rejects it.
+    const window = resolveEventWindow(entryNamed('CP Test #1 (4-min)'));
+    const session61 = SESSIONS.find((s) => s.id === 61);
+    expect(session61.label.toLowerCase()).toContain('cp retest');
+    expect(
+      matchBenchmarkSession(entryNamed('CP Test #1 (4-min)'), window, [
+        { ...session61, status: 'completed' },
+      ])
+    ).toEqual({ ...session61, status: 'completed' });
+    expect(
+      matchBenchmarkSession(entryNamed('CP Test #1 (4-min)'), window, [
+        session61,
+      ])
+    ).toBeNull();
+  });
+
+  it('does not let a planned session with a perfect label clear a benchmark', () => {
+    const rows = run([
+      ...SESSIONS,
+      {
+        id: 500,
+        date: '8/5/26',
+        label: '5000m Time Trial',
+        status: 'planned',
+      },
+    ]);
+    expect(byName(rows, '5k Time Trial').status).toBe('overdue');
+    expect(byName(rows, '5k Time Trial').matchedSession).toBeNull();
+  });
+});
+
+describe('asymmetric proximity tolerance (RF-1)', () => {
+  it('is 3 days before and 7 days after', () => {
+    expect(BENCHMARK_MATCH_TOLERANCE_BEFORE_DAYS).toBe(3);
+    expect(BENCHMARK_MATCH_TOLERANCE_AFTER_DAYS).toBe(7);
+    expect(UPCOMING_WINDOW_DAYS).toBe(7);
+  });
+
+  it('excludes session 45 (8 days early) but would match it at a 14-day before tolerance', () => {
+    const entry = entryNamed('CP Test #1 (4-min)');
+    const window = resolveEventWindow(entry);
+    const session45 = SESSIONS.filter((s) => s.id === 45);
+
+    expect(matchBenchmarkSession(entry, window, session45)).toBeNull();
+
+    // Same session, same terms, same status — only the reach changes. Moving
+    // the window start back 11 days is exactly a 14-day before-tolerance.
+    const widened = {
+      ...window,
+      start: new Date(2026, 5, 20),
+    };
+    expect(matchBenchmarkSession(entry, widened, session45)).toEqual(
+      session45[0]
+    );
+  });
+});
+
+describe('upcoming window (AC3)', () => {
+  it('reports a benchmark 4 days out as upcoming', () => {
+    const rows = deriveBenchmarkStatuses(
+      [fixtureEntry('2026-08-01', '2026-08-10')],
+      [],
+      { today: new Date(2026, 6, 28) }
+    );
+    expect(rows[0].status).toBe('upcoming');
+    expect(rows[0].daysUntil).toBe(4);
+    expect(rows[0].daysOverdue).toBeNull();
+  });
+
+  it('includes today+7, excludes today+8 and includes today itself', () => {
+    const at = (windowStart, windowEnd) =>
+      deriveBenchmarkStatuses([fixtureEntry(windowStart, windowEnd)], [], {
+        today: TODAY,
+      })[0];
+
+    expect(at('2026-08-27', '2026-08-27').status).toBe('upcoming');
+    expect(at('2026-08-28', '2026-08-28').status).toBe('none');
+    const sameDay = at('2026-08-20', '2026-08-20');
+    expect(sameDay.status).toBe('upcoming');
+    expect(sameDay.daysUntil).toBe(0);
+  });
+});
+
+describe('clearing and loading', () => {
+  it('clears the 5k once a matching logged session exists (AC7)', () => {
+    const rows = run([
+      ...SESSIONS,
+      { id: 99, date: '8/5/26', label: '5000m Time Trial', status: 'logged' },
+    ]);
+    const fiveK = byName(rows, '5k Time Trial');
+    expect(fiveK.status).toBe('done');
+    expect(fiveK.matchedSession.id).toBe(99);
+    expect(rows.filter((r) => r.status === 'overdue').length).toBe(2);
+  });
+
+  it('reports every benchmark as pending while sessions are in flight (AC8)', () => {
+    const rows = run(undefined, { sessionsReady: false });
+    const benchmarks = rows.filter((r) => r.entry.kind === 'benchmark');
+    expect(benchmarks.length).toBe(5);
+    for (const r of benchmarks) expect(r.status).toBe('pending');
+    expect(rows.filter((r) => r.status === 'done').length).toBe(0);
+    expect(rows.filter((r) => r.status === 'overdue').length).toBe(0);
+    expect(rows.filter((r) => r.status === 'upcoming').length).toBe(0);
+  });
+
+  it('defaults to still-due when there are no sessions at all (AC6)', () => {
+    for (const sessions of [null, undefined, []]) {
+      const rows = run(sessions);
+      expect(rows.filter((r) => r.status === 'overdue').length).toBe(3);
+      expect(rows.filter((r) => r.status === 'done').length).toBe(0);
+    }
+  });
+
+  it('uses new Date() when no today is supplied', () => {
+    const rows = deriveBenchmarkStatuses(EVENT_LADDER, []);
+    expect(rows.length).toBe(EVENT_LADDER.length);
+    expect(byName(rows, 'CP Test #1 (4-min)').status).toBe('overdue');
+  });
+});
+
+describe('matchBenchmarkSession details', () => {
+  const entry = fixtureEntry('2026-08-10', '2026-08-10');
+  const window = resolveEventWindow(entry);
+
+  it('picks the nearest session, tie-breaking on the lower id, order-independently', () => {
+    const near = {
+      id: 2,
+      date: '8/11/26',
+      label: 'fixture A',
+      status: 'logged',
+    };
+    const far = {
+      id: 1,
+      date: '8/14/26',
+      label: 'fixture B',
+      status: 'logged',
+    };
+    expect(matchBenchmarkSession(entry, window, [far, near]).id).toBe(2);
+    expect(matchBenchmarkSession(entry, window, [near, far]).id).toBe(2);
+
+    const tieHigh = {
+      id: 8,
+      date: '8/12/26',
+      label: 'fixture C',
+      status: 'logged',
+    };
+    const tieLow = {
+      id: 3,
+      date: '8/8/26',
+      label: 'fixture D',
+      status: 'logged',
+    };
+    expect(matchBenchmarkSession(entry, window, [tieHigh, tieLow]).id).toBe(3);
+    expect(matchBenchmarkSession(entry, window, [tieLow, tieHigh]).id).toBe(3);
+  });
+
+  it('breaks a full tie on the label, lexically', () => {
+    const a = {
+      id: 4,
+      date: '8/11/26',
+      label: 'fixture alpha',
+      status: 'logged',
+    };
+    const b = {
+      id: 4,
+      date: '8/9/26',
+      label: 'fixture beta',
+      status: 'logged',
+    };
+    expect(matchBenchmarkSession(entry, window, [b, a]).label).toBe(
+      'fixture alpha'
+    );
+  });
+
+  it('skips sessions with an unparseable date instead of throwing', () => {
+    const rows = [
+      { id: 1, date: 'not-a-date', label: 'fixture X', status: 'logged' },
+      null,
+    ];
+    expect(() => matchBenchmarkSession(entry, window, rows)).not.toThrow();
+    expect(matchBenchmarkSession(entry, window, rows)).toBeNull();
+  });
+
+  it('never matches an entry that has no matchTerms', () => {
+    const bare = fixtureEntry('2026-08-10', '2026-08-10', {
+      matchTerms: undefined,
+    });
+    const perfect = {
+      id: 1,
+      date: '8/10/26',
+      label: 'Fixture Benchmark',
+      status: 'logged',
+    };
+    expect(
+      matchBenchmarkSession(bare, resolveEventWindow(bare), [perfect])
+    ).toBeNull();
+    const empty = fixtureEntry('2026-08-10', '2026-08-10', { matchTerms: [] });
+    expect(
+      matchBenchmarkSession(empty, resolveEventWindow(empty), [perfect])
+    ).toBeNull();
+  });
+
+  it('returns null without an entry or a window', () => {
+    expect(matchBenchmarkSession(null, window, [])).toBeNull();
+    expect(matchBenchmarkSession(entry, null, [])).toBeNull();
+  });
+
+  it('stays silent for a benchmark whose date cannot be resolved', () => {
+    const rows = deriveBenchmarkStatuses(
+      [{ date: 'TBC', name: 'Mystery', kind: 'benchmark', matchTerms: ['x'] }],
+      SESSIONS,
+      { today: TODAY }
+    );
+    expect(rows[0].status).toBe('none');
+    expect(rows[0].window).toBeNull();
+  });
+
+  it('tolerates a non-array entries argument', () => {
+    expect(deriveBenchmarkStatuses(null, [], { today: TODAY })).toEqual([]);
+  });
+});

--- a/web/src/utils/__tests__/eventLadderDates.test.js
+++ b/web/src/utils/__tests__/eventLadderDates.test.js
@@ -1,0 +1,172 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  resolveEventWindow,
+  parseLadderDateText,
+} from '../eventLadderDates.js';
+import { EVENT_LADDER } from '../../constants/schedule.js';
+
+function ymd(d) {
+  return [d.getFullYear(), d.getMonth(), d.getDate()];
+}
+
+describe('parseLadderDateText', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    delete globalThis.process.env.TZ;
+  });
+
+  it('parses "Wed 1 Jul 26" as a single exact day', () => {
+    const w = parseLadderDateText('Wed 1 Jul 26');
+    expect(ymd(w.start)).toEqual([2026, 6, 1]);
+    expect(ymd(w.end)).toEqual([2026, 6, 1]);
+    expect(ymd(w.overdueAfter)).toEqual([2026, 6, 1]);
+    expect(w.approximate).toBe(false);
+    expect(w.source).toBe('parsed');
+  });
+
+  it('parses "1 Jul 26" without a weekday prefix', () => {
+    const w = parseLadderDateText('1 Jul 26');
+    expect(ymd(w.start)).toEqual([2026, 6, 1]);
+    expect(ymd(w.end)).toEqual([2026, 6, 1]);
+  });
+
+  it('parses "~Mid Jul 26" as 11-20 Jul with a month-end overdueAfter', () => {
+    const w = parseLadderDateText('~Mid Jul 26');
+    expect(ymd(w.start)).toEqual([2026, 6, 11]);
+    expect(ymd(w.end)).toEqual([2026, 6, 20]);
+    expect(ymd(w.overdueAfter)).toEqual([2026, 6, 31]);
+    expect(w.approximate).toBe(true);
+  });
+
+  it('parses "~Early Aug 26" as 1-10 Aug with a month-end overdueAfter', () => {
+    const w = parseLadderDateText('~Early Aug 26');
+    expect(ymd(w.start)).toEqual([2026, 7, 1]);
+    expect(ymd(w.end)).toEqual([2026, 7, 10]);
+    expect(ymd(w.overdueAfter)).toEqual([2026, 7, 31]);
+  });
+
+  it('parses "Late Jan 27" as 21-31 Jan', () => {
+    const w = parseLadderDateText('Late Jan 27');
+    expect(ymd(w.start)).toEqual([2027, 0, 21]);
+    expect(ymd(w.end)).toEqual([2027, 0, 31]);
+  });
+
+  it('parses a cross-month en-dash range "12 Sep–9 Oct 26"', () => {
+    const w = parseLadderDateText('12 Sep–9 Oct 26');
+    expect(ymd(w.start)).toEqual([2026, 8, 12]);
+    expect(ymd(w.end)).toEqual([2026, 9, 9]);
+  });
+
+  it('parses a month-to-month range "Nov–Dec 26"', () => {
+    const w = parseLadderDateText('Nov–Dec 26');
+    expect(ymd(w.start)).toEqual([2026, 10, 1]);
+    expect(ymd(w.end)).toEqual([2026, 11, 31]);
+    expect(w.approximate).toBe(true);
+  });
+
+  it('parses a bare "Aug 26" as the whole month', () => {
+    const w = parseLadderDateText('Aug 26');
+    expect(ymd(w.start)).toEqual([2026, 7, 1]);
+    expect(ymd(w.end)).toEqual([2026, 7, 31]);
+  });
+
+  it('strips a leading emoji prefix: "🎯 Late Feb 27"', () => {
+    const w = parseLadderDateText('🎯 Late Feb 27');
+    expect(ymd(w.start)).toEqual([2027, 1, 21]);
+    expect(ymd(w.end)).toEqual([2027, 1, 28]);
+  });
+
+  it('is leap-year safe: "Late Feb 28" ends on the 29th', () => {
+    const w = parseLadderDateText('Late Feb 28');
+    expect(ymd(w.end)).toEqual([2028, 1, 29]);
+  });
+
+  it('returns null on garbage rather than guessing', () => {
+    for (const bad of [
+      '',
+      null,
+      undefined,
+      'TBC',
+      'sometime',
+      '99 Xyz 26',
+      '99 Jul 26',
+      'Nov–Xyz 26',
+      'Late Xyz 27',
+      'Xyz 26',
+      '32 Jan-9 Oct 26',
+      '12 Sep-99 Oct 26',
+      '12 Xyz-9 Oct 26',
+    ]) {
+      expect(parseLadderDateText(bad)).toBeNull();
+    }
+  });
+
+  it('never falls back to today for unparseable input (the toLogDate trap)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 20, 9, 0));
+    expect(parseLadderDateText('TBC')).toBeNull();
+    expect(parseLadderDateText('sometime')).toBeNull();
+    // and a good parse is unaffected by the mocked clock
+    const w = parseLadderDateText('Wed 1 Jul 26');
+    for (const d of [w.start, w.end, w.overdueAfter]) {
+      expect(ymd(d)).not.toEqual([2026, 7, 20]);
+    }
+  });
+
+  it('keeps its boundary days under a negative-offset timezone', () => {
+    globalThis.process.env.TZ = 'America/New_York';
+    expect(ymd(parseLadderDateText('Wed 1 Jul 26').start)).toEqual([
+      2026, 6, 1,
+    ]);
+    const mid = parseLadderDateText('~Mid Jul 26');
+    expect(mid.start.getDate()).toBe(11);
+    expect(mid.end.getDate()).toBe(20);
+    expect(mid.overdueAfter.getDate()).toBe(31);
+    const structured = resolveEventWindow({
+      date: '~Early Aug 26',
+      windowStart: '2026-08-01',
+      windowEnd: '2026-08-10',
+    });
+    expect(structured.start.getDate()).toBe(1);
+    expect(structured.end.getDate()).toBe(10);
+  });
+});
+
+describe('resolveEventWindow', () => {
+  it('prefers a structured window over the free-text date and never widens it', () => {
+    const w = resolveEventWindow({
+      date: '~Early Aug 26',
+      windowStart: '2026-08-01',
+      windowEnd: '2026-08-10',
+    });
+    expect(w.source).toBe('structured');
+    expect(w.approximate).toBe(false);
+    expect(ymd(w.start)).toEqual([2026, 7, 1]);
+    expect(ymd(w.end)).toEqual([2026, 7, 10]);
+    expect(w.overdueAfter).toEqual(w.end);
+  });
+
+  it('falls back to the free-text date when the structured fields are malformed', () => {
+    const w = resolveEventWindow({
+      date: 'Late Jan 27',
+      windowStart: '2027-1-1',
+      windowEnd: '2027-01-20',
+    });
+    expect(w.source).toBe('parsed');
+    expect(ymd(w.start)).toEqual([2027, 0, 21]);
+  });
+
+  it('returns null for a null entry', () => {
+    expect(resolveEventWindow(null)).toBeNull();
+  });
+
+  it('resolves every real EVENT_LADDER entry to a non-null window', () => {
+    expect(EVENT_LADDER.length).toBe(9);
+    for (const entry of EVENT_LADDER) {
+      const w = resolveEventWindow(entry);
+      expect(w, `${entry.name} (${entry.date})`).not.toBeNull();
+      expect(w.start.getTime()).toBeLessThanOrEqual(w.end.getTime());
+      expect(w.overdueAfter.getTime()).toBeGreaterThanOrEqual(w.end.getTime());
+    }
+  });
+});

--- a/web/src/utils/benchmarkStatus.js
+++ b/web/src/utils/benchmarkStatus.js
@@ -10,6 +10,48 @@ export const UPCOMING_WINDOW_DAYS = 7;
 
 const DAY_MS = 86400000;
 
+// Thousands separators are stripped before matching so `5,000m` and `5000m`
+// are one label. Lookahead only — there is deliberately NO LOOKBEHIND
+// anywhere in this module: iOS Safari < 16.4 does not support it and this
+// dashboard is used on a phone. The lookahead form also handles `1,000,000`
+// in a single pass, because the comma is consumed and the trailing digit is
+// not, leaving the scan positioned to find the next separator.
+const THOUSANDS_SEPARATOR = /(\d),(?=\d)/g;
+
+const REGEX_SPECIALS = /[.*+?^${}()|[\]\\]/g;
+
+// Exported for direct testing.
+export function normaliseLabel(label) {
+  // Case-folding and separator removal ONLY. Spaces, hyphens and other
+  // punctuation are left alone — every extra normalisation is a new
+  // false-positive surface.
+  return String(label ?? '')
+    .toLowerCase()
+    .replace(THOUSANDS_SEPARATOR, '$1');
+}
+
+// Exported for direct testing.
+export function labelMatchesTerms(label, terms) {
+  const normalised = normaliseLabel(label);
+  return (Array.isArray(terms) ? terms : []).some((term) => {
+    if (!term) return false;
+    const escaped = String(term).toLowerCase().replace(REGEX_SPECIALS, '\\$&');
+    // Three guards, each load-bearing:
+    //  - Left `[^0-9a-z.,]` is stricter than `\b` on purpose. `\b` still
+    //    accepts `18.5km` as a `5k` hit, because the `.` before the `5` IS a
+    //    word boundary. Excluding digits kills `22km`/`12km`/`21000m`;
+    //    excluding `.` and `,` kills `18.5km`.
+    //  - Optional `s?` keeps the true positive `tune-ups` for term `tune-up`;
+    //    without it the right guard would reject the plural.
+    //  - Right `[^0-9a-z]|$` kills `5km`/`2km` — `km` appears only on
+    //    Zwift/cycling labels here, erg distances are always `NNNNm`.
+    // The guards are consumed rather than looked around, which is safe
+    // because only a boolean is needed and no term can overlap itself.
+    const pattern = new RegExp(`(^|[^0-9a-z.,])${escaped}s?([^0-9a-z]|$)`, 'i');
+    return pattern.test(normalised);
+  });
+}
+
 function addDays(date, n) {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate() + n);
 }
@@ -44,10 +86,7 @@ export function matchBenchmarkSession(entry, window, sessions) {
     const when = sessionDate(session.date);
     if (!when) continue;
     if (when < from || when > to) continue;
-    const label = String(session.label ?? '').toLowerCase();
-    if (!terms.some((t) => t && label.includes(String(t).toLowerCase()))) {
-      continue;
-    }
+    if (!labelMatchesTerms(session.label, terms)) continue;
     candidates.push({
       session,
       distance: Math.abs(wholeDaysBetween(window.start, when)),

--- a/web/src/utils/benchmarkStatus.js
+++ b/web/src/utils/benchmarkStatus.js
@@ -1,0 +1,111 @@
+import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+import { toISODate } from './dateFormat.js';
+import { resolveEventWindow } from './eventLadderDates.js';
+
+// Benchmarks slip late, they do not happen early — hence the asymmetric
+// tolerance. A test done 8 days before the window opened was a different test.
+export const BENCHMARK_MATCH_TOLERANCE_BEFORE_DAYS = 3;
+export const BENCHMARK_MATCH_TOLERANCE_AFTER_DAYS = 7;
+export const UPCOMING_WINDOW_DAYS = 7;
+
+const DAY_MS = 86400000;
+
+function addDays(date, n) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + n);
+}
+
+function wholeDaysBetween(from, to) {
+  return Math.round((to.getTime() - from.getTime()) / DAY_MS);
+}
+
+function sessionDate(value) {
+  const iso = toISODate(value);
+  if (!iso) return null;
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+// Exported for direct testing.
+export function matchBenchmarkSession(entry, window, sessions) {
+  if (!entry || !window) return null;
+
+  const terms = Array.isArray(entry.matchTerms) ? entry.matchTerms : [];
+  if (terms.length === 0) return null;
+
+  const from = addDays(window.start, -BENCHMARK_MATCH_TOLERANCE_BEFORE_DAYS);
+  const to = addDays(window.overdueAfter, BENCHMARK_MATCH_TOLERANCE_AFTER_DAYS);
+
+  const candidates = [];
+  for (const session of Array.isArray(sessions) ? sessions : []) {
+    if (!session) continue;
+    // The status gate. NOT `status !== 'planned'` — that classifies a
+    // cancelled session as done and would clear a benchmark that never ran.
+    if (!COMPLETED_STATUSES.includes(session.status)) continue;
+    const when = sessionDate(session.date);
+    if (!when) continue;
+    if (when < from || when > to) continue;
+    const label = String(session.label ?? '').toLowerCase();
+    if (!terms.some((t) => t && label.includes(String(t).toLowerCase()))) {
+      continue;
+    }
+    candidates.push({
+      session,
+      distance: Math.abs(wholeDaysBetween(window.start, when)),
+    });
+  }
+
+  if (candidates.length === 0) return null;
+
+  candidates.sort(
+    (a, b) =>
+      a.distance - b.distance ||
+      Number(a.session.id) - Number(b.session.id) ||
+      String(a.session.label ?? '').localeCompare(String(b.session.label ?? ''))
+  );
+  return candidates[0].session;
+}
+
+export function deriveBenchmarkStatuses(entries, sessions, options = {}) {
+  const { today = new Date(), sessionsReady = true } = options;
+  const now = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  return (Array.isArray(entries) ? entries : []).map((entry) => {
+    const base = {
+      entry,
+      window: null,
+      status: 'none',
+      matchedSession: null,
+      daysOverdue: null,
+      daysUntil: null,
+    };
+
+    if (!entry || entry.kind !== 'benchmark') return base;
+
+    const window = resolveEventWindow(entry);
+    if (!window) return base;
+
+    const resolved = { ...base, window };
+
+    // Evaluated before matching so an in-flight query can never be mistaken
+    // for either "no match found → overdue" or "matched → done".
+    if (!sessionsReady) return { ...resolved, status: 'pending' };
+
+    const matchedSession = matchBenchmarkSession(entry, window, sessions);
+    if (matchedSession) return { ...resolved, status: 'done', matchedSession };
+
+    if (now > window.overdueAfter) {
+      return {
+        ...resolved,
+        status: 'overdue',
+        daysOverdue: wholeDaysBetween(window.overdueAfter, now),
+      };
+    }
+
+    const daysUntil = wholeDaysBetween(now, window.start);
+    if (window.start >= now && daysUntil <= UPCOMING_WINDOW_DAYS) {
+      return { ...resolved, status: 'upcoming', daysUntil };
+    }
+
+    return resolved;
+  });
+}

--- a/web/src/utils/eventLadderDates.js
+++ b/web/src/utils/eventLadderDates.js
@@ -1,0 +1,198 @@
+// Resolves an EVENT_LADDER entry to the calendar window in which the event may
+// legitimately happen. Knows nothing about sessions or "today" — it returns a
+// window, never a status.
+//
+// Two deliberate traps are avoided here:
+//  - Unparseable input returns null, NEVER today. toLogDate() in dateFormat.js
+//    falls back to today; copying that here would silently invent a window and
+//    turn "cannot determine" into a confident (wrong) overdue signal.
+//  - Every Date is built with new Date(y, mIdx, d). new Date('2026-07-01')
+//    parses as UTC midnight and reads back as 30 Jun in any negative-offset
+//    zone, shifting every window boundary by a day.
+
+const MONTHS = [
+  'jan',
+  'feb',
+  'mar',
+  'apr',
+  'may',
+  'jun',
+  'jul',
+  'aug',
+  'sep',
+  'oct',
+  'nov',
+  'dec',
+];
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function monthIndex(token) {
+  return MONTHS.indexOf(String(token).toLowerCase().slice(0, 3));
+}
+
+function lastDayOfMonth(year, mIdx) {
+  return new Date(year, mIdx + 1, 0).getDate();
+}
+
+function localDate(year, mIdx, day) {
+  return new Date(year, mIdx, day);
+}
+
+function fromISO(iso) {
+  const [y, m, d] = iso.split('-').map(Number);
+  return localDate(y, m - 1, d);
+}
+
+function endOfMonthOf(date) {
+  return localDate(
+    date.getFullYear(),
+    date.getMonth(),
+    lastDayOfMonth(date.getFullYear(), date.getMonth())
+  );
+}
+
+function normalise(text) {
+  const raw = text == null ? '' : String(text);
+  const stripped = raw.replace(/^[^a-zA-Z0-9]+/, '');
+  const approximate = stripped.includes('~');
+  const cleaned = stripped
+    .replace(/~/g, '')
+    .replace(/[–—]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return { cleaned, approximate };
+}
+
+function build(start, end, approximate, source) {
+  return {
+    start,
+    end,
+    overdueAfter: approximate ? endOfMonthOf(end) : end,
+    approximate,
+    source,
+  };
+}
+
+// Exported for direct testing.
+export function parseLadderDateText(text) {
+  const { cleaned, approximate } = normalise(text);
+  if (!cleaned) return null;
+
+  // Ddd D MON YY — "Wed 1 Jul 26". The weekday prefix is discarded, never
+  // validated; the numeric date is authoritative.
+  let m = cleaned.match(/^[a-z]{3,}\s+(\d{1,2})\s+([a-z]{3,})\s+(\d{2})$/i);
+  if (m) return singleDay(Number(m[1]), m[2], m[3], approximate);
+
+  // D MON YY — "1 Jul 26"
+  m = cleaned.match(/^(\d{1,2})\s+([a-z]{3,})\s+(\d{2})$/i);
+  if (m) return singleDay(Number(m[1]), m[2], m[3], approximate);
+
+  // D MON-D MON YY — "12 Sep-9 Oct 26"
+  m = cleaned.match(
+    /^(\d{1,2})\s+([a-z]{3,})\s*-\s*(\d{1,2})\s+([a-z]{3,})\s+(\d{2})$/i
+  );
+  if (m) {
+    const year = 2000 + Number(m[5]);
+    const fromIdx = monthIndex(m[2]);
+    const toIdx = monthIndex(m[4]);
+    const fromDay = Number(m[1]);
+    const toDay = Number(m[3]);
+    if (fromIdx < 0 || toIdx < 0) return null;
+    if (!validDay(year, fromIdx, fromDay) || !validDay(year, toIdx, toDay)) {
+      return null;
+    }
+    return build(
+      localDate(year, fromIdx, fromDay),
+      localDate(year, toIdx, toDay),
+      approximate,
+      'parsed'
+    );
+  }
+
+  // MON-MON YY — "Nov-Dec 26"
+  m = cleaned.match(/^([a-z]{3,})\s*-\s*([a-z]{3,})\s+(\d{2})$/i);
+  if (m) {
+    const year = 2000 + Number(m[3]);
+    const fromIdx = monthIndex(m[1]);
+    const toIdx = monthIndex(m[2]);
+    if (fromIdx < 0 || toIdx < 0) return null;
+    return build(
+      localDate(year, fromIdx, 1),
+      localDate(year, toIdx, lastDayOfMonth(year, toIdx)),
+      true,
+      'parsed'
+    );
+  }
+
+  // Early/Mid/Late MON YY
+  m = cleaned.match(/^(early|mid|late)\s+([a-z]{3,})\s+(\d{2})$/i);
+  if (m) {
+    const year = 2000 + Number(m[3]);
+    const mIdx = monthIndex(m[2]);
+    if (mIdx < 0) return null;
+    const band = m[1].toLowerCase();
+    const startDay = band === 'early' ? 1 : band === 'mid' ? 11 : 21;
+    const endDay =
+      band === 'early' ? 10 : band === 'mid' ? 20 : lastDayOfMonth(year, mIdx);
+    return build(
+      localDate(year, mIdx, startDay),
+      localDate(year, mIdx, endDay),
+      true,
+      'parsed'
+    );
+  }
+
+  // MON YY — "Aug 26"
+  m = cleaned.match(/^([a-z]{3,})\s+(\d{2})$/i);
+  if (m) {
+    const year = 2000 + Number(m[2]);
+    const mIdx = monthIndex(m[1]);
+    if (mIdx < 0) return null;
+    return build(
+      localDate(year, mIdx, 1),
+      localDate(year, mIdx, lastDayOfMonth(year, mIdx)),
+      true,
+      'parsed'
+    );
+  }
+
+  return null;
+}
+
+function validDay(year, mIdx, day) {
+  return day >= 1 && day <= lastDayOfMonth(year, mIdx);
+}
+
+function singleDay(day, monToken, yyToken, approximate) {
+  const year = 2000 + Number(yyToken);
+  const mIdx = monthIndex(monToken);
+  if (mIdx < 0 || !validDay(year, mIdx, day)) return null;
+  const when = localDate(year, mIdx, day);
+  return build(when, when, approximate, 'parsed');
+}
+
+export function resolveEventWindow(entry) {
+  if (!entry) return null;
+
+  // Structured windows win, and are never widened to month-end regardless of a
+  // '~' in the free-text date.
+  const { windowStart, windowEnd } = entry;
+  if (
+    typeof windowStart === 'string' &&
+    typeof windowEnd === 'string' &&
+    ISO_RE.test(windowStart) &&
+    ISO_RE.test(windowEnd)
+  ) {
+    const end = fromISO(windowEnd);
+    return {
+      start: fromISO(windowStart),
+      end,
+      overdueAfter: end,
+      approximate: false,
+      source: 'structured',
+    };
+  }
+
+  return parseLadderDateText(entry.date);
+}

--- a/web/src/views/CalendarView.jsx
+++ b/web/src/views/CalendarView.jsx
@@ -1,4 +1,5 @@
 import WorkoutItem from '../components/WorkoutItem.jsx';
+import BenchmarkStatusBanner from '../components/BenchmarkStatusBanner.jsx';
 import {
   getRosterMode,
   resolveDay,
@@ -177,6 +178,7 @@ export default function CalendarView({ loggedSessions, isWide }) {
       </div>
 
       {/* Upcoming events from the ladder */}
+      <BenchmarkStatusBanner />
       <div
         style={{
           background: 'linear-gradient(135deg,#ffd70010,#1e1e30)',

--- a/web/src/views/ErgLiveView.jsx
+++ b/web/src/views/ErgLiveView.jsx
@@ -646,6 +646,7 @@ export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
     if (!dbError || isDuplicate(dbError)) {
       queryClient.invalidateQueries({ queryKey: ['sessions'] });
       queryClient.invalidateQueries({ queryKey: ['erg-sessions'] });
+      queryClient.invalidateQueries({ queryKey: ['benchmark-sessions'] });
       setSaveState('saved');
     } else {
       queue();

--- a/web/src/views/__tests__/CalendarView.test.jsx
+++ b/web/src/views/__tests__/CalendarView.test.jsx
@@ -1,13 +1,47 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('../../hooks/useBenchmarkSessions.js', () => ({
+  useBenchmarkSessions: () => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
 import CalendarView from '../CalendarView.jsx';
+
+function renderView() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    React.createElement(
+      QueryClientProvider,
+      { client },
+      React.createElement(CalendarView, { loggedSessions: [], isWide: false })
+    )
+  );
+}
 
 describe('CalendarView', () => {
   it('renders the week strip header and the upcoming events ladder', () => {
-    render(<CalendarView loggedSessions={[]} isWide={false} />);
+    renderView();
     expect(screen.getByText(/YOUR WEEKS/i)).toBeInTheDocument();
     expect(
       screen.getByText(/UPCOMING EVENTS · SEASON 1 LADDER/i)
     ).toBeInTheDocument();
+  });
+
+  it('renders the benchmark banner above the ladder heading', () => {
+    const { container } = renderView();
+    const banner = screen.getByText('BENCHMARKS');
+    const ladder = screen.getByText(/UPCOMING EVENTS · SEASON 1 LADDER/i);
+    // querySelectorAll returns document order.
+    const inOrder = [...container.querySelectorAll('div')];
+    expect(inOrder).toContain(banner);
+    expect(inOrder.indexOf(banner)).toBeLessThan(inOrder.indexOf(ladder));
   });
 });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -110,6 +110,21 @@ export default defineConfig({
         // the monolith is decomposed and its exclusions fall away.
         'src/utils/sentry.js': { lines: 80, functions: 80, branches: 70 },
         'src/utils/dateFormat.js': { lines: 80, functions: 80, branches: 70 },
+        'src/utils/eventLadderDates.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/utils/benchmarkStatus.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/components/BenchmarkStatusBanner.jsx': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
         'src/components/ErrorFallback.jsx': {
           lines: 80,
           functions: 80,


### PR DESCRIPTION
Closes #175

## What changed and why

Surfaces overdue and upcoming benchmark tests so one cannot silently slip the way the CP retest did in July — session 61 was cancelled on 7/5 and never rescheduled, the end-of-base 5k was due in early August and never logged, and `anchors.rowing_cp` has sat at 205 provisional since 7/1 with nothing on screen saying so.

On first load today this surfaces three overdue benchmarks: CP Test #1, CP Test #2, and the 5k Time Trial.

### How it works

Four new modules, composed into a self-contained banner:

| File | Role |
|---|---|
| `utils/eventLadderDates.js` | Resolves an `EVENT_LADDER` entry to a date window |
| `utils/benchmarkStatus.js` | Derives overdue / upcoming / done / pending / none |
| `hooks/useBenchmarkSessions.js` | React Query read of completed sessions |
| `components/BenchmarkStatusBanner.jsx` | Renders the signals |

`EVENT_LADDER` gains three optional fields on its five `kind: 'benchmark'` entries — `windowStart`, `windowEnd`, `matchTerms`. Every pre-existing value on all nine entries is unchanged, and the four non-benchmark entries are untouched.

`CalendarView.jsx` gains exactly two lines, an import and `<BenchmarkStatusBanner />`. The banner calls its own hook rather than taking sessions as a prop, so nothing threads through and `ProgramYear.jsx` is not touched at all — the #77/#114 split is clear of this change.

### Design decisions worth flagging for review

**A benchmark is only "done" if a session matching `COMPLETED_STATUSES` exists.** A `cancelled` session reads as not-done. Session 61 is the regression fixture: it label-matches and falls inside the date tolerance, so the status gate is the only thing rejecting it, and a test proves that by flipping just its status and watching it match.

**Match tolerance is asymmetric — 3 days before the window, 7 days after** — encoding that benchmarks slip late rather than happening early. This is why session 45 (`6/23/26`, a real 4-min CP test eight days before the ladder slot) does not clear CP Test #1. Deliberate: the 1-minute companion piece was cancelled, so CP still cannot be recomputed.

**Absence of evidence is never completion.** A missing, unreadable, or RLS-empty session list leaves a benchmark still-due. There is no code path where "no session found" becomes done.

**The component has no affirmative all-clear state.** It renders overdue and upcoming, or nothing. This is structural rather than cosmetic — while loading it cannot flash a false cleared state, because there is no cleared state to flash.

### Follow-up commit — review findings

The initial matcher used a raw substring test, which matched `5k` inside `18.5km` and `1000m` inside `21000m`. A false match renders nothing and is permanent, so it recreates precisely the silent-slip failure this feature exists to prevent. Matching is now boundary-guarded, and `\b` is deliberately not used — in `18.5km` the `.` is itself a word boundary, so `\b` leaves the bug intact. No regex lookbehind appears anywhere in the module, since iOS Safari below 16.4 lacks support.

Thousands separators are now stripped before matching. This closed a live gap: `5,000m` contains neither `5k` nor `5000m`, so a benchmark logged in the existing house style (sessions 19, 20, 25) would never have cleared the indicator.

A failed session query now renders a neutral `BENCHMARK STATUS UNAVAILABLE` line rather than nothing, so an outage cannot be mistaken for "nothing due". The loading state still renders nothing, so a slow first fetch cannot flash that line before the real signals arrive.

`1-min` was dropped from the tune-ups match terms — a one-minute piece appears in warm-ups, CP tests and intervals, and is not evidence the benchmark happened.

Verified against all 92 live session rows: of 460 label/term combinations, the only 7 hits are genuine benchmark labels.

## How to test manually

Open the Calendar tab. Three overdue benchmarks should appear above the `UPCOMING EVENTS · SEASON 1 LADDER` heading. No competition, TARGET, or optional ladder entry should ever appear there.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

509 tests pass (up from 484). New files sit at 100% lines and functions; branch coverage 96.66% on `benchmarkStatus.js` and 100% elsewhere. Three per-file 80/80/70 gates added; no threshold lowered.

## Deferred to follow-up issues

- **Reschedule/acknowledge state.** The three overdue benchmarks will render indefinitely, since they genuinely never happened. Recommended design is a `planned` session row rather than a dismiss button, so a reschedule is real and visible rather than hidden in one device's local storage.
- **`useSessions.js`** orders a TEXT `MM/DD/YY` column lexically under `.limit(50)`, so `'12/1/26'` sorts before `'7/1/26'` and the returned rows are effectively arbitrary. Pre-existing; avoided here via a dedicated hook rather than fixed.
- **`useSessionLog.js:69`** treats `status !== 'planned'` as done, classifying cancelled sessions as complete. Pre-existing; deliberately not copied.
- **`useOfflineQueue.js:73`** inserts sessions and invalidates no query at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_017iDtU2Bm6JTKwxWyijfn4K)_