### PR TITLE
fix: say when benchmark status is unavailable instead of rendering silence

### DIFF
--- a/web/src/hooks/useBenchmarkStatuses.js
+++ b/web/src/hooks/useBenchmarkStatuses.js
@@ -16,3 +16,14 @@ export function useBenchmarkStatuses(ladder = EVENT_LADDER, options = {}) {
     [ladder, data, today, sessionsReady]
   );
 }
+
+// A failed read resolves every entry to `unknown`, which renders no badge —
+// and silence is exactly what "no benchmarks due" looks like. Callers use this
+// to say the status is unknown rather than imply everything is fine. Pending is
+// deliberately NOT unavailable: a slow first read must not flash an outage line
+// and then replace it with badges. Same query key as above, so react-query
+// serves it from cache rather than issuing a second request.
+export function useBenchmarkDataUnavailable() {
+  const { isError } = useBenchmarkSessions();
+  return isError;
+}

--- a/web/src/views/CalendarView.jsx
+++ b/web/src/views/CalendarView.jsx
@@ -1,6 +1,9 @@
 import WorkoutItem from '../components/WorkoutItem.jsx';
 import BenchmarkBadge from '../components/BenchmarkBadge.jsx';
-import { useBenchmarkStatuses } from '../hooks/useBenchmarkStatuses.js';
+import {
+  useBenchmarkStatuses,
+  useBenchmarkDataUnavailable,
+} from '../hooks/useBenchmarkStatuses.js';
 import {
   getRosterMode,
   resolveDay,
@@ -18,6 +21,7 @@ export default function CalendarView({ loggedSessions, isWide }) {
   // Resolved once for the FULL ladder; the panel below indexes into it
   // positionally, so the badges stay aligned if the slice is ever widened.
   const benchmarkStatuses = useBenchmarkStatuses();
+  const benchmarksUnavailable = useBenchmarkDataUnavailable();
   const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   const monthNames = [
     'Jan',
@@ -202,6 +206,18 @@ export default function CalendarView({ loggedSessions, isWide }) {
         >
           UPCOMING EVENTS · SEASON 1 LADDER
         </div>
+        {benchmarksUnavailable && (
+          <div
+            style={{
+              fontSize: 9,
+              letterSpacing: 2,
+              color: '#7e7e9a',
+              marginBottom: 8,
+            }}
+          >
+            BENCHMARK STATUS UNAVAILABLE
+          </div>
+        )}
         {EVENT_LADDER.slice(0, 5).map((e, i) => {
           const bench = benchmarkStatuses[i];
           const col =

--- a/web/src/views/__tests__/CalendarView.benchmark.test.jsx
+++ b/web/src/views/__tests__/CalendarView.benchmark.test.jsx
@@ -98,6 +98,40 @@ describe('CalendarView + useBenchmarkStatuses (integration, unmocked hook)', () 
     renderView();
     expect(screen.queryByText(/OVERDUE/)).not.toBeInTheDocument();
     expect(screen.getByText(/UPCOMING EVENTS/i)).toBeInTheDocument();
+    // Pending is not unavailable. A slow first read must not flash the outage
+    // line and then replace it with badges.
+    expect(screen.queryByText(/UNAVAILABLE/i)).not.toBeInTheDocument();
+  });
+
+  // A failed read resolves every entry to `unknown`, which renders no badge.
+  // Silence is exactly what "no benchmarks due" looks like, so an outage that
+  // says nothing is the feature's own failure mode arriving by another door.
+  it('says so when the sessions read fails, instead of rendering silence', async () => {
+    fromMock.mockImplementation(() => {
+      const chain = {
+        select: () => chain,
+        order: () => chain,
+        limit: () => Promise.resolve({ data: null, error: new Error('nope') }),
+      };
+      return chain;
+    });
+    renderView();
+
+    expect(
+      await screen.findByText(/BENCHMARK STATUS UNAVAILABLE/i)
+    ).toBeInTheDocument();
+    // The ladder itself still renders; only the benchmark verdicts are unknown.
+    expect(screen.getByText(/UPCOMING EVENTS/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^OVERDUE/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^DUE/)).not.toBeInTheDocument();
+  });
+
+  it('shows no outage line once the read succeeds', async () => {
+    mockSessions(PAYLOAD);
+    renderView();
+
+    await screen.findByText(/^OVERDUE/);
+    expect(screen.queryByText(/UNAVAILABLE/i)).not.toBeInTheDocument();
   });
 
   // Waits on a POSITIVE render before asserting the 5k's badge is gone. An

--- a/web/src/views/__tests__/CalendarView.test.jsx
+++ b/web/src/views/__tests__/CalendarView.test.jsx
@@ -9,6 +9,7 @@ const statusesMock = vi.fn();
 // the wall clock; the resolver itself is covered in benchmarkStatus.test.js.
 vi.mock('../../hooks/useBenchmarkStatuses.js', () => ({
   useBenchmarkStatuses: (...args) => statusesMock(...args),
+  useBenchmarkDataUnavailable: () => false,
 }));
 
 import CalendarView from '../CalendarView.jsx';


### PR DESCRIPTION
Follow-up to #189 / #190.

## What changed and why

A failed sessions read resolves every ladder entry to `unknown` (`benchmarkStatus.js:91`), and `BenchmarkBadge` returns `null` for unknown. So an outage silently removes the overdue warnings and leaves the ladder panel looking reassuring — silence is exactly what "no benchmarks due" looks like.

That is the feature's own failure mode arriving by another door: the whole point is that a benchmark cannot slip unnoticed, and a Supabase hiccup currently makes three overdue benchmarks disappear.

The panel now carries a neutral line when the read has failed:

```
BENCHMARK STATUS UNAVAILABLE
```

It is a statement about the *data*, not about the benchmarks. No `⚠`, no `●` — reusing either would make an outage read as a signal — muted grey rather than the red/gold the badges own, and no claim that anything is fine.

**Pending is deliberately not unavailable.** A slow first read must not flash the outage line and then replace it with badges, so the line is driven by `isError` alone and the loading path still renders nothing.

## Why the hook lives where it does

`useBenchmarkDataUnavailable` sits alongside `useBenchmarkStatuses` rather than being read from `useBenchmarkSessions` in the view. Importing `useBenchmarkSessions` into `CalendarView` directly pulls `supabaseClient` into every test that renders the view, which breaks `CalendarView.test.jsx` at import time with `supabaseUrl is required` — it mocks the statuses module, not the sessions one. Keeping the view on a single hooks module preserves that boundary. It shares the query key, so react-query serves it from cache rather than issuing a second request.

## How to test manually

Open the Calendar tab with the network blocked (DevTools → Offline, or block the Supabase host). The ladder still lists its five entries, with `BENCHMARK STATUS UNAVAILABLE` under the heading and no badges. Restore the network and the line disappears as the badges resolve.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

549 tests pass across 50 files (up from 544/50).

Three tests added to `CalendarView.benchmark.test.jsx`, which mocks only at the Supabase boundary so the real hook, resolver and badge all run:

- a failed read renders the line, keeps the ladder, and shows no badge
- a successful read shows no line
- the existing pending test now also asserts the line is absent

**The outage test has teeth** — verified by reverting the render condition to `false` and confirming it goes red, then restoring it.

## Related

Found while reviewing the benchmark work. Also filed: #192 (reschedule/acknowledge state), #193 (`useSessions` lexical sort under `limit(50)`), #194 (`useSessionLog` counts cancelled as completed — 32 live rows), #195 (offline queue drain invalidates nothing).

---
_Generated by [Claude Code](https://claude.ai/code/session_017iDtU2Bm6JTKwxWyijfn4K)_