### PR TITLE
fix: order sessions by a real date column so LIMIT stops dropping recent rows (#187)

### DIFF
--- a/.claude/skills/erg-context.md
+++ b/.claude/skills/erg-context.md
@@ -33,7 +33,9 @@ Testing Library. Full briefing: `CLAUDE.md`.
 ## Supabase gotchas (honour on every write)
 
 - Supply `user_id` explicitly on inserts. RLS is always on — never bypass it.
-- `sessions.date` is TEXT `MM/DD/YY` — order with `to_date(date,'MM/DD/YY')`.
+- `sessions.date` is TEXT `M/D/YY` — **write** it, never order by it. Order by the
+  generated `date_iso` date column (`nullsFirst: false` on desc). `date_iso` is
+  read-only; an insert naming it is rejected.
 - `UNIQUE(date, label)` on `sessions` — temp-suffix labels before bulk shuffles.
 - Vitals upsert on `(user_id, date)`. Migrations are additive and reversible;
   DDL via `apply_migration`, never raw `execute_sql`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,11 @@ coach use), and the context store (Code↔Coach shared memory, added by #94):
 | `coach_log`         | **Context store** — append-only diary + decision record (Coach's content) |
 | `anchors`           | **Context store** — current calibration + phase state (one live row/key)  |
 
-**`sessions` columns:** `date` (**text `MM/DD/YY`**), `type`, `label`, `duration`,
+**`sessions` columns:** `date` (**text `M/D/YY`, unpadded** — the write column),
+`date_iso` (**generated `date`, read-only** — derived from `date` by
+`session_date_to_iso()`, indexed, and the only correct thing to `order by`; an
+insert that names it is rejected, and a `date` that will not parse is rejected by
+the `sessions_date_parseable` check), `type`, `label`, `duration`,
 `srpe`, `prs`, `exercises` (jsonb), `coach_note`, `status`, `coach_flag`,
 `avg_watts`, `avg_hr`, `distance_m`, `source` (default `portal`; Coach writes
 `coach`), `user_id`. **No watt-target columns — targets live in `label` +
@@ -171,7 +175,10 @@ legacy `sessions.date` text pattern); RLS single-owner policy like the modern ta
 **Data-layer gotchas (honour on every write):**
 - Supply the `user_id` UUID explicitly on inserts — `auth.uid()` is the column
   default but does not resolve through the MCP connector.
-- Order `sessions` chronologically with `to_date(date,'MM/DD/YY')` (date is text).
+- Order `sessions` chronologically with **`date_iso`** (generated + indexed), never the
+  text `date` — lexical order silently returns the wrong rows under a `LIMIT`. On
+  descending, pass `NULLS LAST` (`nullsFirst: false` from supabase-js). Do not use
+  `to_date(...)`: it is STABLE, so it cannot be indexed or used in a generated column.
 - `UNIQUE(date, label)` on `sessions` — temp-suffix labels before bulk shuffles
   (`set label = label || '~tmp'`).
 - Vitals upsert: `on conflict (user_id, date) do update`.

--- a/supabase/migrations/008_sessions_date_iso.sql
+++ b/supabase/migrations/008_sessions_date_iso.sql
@@ -1,0 +1,69 @@
+-- 008_sessions_date_iso.sql
+-- Additive + reversible. Gives sessions a real DATE key derived from the legacy
+-- TEXT `date`, so PostgREST .order() is chronological and .limit() selects the
+-- right rows (#187). The TEXT column is untouched: every write path still writes
+-- "M/D/YY" via toLogDate(), every display still reads sessions.date.
+--
+-- to_date(text,text) and text::date are both STABLE (DateStyle-dependent), so
+-- NEITHER may appear in a generated column or an index expression. make_date,
+-- split_part, text::int and the regex operator are all IMMUTABLE, so the
+-- IMMUTABLE marking below is honest rather than a promise.
+
+CREATE OR REPLACE FUNCTION public.session_date_to_iso(d text)
+RETURNS date
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+-- Pinned so the body cannot be hijacked by a caller's search_path. Everything
+-- it calls (make_date, split_part, the int cast, the regex operator) lives in
+-- pg_catalog, which Postgres searches implicitly even when the path is empty.
+SET search_path = ''
+AS $$
+BEGIN
+  IF d ~ '^\d{1,2}/\d{1,2}/\d{2}$' THEN
+    RETURN make_date(2000 + split_part(d, '/', 3)::int,
+                     split_part(d, '/', 1)::int,
+                     split_part(d, '/', 2)::int);
+  ELSIF d ~ '^\d{4}-\d{2}-\d{2}$' THEN
+    RETURN make_date(split_part(d, '-', 1)::int,
+                     split_part(d, '-', 2)::int,
+                     split_part(d, '-', 3)::int);
+  END IF;
+  RETURN NULL;
+EXCEPTION
+  -- "2/31/26" passes the regex but make_date raises. Never propagate: this runs
+  -- inside every INSERT and every UPDATE of a sessions row, so raising here
+  -- would abort a Coach-written session outright and would make any legacy bad
+  -- row permanently un-updatable. The CHECK below is what makes a bad write
+  -- loud; this handler is what stops it being fatal to the derivation.
+  WHEN others THEN RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.session_date_to_iso(text) IS
+  'IMMUTABLE parser for the legacy sessions.date TEXT format ("M/D/YY", also '
+  'accepts ISO). Do NOT CREATE OR REPLACE this in place: sessions.date_iso is a '
+  'STORED generated column and Postgres does not recompute stored values when a '
+  'function body changes, so a replaced body silently leaves stale dates. To '
+  'change it, drop the CHECK and date_iso, replace the function, re-add both.';
+
+ALTER TABLE public.sessions
+  ADD COLUMN IF NOT EXISTS date_iso date
+  GENERATED ALWAYS AS (public.session_date_to_iso(date)) STORED;
+
+COMMENT ON COLUMN public.sessions.date_iso IS
+  'Derived from sessions.date (TEXT "M/D/YY"). READ-ONLY - write `date`; an '
+  'INSERT naming date_iso is rejected by Postgres. Ordering key for #187.';
+
+CREATE INDEX IF NOT EXISTS sessions_user_id_date_iso_desc_idx
+  ON public.sessions (user_id, date_iso DESC NULLS LAST);
+
+-- NOT VALID: enforced on new INSERT/UPDATE only, existing rows are never
+-- re-checked, so this cannot fail on legacy data. All 92 live rows parse today;
+-- do NOT run VALIDATE CONSTRAINT - leaving it NOT VALID keeps rollback
+-- unconditional rather than contingent on the data.
+ALTER TABLE public.sessions DROP CONSTRAINT IF EXISTS sessions_date_parseable;
+ALTER TABLE public.sessions
+  ADD CONSTRAINT sessions_date_parseable
+  CHECK (public.session_date_to_iso(date) IS NOT NULL) NOT VALID;

--- a/supabase/migrations/008_sessions_date_iso_rollback.sql
+++ b/supabase/migrations/008_sessions_date_iso_rollback.sql
@@ -1,0 +1,10 @@
+-- Rollback for 008_sessions_date_iso.sql. NOT auto-applied.
+--
+-- Revert the Vercel deploy FIRST. A client carrying .order('date_iso') against a
+-- schema without the column gets a PostgREST 400 on every sessions read.
+-- The function can only be dropped after its two dependants.
+
+ALTER TABLE public.sessions DROP CONSTRAINT IF EXISTS sessions_date_parseable;
+DROP INDEX IF EXISTS public.sessions_user_id_date_iso_desc_idx;
+ALTER TABLE public.sessions DROP COLUMN IF EXISTS date_iso;
+DROP FUNCTION IF EXISTS public.session_date_to_iso(text);

--- a/web/src/hooks/__tests__/useCoach.test.js
+++ b/web/src/hooks/__tests__/useCoach.test.js
@@ -23,7 +23,6 @@ vi.mock('../useVitals.js', () => ({
     readinessLabel: 'FATIGUED',
   }),
 }));
-vi.mock('../useSessions.js', () => ({ useSessions: () => ({ data: [] }) }));
 
 import { buildTrainingContext } from '../useCoach.js';
 

--- a/web/src/hooks/__tests__/useSessions.test.js
+++ b/web/src/hooks/__tests__/useSessions.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const fromMock = vi.fn();
+const orderMock = vi.fn();
+const limitMock = vi.fn();
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: (...args) => fromMock(...args),
+  },
+}));
+
+import { useSessions } from '../useSessions.js';
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function makeWrapper(client) {
+  function Wrapper({ children }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  }
+  return Wrapper;
+}
+
+// order() is called twice (date_iso, then id) and must keep returning the chain;
+// limit() terminates it. Both spy on their arguments so the query contract —
+// which is where the #187 fix actually lives — can be asserted.
+function mockQuery(data, error = null) {
+  const chain = {
+    select: () => chain,
+    order: (...args) => {
+      orderMock(...args);
+      return chain;
+    },
+    limit: (...args) => {
+      limitMock(...args);
+      return Promise.resolve({ data, error });
+    },
+  };
+  fromMock.mockReturnValue(chain);
+}
+
+function rows(...dates) {
+  return dates.map((date, i) => ({ id: i + 1, date, type: 'erg' }));
+}
+
+async function renderSessions(client = makeClient()) {
+  const { result } = renderHook(() => useSessions(), {
+    wrapper: makeWrapper(client),
+  });
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  return result;
+}
+
+beforeEach(() => {
+  fromMock.mockReset();
+  orderMock.mockReset();
+  limitMock.mockReset();
+});
+
+describe('useSessions', () => {
+  it('orders on the derived date_iso column with NULLS LAST', async () => {
+    mockQuery([]);
+    await renderSessions();
+    expect(orderMock).toHaveBeenCalledWith('date_iso', {
+      ascending: false,
+      nullsFirst: false,
+    });
+  });
+
+  it('never orders on the lexically-sorting text date column (#187)', async () => {
+    mockQuery([]);
+    await renderSessions();
+    expect(orderMock).not.toHaveBeenCalledWith('date', expect.anything());
+  });
+
+  it('breaks ties on id so the limit boundary is deterministic', async () => {
+    mockQuery([]);
+    await renderSessions();
+    expect(orderMock).toHaveBeenCalledWith('id', { ascending: false });
+  });
+
+  it('requests a 50-row recency window', async () => {
+    mockQuery([]);
+    await renderSessions();
+    expect(limitMock).toHaveBeenCalledWith(50);
+  });
+
+  it('re-sorts a lexically-ordered payload across a month boundary', async () => {
+    mockQuery(rows('6/4/26', '6/30/26', '9/30/26', '12/1/26'));
+    const result = await renderSessions();
+    expect(result.current.data.map((s) => s.date)).toEqual([
+      '12/1/26',
+      '9/30/26',
+      '6/30/26',
+      '6/4/26',
+    ]);
+  });
+
+  it('re-sorts across a year boundary', async () => {
+    mockQuery(rows('12/31/25', '1/1/26', '2/14/26'));
+    const result = await renderSessions();
+    expect(result.current.data.map((s) => s.date)).toEqual([
+      '2/14/26',
+      '1/1/26',
+      '12/31/25',
+    ]);
+  });
+
+  it('sorts an unparseable date last, mirroring NULLS LAST', async () => {
+    mockQuery(rows('garbage', '8/7/26', '5/22/26'));
+    const result = await renderSessions();
+    expect(result.current.data.map((s) => s.date)).toEqual([
+      '8/7/26',
+      '5/22/26',
+      'garbage',
+    ]);
+  });
+
+  it('keeps the cache key exactly ["sessions"] so prefix invalidation still reaches the benchmark window', async () => {
+    mockQuery([]);
+    const client = makeClient();
+    await renderSessions(client);
+    expect(
+      client
+        .getQueryCache()
+        .getAll()
+        .map((q) => q.queryKey)
+    ).toContainEqual(['sessions']);
+  });
+
+  it('returns an empty array when there are no sessions', async () => {
+    mockQuery(null);
+    const result = await renderSessions();
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('surfaces a supabase error', async () => {
+    mockQuery(null, { message: 'network error' });
+    const { result } = renderHook(() => useSessions(), {
+      wrapper: makeWrapper(makeClient()),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/web/src/hooks/__tests__/useTSSHistory.test.js
+++ b/web/src/hooks/__tests__/useTSSHistory.test.js
@@ -5,6 +5,7 @@ import React from 'react';
 
 const fromMock = vi.fn();
 const inMock = vi.fn();
+const orderMock = vi.fn();
 
 vi.mock('../../supabaseClient.js', () => ({
   supabase: {
@@ -33,7 +34,10 @@ function mockQuery(data, error = null) {
       return chain;
     },
     gt: () => chain,
-    order: () => Promise.resolve({ data, error }),
+    order: (...args) => {
+      orderMock(...args);
+      return Promise.resolve({ data, error });
+    },
   };
   fromMock.mockReturnValue(chain);
 }
@@ -41,6 +45,7 @@ function mockQuery(data, error = null) {
 beforeEach(() => {
   fromMock.mockReset();
   inMock.mockReset();
+  orderMock.mockReset();
 });
 
 describe('useTSSHistory', () => {
@@ -122,7 +127,23 @@ describe('useTSSHistory', () => {
     expect(Number.isNaN(result.current.data[0].tss)).toBe(false);
   });
 
-  it('returns multiple sessions in ascending date order', async () => {
+  // Ordering happens in Postgres, so a mock cannot demonstrate it — asserting
+  // on an already-ordered fixture would prove nothing. Pin the query contract
+  // instead: date_iso, never the lexically-sorting TEXT date column (#187).
+  it('orders on the derived date_iso column, not the text date', async () => {
+    mockQuery([]);
+    const { result } = renderHook(() => useTSSHistory(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(orderMock).toHaveBeenCalledWith('date_iso', {
+      ascending: true,
+      nullsFirst: false,
+    });
+    expect(orderMock).not.toHaveBeenCalledWith('date', expect.anything());
+  });
+
+  it('maps every returned row, preserving the order the server sent', async () => {
     mockQuery([
       { date: '2026-06-01', duration: 60, srpe: 5 },
       { date: '2026-06-10', duration: 60, srpe: 8 },
@@ -131,8 +152,10 @@ describe('useTSSHistory', () => {
       wrapper: makeWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data.length).toBe(2);
-    expect(result.current.data[0].date).toBe('2026-06-01');
+    expect(result.current.data.map((d) => d.date)).toEqual([
+      '2026-06-01',
+      '2026-06-10',
+    ]);
   });
 
   it('throws (isError) when supabase returns an error', async () => {

--- a/web/src/hooks/useCoach.js
+++ b/web/src/hooks/useCoach.js
@@ -3,7 +3,6 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
 import { useTSSHistory } from './useTSSHistory.js';
 import { useVitals } from './useVitals.js';
-import { useSessions } from './useSessions.js';
 
 export function buildTrainingContext(
   latestLoad,
@@ -78,7 +77,6 @@ export function useCoach() {
 
   const tssQuery = useTSSHistory();
   const vitals = useVitals();
-  const sessions = useSessions();
 
   const setModel = (m) => {
     setModelState(m);

--- a/web/src/hooks/useSessions.js
+++ b/web/src/hooks/useSessions.js
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
+import { toISODate } from '../utils/dateFormat.js';
 
 export function useSessions() {
   return useQuery({
@@ -10,10 +11,25 @@ export function useSessions() {
         .select(
           'id, date, type, label, duration, srpe, status, distance_m, avg_watts, avg_hr'
         )
-        .order('date', { ascending: false })
+        // date_iso, not date: sessions.date is TEXT "M/D/YY" and sorts
+        // lexically, so a LIMIT over it returns the wrong SET of rows (#187).
+        // nullsFirst is mandatory — postgrest-js omits the clause entirely when
+        // it is undefined, and Postgres defaults descending to NULLS FIRST,
+        // which would float an unparseable date to the top as "most recent".
+        // id breaks ties: 24 of 57 dates carry more than one session, so
+        // without it the 50-row cut is arbitrary and moves between refetches.
+        .order('date_iso', { ascending: false, nullsFirst: false })
+        .order('id', { ascending: false })
         .limit(50);
       if (error) throw error;
-      return data ?? [];
+      // A deliberate no-op against the DB order above — keep it. The migration
+      // and the deploy are not atomic and PostgREST reloads its schema cache
+      // asynchronously, so this covers that window and any rollback.
+      return (data ?? []).slice().sort((a, b) => {
+        const ai = toISODate(a.date);
+        const bi = toISODate(b.date);
+        return ai < bi ? 1 : ai > bi ? -1 : 0;
+      });
     },
     staleTime: 60_000,
   });

--- a/web/src/hooks/useTSSHistory.js
+++ b/web/src/hooks/useTSSHistory.js
@@ -12,7 +12,11 @@ export function useTSSHistory() {
         .select('date, duration, srpe')
         .in('status', COMPLETED_STATUSES)
         .gt('srpe', 0)
-        .order('date', { ascending: true });
+        // date_iso, not the lexically-sorting TEXT date (#187). This ordering
+        // is a contract, not a correctness requirement: calcTrainingLoad keys a
+        // map by date and walks day-by-day, so CTL/ATL/TSB are unaffected by
+        // input order. Do not re-file the old ordering as a CTL bug.
+        .order('date_iso', { ascending: true, nullsFirst: false });
       if (error) throw error;
       return (data ?? []).map((s) => ({
         date: s.date,

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -99,12 +99,12 @@ export default defineConfig({
       //   measured: lines 48.98 / functions 46.81 / branches 40.38
       thresholds: {
         // Global floor — ratcheted up as extractions land tests (measured
-        // lines 76.86 / functions 75.45 / branches 72.00 on 2026-08-20, after
-        // the PM5 save-path tests (#173) and the erg date-handling tests (#184)
-        // landed; ~4 points headroom for denominator drift).
-        lines: 72,
-        functions: 71,
-        branches: 68,
+        // lines 79.92 / functions 77.47 / branches 74.49 on 2026-08-21, after
+        // the sessions date_iso ordering fix (#187) added the first
+        // useSessions.js tests; ~4 points headroom for denominator drift).
+        lines: 75,
+        functions: 73,
+        branches: 70,
         // Commercial-baseline gate (80/80/70) for new/extracted code, applied
         // per-file as it lands. The global floor above ratchets toward this as
         // the monolith is decomposed and its exclusions fall away.
@@ -126,6 +126,12 @@ export default defineConfig({
           branches: 70,
         },
         'src/utils/dateFormat.js': { lines: 80, functions: 80, branches: 70 },
+        'src/hooks/useSessions.js': { lines: 80, functions: 80, branches: 70 },
+        'src/hooks/useTSSHistory.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
         'src/components/ErrorFallback.jsx': {
           lines: 80,
           functions: 80,


### PR DESCRIPTION
Closes #187

## The bug

`sessions.date` is a **TEXT** column holding unpadded `M/D/YY`, so ordering on it is lexical — wrong within a month (`'6/4/26' > '6/30/26'`) and across months (`'9/30/26' > '12/1/26'`). Combined with `.limit(50)` in `useSessions()`, that returns the **wrong set of rows**, not merely a strange order.

Measured against the live 92-row table:

| | |
|---|---|
| Genuinely-recent sessions the old query dropped | **8** |
| Stale sessions it included instead | **8** |

## The fix

A generated `date_iso` date column derived from the text `date`, indexed on `(user_id, date_iso desc nulls last)`, with `useSessions` and `useTSSHistory` ordering on it. The text `date` column is untouched — every write path still writes `M/D/YY` and every display still reads `sessions.date`, so no consumer changed.

### Three things worth reviewing carefully

**`to_date` could not be used.** Both the issue and `CLAUDE.md` suggested `to_date(date,'MM/DD/YY')`. It is `provolatile = 's'` (STABLE — it honours `DateStyle`), so Postgres rejects it in a generated column *and* in an index expression; `text::date` is STABLE too. The parser uses `make_date`/`split_part`, which are genuinely IMMUTABLE, and agrees with `to_date` on **92/92 live rows**.

**The parser returns NULL rather than raising.** It is recomputed on every `UPDATE`, so a raising expression would abort a Coach-written session outright and leave any bad row permanently un-updatable. A `NOT VALID` CHECK makes bad *writes* loud instead — so `M/D/YY` is now enforced by the schema rather than by convention in a markdown file, including for Coach's MCP writes. `NOT VALID` means existing rows are never re-checked, which keeps the rollback unconditional.

**`nullsFirst: false` is mandatory, not stylistic.** `postgrest-js` emits the nulls clause *only* when the option is defined (`dist/index.cjs:881`). A bare `.order('date_iso', {ascending: false})` sends `date_iso.desc`, which is Postgres default **NULLS FIRST** — an unparseable date would sit at the top of the window and present as the most recent session. That would be worse than the bug being fixed.

## Scope notes

**`useTSSHistory` is included for consistency, not correctness.** I initially believed its misordering corrupted CTL/ATL/TSB. It does not: `calcTrainingLoad()` keys a map by `toISODate(date)`, derives min/max with `reduce` rather than by array position, and walks day-by-day. Input order cannot affect the output — **CTL/ATL/TSB have been correct all along.** What was genuinely wrong is its ordering test, which fed an already-sorted fixture through a mock that ignores `.order()`; that has been replaced with a real contract assertion.

**`useErgSessions.js` and `useBenchmarkSessions.js` are deliberately untouched.** Both already self-correct client-side, and their comments remain accurate while they keep ordering on `date`. Moving them onto `date_iso` is a one-line follow-up each.

**The dead `useSessions()` call in `useCoach.js` is removed.** The value was never read or returned, but it mounted a live query observer that refetched on every `['sessions']` invalidation. Separately worth knowing: `buildTrainingContext()` is never called outside its own test file, so the Coach training context is unreachable in production — a follow-up, not something to wire up inside a bug fix.

## Verification

Migration applied via `apply_migration`, then verified against live data:

```
parser:  6/4/26→2026-06-04  6/30/26→2026-06-30  9/30/26→2026-09-30
         12/1/26→2026-12-01  12/31/25→2025-12-31  2026-08-07→2026-08-07
         2/31/26→NULL (no error)  garbage→NULL
backfill: 92 total / 92 parsed / 2026-05-22 → 2026-08-07 / 0 stale
proof:    recent rows the old query dropped = 8
          stale rows it included            = 8
```

Supabase advisors: the one finding this change introduced (`function_search_path_mutable`) is fixed — the function now pins `search_path = ''`. All remaining advisor findings are pre-existing and unrelated.

Gates: **558 tests pass** across 51 files, lint clean, build exits 0. Coverage rose from 76.86/75.45/72.00 to **79.92/77.47/74.49**, so the global floor is ratcheted 72/71/68 → **75/73/70**, and `useSessions.js` (previously untested, 100% lines now) plus `useTSSHistory.js` get per-file 80/80/70 entries.

## Rollback

`supabase/migrations/008_sessions_date_iso_rollback.sql`. **Revert the deploy first** — a client carrying `.order('date_iso')` against a schema without the column gets a PostgREST 400 on every sessions read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
