### PR TITLE
config: sync SplitIQ's shared UI layer to claude.ai/design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ playwright-report
 .playwright
 # Lighthouse CI local run output
 .lighthouseci/
+
+# design-sync (claude.ai/design) — staged scripts, build output, machine state
+web/.ds-sync/
+web/ds-bundle/
+web/.design-sync/.cache/
+web/.design-sync/learnings/
+web/.design-sync/node_modules

--- a/web/.design-sync/DESIGN_BRIEF.md
+++ b/web/.design-sync/DESIGN_BRIEF.md
@@ -1,0 +1,657 @@
+---
+title: UI & Information Architecture Brief
+category: guidelines
+status: proposed
+date: 2026-08-22
+---
+
+# SplitIQ — UI & Information Architecture Brief
+
+Companion to [`conventions.md`](./conventions.md). That document is **descriptive** — written to make
+a design agent reproduce the current look, not to state intent. This one is **prescriptive**: where
+SplitIQ should go, and why.
+
+The distinction matters for how freely this brief proposes change. Per the sync session that
+authored it, one part of `conventions.md` is real and must be preserved:
+
+> **The accent→meaning mapping is domain logic.** `cyan` = erg/aerobic and primary, `green` =
+> done/healthy/UT1 and lower strength, `purple` = upper strength, `gold` = threshold or target
+> prompt, `orange` = elevated load, `red` = error/redline, `teal` = cycling, `grey`/`neutral` = rest.
+
+Everything else in it — **the palette values, radii, spacing and type scale — is incidental and was
+never designed.** Nothing in this brief needs to defend them, and it does not try to.
+
+Scope: direction only. Nothing here is implemented. Every claim is measured against branch
+`config/design-sync` at commit `7f22f66` (2026-08-22), with file and line references.
+
+The brief exists because the app has two problems its owner named plainly:
+
+> "Too much data on screen." · "Navigation is confusing."
+
+Neither is a matter of taste. Both are structural, both are measurable, and the measurements point
+somewhere specific.
+
+---
+
+## 0. The six findings, up front
+
+1. **Thirteen tabs is not a decision.** It is what happens thirteen times when the only container
+   the app has ever had is an array entry. (§1.1)
+2. **Six of the thirteen tabs are documents, not tools** — and two more are live features rendered
+   from stale constants while working hooks sit unused. (§1.2)
+3. **Several headline desktop numbers are decorative** — CTL/ATL/TSB from a constant, distance
+   hardcoded, FTP hardcoded. This is the *hidden cause* of "too much data": you cannot delete a
+   number you do not trust. (§1.3)
+4. **66% of all type in the app is ≤10px**; 3.3% is ≥18px. Nothing is bigger than anything else, so
+   the eye has nowhere to land. (§1.4)
+5. **The app renders entirely in the Courier fallback.** `'DM Mono'` is named 45 times and never
+   loaded. This is the single largest, cheapest win available — and the typography strategy behind
+   it deserves a harder look than just fixing the link. (§1.5)
+6. **There is no styling seam.** No component accepts `className`, `style`, or any override. A
+   restyle is an edit to every component file. Theming, light mode and density options are not
+   currently possible at all. (§1.8)
+
+---
+
+## 1. Diagnosis
+
+### 1.1 The tab array is the app's only unit of composition
+
+`src/App.jsx:300-338` is a literal array of thirteen `[id, label]` pairs rendered as buttons at
+`fontSize: 9`. `src/App.jsx:164` is `useState('overview')`. There is no router, no URL, no browser
+back, no deep link. There is also no `Card`, no `Section`, no drawer, no modal, no tab primitive.
+
+**Thirteen tabs is not a decision anyone made.** It is what happens thirteen separate times when the
+only available move is "add an entry to the array."
+
+The corroborating evidence: the two places that genuinely needed second-level navigation each
+invented it locally, and incompatibly. `src/views/ProgramView.jsx:34-60` hand-rolls a
+Phases / 2-Wk Cycle / Annual strip. `src/StrengthLogger.jsx` ships its own `<nav>` inside an
+`innerHTML` skeleton. Same problem, two solutions, because there was no shared one.
+
+### 1.2 Six of the thirteen tabs are documents, not tools
+
+Classified by what each view actually reads:
+
+| Tab | Reads | Verdict |
+|---|---|---|
+| `live` | `usePM5`, `useOfflineQueue`, Supabase write | Tool |
+| `logger` | Supabase direct | Tool |
+| `log` | `useSessionLog` + `LogSessionForm` | Tool |
+| `coach` | `useCoach` | Tool |
+| `erg` | `useErgSessions`, `useAnchors` | Live analysis |
+| `calendar` | `useBenchmarkStatuses` + live sessions | Live analysis |
+| `plan` | live `plannedSessions` (75 lines) | Live analysis, thin |
+| `overview` | mixed — mostly constants | Mixed |
+| `program` | `PHASES`, `HR_ZONES`, `SRPE_SCALE` constants (3,055 lines) | **Document** |
+| `journal` | `DECISION_LOG`, `HYPOTHESES`, `RULE_FIRING_HISTORY` | **Document** |
+| `mobility` | `mobilityLog` constant | **Document** |
+| `recovery` | `recoveryLog` constant (`src/constants/logs.js:343`) | **Document in a tool's clothing** |
+| `strength` | `strengthTrend` hardcoded at `src/App.jsx:85-122` | **Document in a tool's clothing** |
+
+`src/views/JournalView.jsx` says so itself in its header comment: *pure presentation over static
+journal data — no props, no state.*
+
+The last two rows are the sharp ones. `recovery` and `strength` are live features rendered from
+stale constants — while `useVitals` and `useStrengthPRs` exist, work, and are already wired up on
+mobile. **A document does not need a top-level tab. It needs a shelf.**
+
+### 1.3 Several headline desktop numbers are decorative
+
+| Location | What it does |
+|---|---|
+| `src/App.jsx:190` | CTL/ATL/TSB from the static `DAILY_TSS` constant, not `useTSSHistory` |
+| `src/App.jsx:204` | `totalErgDist = 55000` — hardcoded |
+| `src/App.jsx:166` | `ftp = 190` — hardcoded |
+| `src/App.jsx:85-122` | e1RM history for 8 lifts — hardcoded, passed to `StrengthView` |
+| `trainingConfig.js:261` + `tssData.js:1` | Two copies of `DAILY_TSS`; desktop imports one, mobile the other |
+
+**This is the hidden cause of "too much data on screen."** You cannot delete a number you do not
+trust. When the headline stat might be decorative, the rational response is to keep every
+corroborating number visible so you can cross-check — which is exactly what the current home screen
+does. Data-truth uncertainty causes data hoarding.
+
+The consequence: fixing the numbers is a **design prerequisite**, not a separate engineering chore.
+Redesign first and you build a prettier frame around fake numbers, and the cut cards come back.
+
+### 1.4 The type scale has collapsed
+
+631 numeric `fontSize` declarations across `src/**`:
+
+| px | 6 | 7 | 8 | **9** | 10 | 11 | 12 | 13 | 14 | 15 | 16–17 | 18–24 | 28–52 |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| n | 1 | 8 | 70 | **225** | 115 | 91 | 50 | 24 | 12 | 10 | 4 | 14 | 7 |
+
+**66% of all type is ≤10px. 3.3% is ≥18px.** `fontSize: 9` alone is 225 declarations. There is no
+mid-range.
+
+This is the measurable form of "too much data on screen" — not the *quantity* of information, but
+that **nothing is bigger than anything else**.
+
+`src/views/OverviewView.jsx` compounds it: eight full-width cards, all sharing the same treatment
+(`background:'#2a2a48'`, `1px solid #4a4a68`, `borderRadius:6`, `padding:'14px 16px'`, label at
+`fontSize:9 letterSpacing:3`). Identical visual weight for eight items of wildly different
+importance means the page has no entry point.
+
+Two of those blocks are the same data twice on one screen: the RECENTLY COMPLETED list inside the
+status strip (`:50-362`) and the RECENT SESSIONS list (`:1286-1307`), about 70px apart.
+
+### 1.5 The app has no typeface
+
+`'DM Mono'` is referenced **45 times across 16 files**. `index.html` loads no webfont. There is no
+`@font-face` anywhere in the repo.
+
+**Every screen renders in the Courier/monospace fallback, and always has.** `NOTES.md` records this
+as faithful-to-production for sync purposes — correct there. For the app it is simply a bug.
+
+But the bolder observation is that fixing the link is not the right fix. `conventions.md` describes
+the house identity as *"dark-only, data-dense, monospace-numeral."* **Monospace-numeral is right.
+Monospace-everything is what reads as homemade.** Every commercial reference — Strava, Whoop, Hevy,
+TrainingPeaks — pairs a UI sans for chrome, labels and prose with tabular or monospaced figures for
+data. Courier for section labels, button text and body copy is the single loudest signal that this
+is a personal project.
+
+See §6.1 for the recommendation. This is the highest ratio of perceived polish to effort anywhere in
+the brief.
+
+### 1.6 `THEME.muted` fails WCAG AA on the standard card background
+
+Computed contrast ratios against `src/constants/theme.js`:
+
+| Foreground | on `bg` #08080d | on `surface` #1a1a2e | on `raised` #2a2a48 |
+|---|---|---|---|
+| `text` #e8e8f0 | 16.40 | 14.00 | 11.31 |
+| `textSubtle` #aaaacc | 8.88 | 7.58 | 6.13 |
+| **`muted` #7e7e9a** | 5.08 | **4.34 ✗** | **3.50 ✗** |
+| `textFaint` #6c6c88 | **3.94 ✗** | **3.36 ✗** | **2.72 ✗** |
+| `textDim` #5a5a74 | **3.00 ✗** | **2.56 ✗** | **2.07 ✗** |
+
+`THEME.muted` is the most-used text colour in the app, `THEME.raised` is the standard card
+background, and the pair is **3.50:1** — below the 4.5:1 AA threshold. `conventions.md` currently
+recommends exactly this pairing for section labels.
+
+CI already gates Lighthouse accessibility at **≥ 0.78 as an error** (`lighthouserc.json`). Both a
+real defect and free headroom.
+
+### 1.7 The 767px fork turned one product into two
+
+`src/main.jsx:289` is `{isMobile ? <MobileApp/> : <App/>}` — two entirely separate trees, not a
+responsive layout. Only `ErgLiveView` and `CoachView` are shared. Eight desktop tabs have no mobile
+equivalent. `RecoveryView.jsx` (781 lines) and `MobileRecovery.jsx` (632 lines) are the same feature
+built twice, disagreeing about the data.
+
+Three uncoordinated breakpoints exist: 767 (`hooks/useIsMobile.js`), 900 (`isWide`,
+`src/App.jsx:183`), 600 (`isMid`, `src/App.jsx:184` — **dead, never read**).
+
+The fork *caused* §1.3's divergence. Two trees owning one concept produce two answers.
+
+### 1.8 There is no styling seam
+
+Every component styles itself with inline `style` objects reading a hardcoded `THEME`. **None accept
+`className`, `style`, `sx`, or any escape hatch** — appearance is controlled only by semantic props
+(`accent`, `size`, `dimmed`, `done`). There is no stylesheet, no provider, no context.
+
+Two consequences, and the second is the one that bites:
+
+1. **A restyle is an edit to every component file.** There is no central lever. The 973 hardcoded hex
+   literals are a symptom of this, not the cause.
+2. **Theming, light mode and density options are not currently possible.** Not "deferred" —
+   structurally unavailable. There is nowhere for the decision to enter.
+
+This is the constraint that turns §5's primitives from a convenience into a prerequisite. It also
+narrows §2.3: **a `density` prop cannot propagate through components that have no seam to receive
+it.** Either the new primitives ship a seam the existing eleven lack, or density stays impossible.
+
+The recommendation is in §5.1. It is a deliberate divergence from `conventions.md`'s
+no-escape-hatch rule, and it should be made knowingly rather than by accident.
+
+### In one sentence
+
+> SplitIQ has thirteen tabs because a tab was the only container it ever had; it has too much on
+> screen because eight subsystems render at identical weight in 9px Courier; and none of it can be
+> cut until the desktop numbers stop being decorative.
+
+---
+
+## 2. Target information architecture
+
+### 2.1 Thirteen tabs → five destinations
+
+| # | Destination | Question it answers | Absorbs |
+|---|---|---|---|
+| 1 | **Today** | *What am I doing today, and am I ready?* | `overview` (rebuilt), mobile `analytics` hero |
+| 2 | **Train** | *Do the thing.* | `live`, `logger`, `log` (capture), `plan` |
+| 3 | **Progress** | *Am I getting better?* | `erg`, `strength`, `calendar`, `log` (history), training load |
+| 4 | **Body** | *What state am I in?* | `recovery`, `mobility` (doing), nutrition |
+| 5 | **Coach** | *Why am I doing this?* | `coach` (Ask) + Playbook (§2.2) |
+
+**Nothing is deleted. Everything is re-addressed.** Every current tab has a named home, which is what
+makes this shippable as re-parenting rather than as a rewrite.
+
+Second-level navigation uses one pattern — a `SegmentedNav` strip under the page title. This
+*standardises* the two hand-rolled instances from §1.1 rather than adding a third.
+
+### 2.2 Reference content goes on a shelf, inside Coach
+
+Moving to **Coach → Playbook**: `ProgramView` phases/cycle/annual, `JournalView`'s four ledgers, the
+full `ADAPTIVE_RULES` set and `RULE_EVOLUTION` log currently behind a `<details>` in
+`OverviewView.jsx`, the hardcoded SEQUENCING RULES array (`OverviewView.jsx:1309-1358`),
+`SRPE_GUIDE`, and the mobility routine library. Mobility's *doing* side stays in Body.
+
+**Why Coach and not a sixth tab:** the Playbook answers the same question the chat answers — *why am
+I doing this?* One question, one address. Coach is also one of only two views already shared across
+the `main.jsx:289` fork, making it the lowest-risk merge point in the codebase.
+
+The consequence for Today is the important part: every home-screen block whose job is *explanation*
+becomes a **"Why?" affordance that deep-links into the Playbook**. That is the single largest cut to
+Today, and it is principled — it follows from what the block *is*, not from how much room it takes.
+Cutting explanation stops being a loss of information and becomes a change of address.
+
+`ProgramView`'s internals are not touched — one line of nav config. Decomposition rides with #77;
+#183 already excludes it from hex migration.
+
+### 2.3 Converge onto the mobile IA — phone is primary
+
+Decided 2026-08-22. Android ships via Capacitor, and the phone is what sits next to the erg.
+Desktop's job becomes *the same five destinations with room to breathe*, not a different product.
+
+This does not require deleting the fork immediately. Three stages, each independently shippable:
+
+1. **Nav semantics** — same five ids, same order, same content ownership on both trees.
+2. **Per-destination layout** convergence.
+3. Only then does `main.jsx:289` become `<AppShell density={isMobile ? 'compact' : 'comfortable'}>`.
+
+The fork survives as a **density** decision long after it stops being an **IA** decision. Along the
+way `isWide` (900) and dead `isMid` (600) are deleted — one breakpoint, one source.
+
+**Stage 3 is gated on §1.8.** Density is not a prop that can be threaded through today's components;
+they have no seam to receive it. It requires the token-module mechanism in §5.1. Stages 1 and 2
+deliver most of the value and need no seam at all — so this ordering is not a dependency trap.
+
+### 2.4 StrengthLogger becomes a mode, not a place
+
+Entered from Today's primary CTA or from Train: push in, do the workout, pop back.
+
+1. **It cannot be a peer.** `src/StrengthLogger.jsx` is a vanilla-JS app — a ~110-line CSS template
+   string with `.slog`-scoped classes, a `SKELETON` innerHTML string, imperative
+   `document.createElement` throughout. React's only role is `dangerouslySetInnerHTML` plus a mount
+   effect. It cannot consume shared components without the rewrite that is #79's job. Making it a
+   *mode* requires touching none of that.
+2. **It is the correct commercial pattern.** Hevy, Strong and Fitbod all treat an active workout as
+   a full-screen mode that suppresses global chrome. Logging is a state you are in, not a page you
+   are on.
+3. **It fixes a live z-index bug by construction.** `#restBar` is z-110 and outranks `BottomTabBar`
+   at z-100; `#toast` at z-80 renders *below* the nav. Suppressing the tab bar during a workout
+   resolves this without renumbering anything.
+
+Worth noting: StrengthLogger's private CSS (`--radius:12px`, `.card`, `.pill`, `.btn` with
+sec/ghost/danger/good/sm/xs variants, `.section-title`) is **the closest thing this repo has to a
+design system** — and it lives in the one file that cannot share it. Mine it for values; do not
+couple to it.
+
+---
+
+## 3. Principles for the Today screen
+
+Six principles, each named and *testable* — the tests matter, because §1.4 shows this screen
+re-accumulates by default.
+
+**P1 · One headline answer per screen.** Every screen answers one question, and the answer appears in
+type ≥28px before any 9px text does. Today's question: *am I recovered, and what am I doing?*
+Exactly one primary action button.
+*Test:* screenshot the top 400px at 390×844 — someone who has never seen the app can state the
+answer. Today the top 400px shows a date, a phase label, a week counter, a readiness score, a
+coloured badge and a workout item: six competing answers.
+
+**P2 · Hierarchy is size and position; colour is domain meaning.** The accent→meaning mapping
+(cyan = erg/aerobic, purple = upper, green = lower/done, gold = threshold, orange = elevated load,
+teal = cycling, grey = rest) is **real domain logic and must be preserved** — it is the one part of
+`conventions.md` that was designed rather than accreted. Which is exactly why it must not be spent
+on decoration: the app currently colour-codes section labels by *topic* (SEQUENCING RULES green
+`:1320`, NUTRITION STATUS red `:1085`, TRAINING LOAD orange `:925`), so a green label means
+"nutrition heading" in one place and "UT1/done" in another. That collision devalues the vocabulary
+everywhere it is legitimately used.
+*Test:* render in greyscale — reading order survives unchanged. And: every accent in the Today
+subtree traces to a session type or a status, never to a heading.
+
+**P3 · Every number on Today is live, or it is not on Today.**
+*Test:* the `views/today/` subtree imports nothing from `constants/` except `theme.js`, `tokens.js`,
+nutrition targets and `sessionStatus.js`.
+*Today, five of eight blocks fail this.* That ratio is the honest measure of how much of this
+redesign is really a data problem.
+
+**P4 · Reference is pulled, never pushed.** Static explanation is one tap from the thing it explains
+and appears in zero default scrolls.
+*Test:* no `<details>` and no inline prose array literals in `views/today/`.
+
+**P5 · Three screenfuls, hard cap.**
+*Test:* Playwright asserts `document.body.scrollHeight <= 3 * window.innerHeight` on Today. Cheap,
+objective, CI-enforceable — the only thing that will stop the screen growing back to 1,361 lines.
+
+**P6 · One card, one section label, one stat tile.** No bespoke card markup in the Today subtree.
+*Test:* zero raw `background:'#2a2a48'`, zero raw `borderRadius:`, zero raw `letterSpacing: 3` in
+`views/today/`.
+Without P6 this is a one-off polish job and Progress and Body get hand-rolled again from scratch.
+
+---
+
+## 4. The proposed Today screen
+
+Hero decided 2026-08-22: **"Am I recovered?"** — a readiness score.
+
+Note the dependency this creates: readiness is computed today from the static `recoveryLog`
+constant, so **the chosen hero is blocked on the data-truth fix**. Interim option is a TSB hero,
+already live on mobile via `useTSSHistory`.
+
+### 4.1 Five blocks
+
+| | Block | Content | Type weight |
+|---|---|---|---|
+| 0 | Header | `SPLITIQ` · date · phase chip (`BUILD · wk 4/6`) | 13 / 11 / 10 |
+| 1 | **Readiness hero** | One number, one plain-English sentence. Nothing else. | 52 / 14 |
+| 2 | **Today's session** | Label, duration, watt band, pacer cue, one adaptive-adjustment line, **one CTA**. "Why?" → Coach. | 20 / 14 / 11 |
+| 3 | Next up | 3 rows: date + label | 12 |
+| 4 | This week | Sessions done/planned, weekly TSS, 40px sparkline | 24 / 10 |
+| 5 | Recent | 3 rows, tap for detail | 12 |
+
+Target ~250 lines across `views/today/*` — satisfying #114's 800-line rule by construction.
+
+### 4.2 Disposition of the current eight blocks
+
+**(a) Today status strip** `:50-362` — **SPLIT into four.** One block doing five jobs in 312 lines;
+splitting it is what makes hierarchy possible at all. Date + phase + week → header chip. Readiness +
+signal → **hero, promoted to 52px**. Today's `WorkoutItem`s → session card. UPCOMING → block 3.
+RECENTLY COMPLETED → **merge into block 5**.
+
+**(b) Phase context card** `:365-468` — **MOVE → Playbook.** The arc strip and Doing / Why now / Not
+yet / Next gate prose is static `PHASE_CONTEXT`. Weekly orientation, not daily. Fails P4. A one-line
+header chip carries everything genuinely daily.
+
+**(c) 4-up stat grid** `:471-527` — **CUT 2, MOVE 2, REPLACE.** SESSIONS LOGGED and ERG DISTANCE are
+cumulative vanity totals that barely move day to day — and `totalErgDist` is literally `55000`
+hardcoded (`App.jsx:204`), a decorative number in prime real estate. LATEST WATTS and SQUAT e1RM are
+progress facts → **Progress** (and `strengthTrend` is stale anyway). Replace with block 4, which
+answers *am I on track?* rather than reporting a number that never meaningfully changes.
+
+**(d) Adaptive Engine card** `:530-747` — **DEMOTE to one line.** *(Decided 2026-08-22.)* 217 lines
+rendering a rules engine's source of truth on the home screen — the highest-value single cut on the
+page. Keep one line inside the session card: *"Volume trimmed 10% — low HRV"*, tappable. The full
+`ADAPTIVE_RULES` set and `RULE_EVOLUTION` log → Playbook. It is documentation, not status.
+
+**(e) Today's Prescription** `:750-905` — **MERGE into block 2.** UT1/UT2 bands and the pacer cue
+*are* today's session. Today currently has two separate cards about today; that duplication costs
+155 lines for zero information gain and is a first-order driver of the density complaint.
+
+**(f) Training Load card** `:908-1065` — **SPLIT.** TSB survives as the hero's supporting line.
+CTL/ATL tiles and the 160px `LineChart` → **Progress**: a 30-day trend answers a weekly question and
+is the largest render cost on the page. Optionally keep a 40px sparkline in block 4. Blocked on the
+data fix — reads static `DAILY_TSS` today and fails P3.
+
+**(g) Nutrition Status** `:1068-1283` — **MOVE → Body.** Daily in kind, but it is a *second
+headline*, which breaks P1 outright. Also reads the static `nutritionLog` and fails P3. If a daily
+cue is wanted it earns **one line** in block 4 — once intake is live.
+
+**(h) RECENT SESSIONS + SEQUENCING RULES** `:1286-1358` — **MERGE + CUT.** Recent sessions merges
+with (a)'s duplicate list. SEQUENCING RULES is an 8-item hardcoded array that has not changed and
+will not change → Playbook. It is a poster on the wall, and posters do not belong on a dashboard.
+
+**Net: 8 cards → 5 blocks. ~1,361 lines → ~250.** Three of the five blocks did not exist as such
+before; they are extractions from (a), which was already carrying them at 9px.
+
+---
+
+## 5. Missing primitives
+
+None of §4 is buildable today. There is no shared `Card`, `StatTile`, `SectionHeader`, `Button`,
+`Pill`, `Badge`, `Grid` or `Modal` — every one is hand-rolled inline in every view. All proposals
+below are inline-style React components; no CSS, no `className`.
+
+### 5.1 The new primitives must ship the seam the existing eleven lack
+
+Per §1.8, no current component accepts a styling override, so theming and density are structurally
+impossible. If the ten primitives below are built the same way, that stays true forever and §2.3
+stage 3 never happens.
+
+**Recommendation — two seams, both narrow:**
+
+1. **Every primitive accepts and merges a `style` prop last.** `style={{...base, ...style}}`. One
+   line per component. This is a deliberate divergence from `conventions.md`'s no-escape-hatch rule,
+   and it is worth taking: the rule was protecting consistency that the 973 loose hex literals show
+   was never actually held. The domain components (`LogEntry`, `WorkoutItem`, `LiveMetric`) can keep
+   their closed contracts — the divergence applies to *layout* primitives only, where the whole job
+   is to be composed into arrangements their author did not anticipate.
+
+2. **Density enters through the token module, not through props.** `tokens.js` exports
+   `spaceFor(density)` / `typeFor(density)`; `AppShell` resolves density once and primitives read
+   the resolved scale. This avoids threading a `density` prop through every component — which is
+   the same prop-drilling mistake `isWide` already makes (`App.jsx:183`, drilled into five views).
+
+Without seam 1, every future visual change is another 973-literal sweep. Without seam 2, the
+desktop/mobile convergence in S5 has no mechanism.
+
+| # | Component | Replaces | Proposed props |
+|---|---|---|---|
+| 1 | `Card` | the background/border/radius/padding quadruple — the `'14px 16px'` padding literal alone appears 42× | `{ children, tone, accent, padding, interactive, onClick }` |
+| 2 | `SectionLabel` | the `fontSize:9 letterSpacing:3` label, ~45× | `{ children, accent, action }` |
+| 3 | `Banner` | `borderLeft:'3px solid'` explainer, **36 occurrences** across 9 files | `{ accent, title, children, dashed }` |
+| 4 | **extend `LiveMetric`** | — see below | `+ { sub, trend }` |
+| 5 | `StatRow` / `Grid` | `gridTemplateColumns: isWide ? …` and the `isWide` prop-drill | `{ cols, gap, children }` |
+| 6 | `SegmentedNav` | the two incompatible strips from §1.1 | `{ items, value, onChange, size }` |
+| 7 | `Pill` / `Badge` | StrengthLogger `.pill`; `BenchmarkBadge` is a one-off of the same idea | `{ children, tone, variant, size }` |
+| 8 | `Button` | desktop has none — `App.jsx:313-337` hand-rolls it inline | `{ children, onClick, variant, size, full, disabled }` |
+| 9 | `AppShell` | absorbs `main.jsx:289` as a **prop** instead of a tree fork | `{ tabs, active, onTabChange, density, title, children }` |
+| 10 | `Sheet` | "Why?" drill-downs, full-screen StrengthLogger | `{ open, onClose, title, size, children }` |
+
+**Do not build `StatTile`.** `src/components/LiveMetric.jsx` already covers ~80% — `label / value /
+unit / accent / size (large 52 · normal 34 · small 22) / dimmed`, with `null → '--'` — and it is
+already published with authored docs. Two extra props beat a parallel component.
+
+### What the existing eleven cover
+
+`LiveMetric` → primitive 4 (extend). `BottomTabBar` → part of primitive 9. `LogEntry`, `WorkoutItem`,
+`WorkoutTarget` → domain rows, keep as they are. The four tooltips and `PaceTrendChart` → Recharts
+adapters, not layout. `ErrorFallback` → one-off.
+
+**The gap in one sentence: the SplitIQ package documents domain components and contains zero layout
+primitives.** Adding `Card`, `SectionLabel`, `Banner`, `Button`, `Pill` and `SegmentedNav` to
+`componentSrcMap` — with docs in the existing style — is what turns the package from a component
+gallery into a design system, and gives Claude Design something real to design *with*.
+
+Per `NOTES.md`, each new component needs three coordinated edits — `entry.jsx`,
+`cfg.componentSrcMap`, and `docs/<Name>.md` with `category:` frontmatter — plus a hand-written
+`dtsPropsFor` contract, which has no drift detection.
+
+---
+
+## 6. Tokens
+
+`src/constants/theme.js` is 24 **colour** tokens and nothing else. No spacing, type, radius, shadow,
+z-index or breakpoint scale exists.
+
+**Shipping mechanism: a new `src/constants/tokens.js` of plain JS objects, not CSS variables.**
+`src/utils/themeCss.js` already emits `:root{--color-*}` and **nothing in the app reads them** — zero
+`var(--color` hits outside StrengthLogger's private set. Repeating that for spacing would be worse,
+not better.
+
+The load-bearing decision: **`TYPE` entries are spreadable style fragments, not scalars.** Under an
+inline-styles-only constraint this is the only shape that keeps application to one line:
+
+```js
+style={{ ...TYPE.label, color: THEME.cyan, marginBottom: SPACE.sm }}
+```
+
+### 6.1 Typography — the boldest recommendation in this brief
+
+**Split the typeface by role. Sans for chrome, mono for figures.**
+
+| Role | Face | Why |
+|---|---|---|
+| Section labels, buttons, prose, nav, coach chat | **UI sans** | Courier at 9–12px is the homemade tell |
+| Metric values, splits, watts, paces, tables, tooltips | **Monospace, tabular figures** | Genuinely correct — digits must not jitter as they tick |
+
+Concretely: one variable sans with real weights — Inter, or IBM Plex Sans to sit beside IBM Plex
+Mono — for everything that is not a number, and DM Mono (or Plex Mono) actually *loaded* for
+everything that is. Self-host both; do not add a Google Fonts request to an app that ships as an
+Android APK from `file://`.
+
+This directly amends `conventions.md`'s *"dark-only, data-dense, monospace-numeral"*. Note it keeps
+**monospace-numeral** — that part is right and worth protecting. What changes is that monospace stops
+being the default for everything else.
+
+Expected impact: larger than the entire layout redesign, for a fraction of the work. It is the
+difference between a terminal readout and a product. **Ship it first, independently of every other
+slice** — it touches `index.html`, a `fontFamily` token, and the 45 existing references.
+
+### 6.2 TYPE scale
+
+```
+hero    { size: 52, weight: 700, letterSpacing: -1,    lineHeight: 1   }   // one per screen
+display { size: 32, weight: 700, letterSpacing: -0.5,  lineHeight: 1.1 }
+title   { size: 20, weight: 700, letterSpacing: -0.25, lineHeight: 1.2 }
+body    { size: 14, weight: 400, lineHeight: 1.5 }    // ← barely exists today: 12 uses
+bodySm  { size: 12, weight: 400, lineHeight: 1.5 }
+label   { size: 11, weight: 600, letterSpacing: 1, lineHeight: 1.3, uppercase }
+caption { size: 10, weight: 400, lineHeight: 1.4 }
+micro   { size:  9, weight: 600, letterSpacing: 3, lineHeight: 1.3, uppercase }  // SECTION LABELS ONLY
+```
+
+**`fontSize: 9` stops being the default and becomes reserved for section labels.** Prose moves
+9/10/11 → 12/14. Per §1.4 that reassigns most of 419 declarations — most of "commercial fitness app
+ready," and most of the Lighthouse accessibility headroom.
+
+This *preserves* the house detail `conventions.md` describes — tiny tracked uppercase section labels
+— while removing 9px from everything that is not a section label.
+
+### 6.3 SPACE — 4px base
+
+```
+{ xxs: 2, xs: 4, sm: 8, md: 12, lg: 16, xl: 24, xxl: 32 }
+```
+
+Observed today: `gap` 6×30, 8×23, 10×17; `marginBottom` 10×59, 4×48, 6×45, 8×43, 12×36. **This scale
+retires 6→8 and 10→12**, nudging roughly 200 call sites by ±2px. Flagged plainly: the largest
+visual-drift risk in the brief, and the repo has **no visual-regression testing** — one Playwright
+smoke spec, and `OverviewView`'s own test file is 89 lines of "renders without crashing" against a
+1,361-line view. Take the nudge deliberately, with screenshot baselines first.
+
+### 6.4 RADIUS
+
+```
+{ sm: 6, md: 12, lg: 16, pill: 999 }
+```
+
+Measured: 192 `borderRadius` declarations across 9 values — `6`×104 dominant, `12`×3.
+
+**Standardise cards on 12**, keeping 6 for chips and inputs. Commercial fitness apps read at 12–16;
+12 is already mobile's value and StrengthLogger's `--radius:12px`.
+
+`conventions.md` records the current style as "6–10px radii" — but per its authors the radii were
+never designed, so this needs no justification beyond looking better. It does need `conventions.md`
+updated in the same change, or the design agent will keep reproducing the old value.
+
+### 6.5 The rest
+
+```
+SURFACE = { base: bg, card: raised, sunken: surfaceAlt, field: bg }
+SHADOW  = { sheet: '0 -8px 32px #00000080' }   // 8-digit hex, never rgba() — #183 convention
+LAYER   = { base: 0, sticky: 10, nav: 100, sheet: 200, toast: 300, modal: 400 }
+BREAKPOINT = { compact: 767 }                   // one value; deletes isWide 900, dead isMid 600
+```
+
+`LAYER` fixes a live bug class: `BottomTabBar` is 100, StrengthLogger `#restBar` is 110, `#toast` is
+80 — **the toast currently renders below the nav.**
+
+### 6.6 Two colour corrections (these belong to #183, not the type pass)
+
+1. **`muted` on cards fails AA** (§1.6). Either lighten `muted` toward `#9494b4` (≈4.6:1 on
+   `raised`), or use `textSubtle` (#aaaacc, 6.13:1) wherever muted sits on a card. Retire `textDim`
+   and `border` as *text* colours entirely.
+2. `conventions.md`'s example section label uses `color: THEME.muted` — update it with whichever fix
+   is chosen.
+
+### 6.7 One legitimate use of CSS variables
+
+Extend `.design-sync/gen-css.mjs` to emit `--space-*`, `--radius-*`, `--font-size-*` and the font
+stacks into `base.css`. That file **is** consumed — by design-sync previews and by Claude Design.
+This does not violate the app-side constraint; it means the design agent designs against the same
+scale the app builds against. Per `NOTES.md`, re-run `gen-css.mjs` as step one of every sync, and
+wire the faces via `cfg.extraFonts` so designs keep matching.
+
+---
+
+## 7. Sequencing
+
+Each slice is one Issue → branch → PR → CI, tests in the same PR.
+
+```
+S-1 type  ──────────────────────────────────────────────► (independent, ship first)
+
+S0 tokens ──► S1 primitives ──► S3 nav 13→5 ──► S4 Today ──► S5 converge ──► S7 logger
+                                                   ▲             │
+S2 data truth ─────────────────────────────────────┘             │
+                                                                 ▼
+             #183 slices 2c/2d ──► S6.0 baselines ──► S6a…S6e spacing + radius
+```
+
+| Slice | What | Value | Risk | Depends |
+|---|---|---|---|---|
+| **S-1** | **Typography split** (§6.1). Self-host a UI sans + a real mono; `fontFamily` tokens; swap the 45 references | **Highest ratio in the brief** | low | — |
+| **S0** | `constants/tokens.js`. Zero call sites changed | Unblocks everything | nil | — |
+| **S1** | `components/ui/*` primitives **with the §5.1 seam**; extend `LiveMetric`; register in design-sync | High | low | S0 |
+| **S2** | **Data truth.** Wire desktop to `useTSSHistory`/`useVitals`/`useStrengthPRs`; collapse duplicate `DAILY_TSS`; resolve or document `rowing_cp` 205 vs displayed 190 (#176) | **Highest** | medium | — |
+| **S3** | Nav 13→5 + `AppShell` + hash routing. Views keep rendering unchanged, at new addresses | Kills complaint #2 | med-low | S1 |
+| **S4** | Today rebuild; delete `OverviewView.jsx` (1,361 lines) | Kills complaint #1 | **highest** | S0–S3 |
+| **S5** | Mobile adopts shared nav config; `main.jsx:289` → `density` prop | Halves future feature cost | medium | S3, S4 |
+| **S6** | Spacing + radius pass, per destination. **S6.0 = screenshot baselines first** | Visible | high *visual* | S0, S4, #183 |
+| **S7** | StrengthLogger as full-screen flow | Med-high | medium | S3, S5 |
+
+**S-1 and S2 are the two to do first.** S-1 because it is the cheapest large perceived change and
+blocks nothing. S2 because without it S4 builds a prettier frame around fake numbers (§1.3) — it also
+drops `App.jsx` toward ~350 lines, direct progress on #114.
+
+### The #183 boundary — the one hard rule
+
+S6 must land **after** #183's slices 2c (desktop views) and 2d (mobile + `App.jsx`), because #183 is
+rewriting colour literals in the same lines. The clean split is **by CSS property**:
+
+> **S6 touches `padding` / `margin` / `gap` / `borderRadius` and never a colour hex.
+> #183 touches colour hexes and never a size.**
+
+The `muted` contrast fix is therefore #183's, not S6's. S-1 and the TYPE scale touch `fontSize` and
+`fontFamily` — neither is contested by #183, so they can proceed in parallel.
+
+### Standing exclusions
+
+- **`ProgramView.jsx` / `ProgramYear.jsx` internals: untouched.** One line of nav config in S3.
+  Decomposition rides with #77; already excluded from #183.
+- **`StrengthLogger.jsx` internals: untouched.** Rewrite is #79. S7 changes only how it is entered.
+- No light mode, no `rgba()`, no Recharts colour props — all deferred by #183.
+- No file over ~800 lines (#114); coverage ratchets up only.
+- Any `web/src/**` change triggers the Android build (`ci-android.yml`).
+
+---
+
+## 8. Open questions
+
+1. **Typeface choice.** §6.1 argues the split; it does not pick the faces. Inter + DM Mono, or the
+   IBM Plex pair for a single designed family? This is a taste call and it should be Scott's.
+2. **The styling seam is a real divergence** (§5.1). `conventions.md` states components accept no
+   escape hatch, and that is currently true of all eleven. Adding `style` passthrough to the new
+   *layout* primitives breaks that rule deliberately. The alternative — keep every primitive closed —
+   means theming, light mode and density remain permanently impossible. Worth an explicit yes or no
+   rather than drifting into it.
+2. **Nutrition** — moved to Body. 215 lines suggests it matters; if intake is adjusted daily it
+   earns one line on Today, but only once it is live.
+3. **`rowing_cp` 205W vs displayed 190** (#176) — assumed a display bug to fix in S2. **If 190 is a
+   deliberate conservative floor, S2 must not "fix" it** — and it needs a comment saying so, because
+   it will keep being reported as a bug.
+4. **Radius 6→12 and ±2px spacing drift across ~200 call sites, with no visual-regression net.** The
+   price of a real scale. Mitigation is S6.0 baselines, but that is new CI surface.
+5. **Five destinations or six?** Program sits in the Playbook. If it is read and revised weekly it
+   may deserve its own destination. Genuine coin-flip; one line in `constants/nav.js` either way.
+6. **Hash routing on Android.** Deep links and back are impossible today (`App.jsx:164` is
+   `useState`). Capacitor serves from `file://`, so hash routing not history — and `MobileApp.jsx`
+   already wires the hardware back button, so the two interact and need testing on a real device.
+7. **Coverage ratchet.** Deleting `OverviewView.jsx` *raises* measured coverage. But S2 rewires
+   `App.jsx`, which is in the denominator. Decide in advance that a threshold bump is a PR-config
+   change, not a reason to stall a slice.

--- a/web/.design-sync/NOTES.md
+++ b/web/.design-sync/NOTES.md
@@ -1,0 +1,112 @@
+# design-sync notes — SplitIQ
+
+Repo-specific gotchas for syncing this repo to claude.ai/design. Read this
+before re-running the sync.
+
+## Shape
+
+- **This repo is an app, not a published component library.** There is no
+  library build, no `dist/` entry, no `.d.ts`, and no Storybook. The synced
+  design system is the app's shared UI layer: `web/src/components/**` plus the
+  `THEME` tokens.
+- Everything lives under `web/` because that is the npm package (`splitiq`).
+  `.design-sync/`, `.ds-sync/` and `ds-bundle/` are all package-relative, and
+  every command below is run from `web/`.
+
+## Sync inputs this repo owns
+
+| File | Why it exists |
+|---|---|
+| `.design-sync/entry.jsx` | The app's components are **default exports**; the converter's synth-entry uses `export *`, which does not re-export defaults. This barrel gives them stable named exports. **Add new components here** or they will not reach `window.SplitIQ`. |
+| `.design-sync/gen-css.mjs` | Generates `base.css` from `src/constants/theme.js`. **Re-run it whenever THEME changes**: `node .design-sync/gen-css.mjs`. |
+| `.design-sync/base.css` | Generated. The token layer (`--color-*`) plus the app ground. Wired as `cfg.cssEntry`. |
+| `.design-sync/docs/*.md` | Per-component docs. Their `category:` frontmatter is what sets the DS pane groups (session / metrics / charts / tooltips / feedback / mobile) — without them everything lands in `general`. |
+| `.design-sync/previews/*.tsx` | Authored preview stories, one file per component. |
+
+## Gotchas
+
+- **`cfg.tokensGlob` is inert without `cfg.tokensPkg`.** `copyTokens()` returns
+  early when there is no tokens *package* in `node_modules`, so a glob pointing
+  at a repo file silently copies nothing and `tokens/` ships empty. That is why
+  the tokens are folded into `cssEntry` (`base.css`) instead — they reach
+  designs through the `styles.css` @import closure either way.
+- **The preview card template hardcodes `body{background:#fff}`** in an inline
+  `<style>` that comes *after* the stylesheet links. SplitIQ is dark-only, so
+  `base.css` sets `background`/`color` with `!important` to win that cascade.
+  Without it every component renders on white and `done`-style opacity fades
+  look broken. Do not remove the `!important`.
+- **`.d.ts` props cannot be auto-extracted.** The source is plain JSX with no
+  type annotations and no JSDoc `@param` types, so ts-morph emits
+  `[key: string]: unknown` for every component. All 11 prop contracts are
+  hand-written in `cfg.dtsPropsFor`, derived from the destructured params and
+  their real usage. **If you change a component's props, update `dtsPropsFor`**
+  — nothing will catch the drift for you.
+- `[DTS_REACT] @types/react not found` prints on every build. It is expected and
+  harmless here: installing it would not help, because there are no React
+  utility types to resolve. Do not add it to the repo just to silence this.
+- **`LogSessionForm` is deliberately excluded.** It imports `supabaseClient.js`,
+  which calls `createClient(import.meta.env.VITE_SUPABASE_URL, …)` at module
+  scope. In an IIFE bundle `import.meta.env` is undefined, so the client throws
+  at load and takes the whole bundle down. To include it later, shim the client
+  (e.g. a `cfg.provider` or a stub module via `cfg.extraEntries`) first.
+- `PACE_ZONES` is exported from `entry.jsx` so `PaceTrendChart` previews use the
+  real zone table rather than an inlined copy that would rot.
+
+## Known render warns
+
+- `[GRID_OVERFLOW]` on **LiveMetric** — fixed by `overrides.LiveMetric.cardMode
+  = "column"`. It cannot re-flag; no action needed.
+- **PaceTrendChart capture is stalled mid-animation.** `package-capture.mjs`
+  pins a fixed clock (`page.clock.setFixedTime`), which stops Recharts'
+  `react-smooth` line-draw animation partway, so the review sheet shows a
+  partial path with disconnected dots. The card itself is fine — verified by
+  rendering the same card under a live clock. There is no way to disable the
+  animation from the preview, because `PaceTrendChart` hardcodes `<Line>`
+  without `isAnimationActive` and the bundled Recharts' `Global` is not
+  reachable. **Expect this on every sync; it is not a regression.**
+
+## States that cannot render statically
+
+Recorded so nobody re-litigates them:
+
+- `LogEntry` and `WorkoutItem` are collapsed by `useState(false)`. The expanded
+  bodies — the erg metric grid, the strength exercise table, and the workout
+  note/fuel/meal detail — are click-gated and never appear in a card. They are
+  described in the `.md` docs instead.
+- `WorkoutTarget` is likewise collapsed; the duration / sRPE / notes body is
+  behind the caret.
+
+## Re-sync risks
+
+- **`dtsPropsFor` is hand-maintained and has no drift detection.** A prop
+  renamed or removed in a component leaves the uploaded contract silently wrong,
+  and the design agent codes against that contract. Diff the components against
+  the config when re-syncing.
+- **`entry.jsx` is hand-maintained too.** A new component in
+  `src/components/` will not sync until it is added there *and* to
+  `cfg.componentSrcMap` *and* given a `.design-sync/docs/<Name>.md` (or it lands
+  in the `general` group).
+- **`base.css` is generated but not automatically regenerated.** If `THEME`
+  gains or loses a colour and `gen-css.mjs` is not re-run, designs ship stale
+  tokens. Re-run it as step one of every sync.
+- **'DM Mono' is referenced but never served.** Several components set
+  `fontFamily: "'DM Mono', monospace"`, but neither the app nor this bundle
+  ships the face — `index.html` loads no webfont. Everything therefore renders
+  in the Courier/monospace fallback, in the app and in designs alike. This is
+  faithful to production, not a bug, but if SplitIQ ever adds DM Mono, wire it
+  here via `cfg.extraFonts` so designs keep matching.
+- **Toolchain assumptions:** the render check runs against **system Chrome**
+  (`DS_CHROMIUM_PATH=/c/Program Files/Google/Chrome/Application/chrome.exe`)
+  because no playwright browser is cached on this machine. `playwright` itself
+  resolves from `web/node_modules`. If the check fails to launch, either install
+  `npx playwright install chromium` or re-point `DS_CHROMIUM_PATH`.
+
+## Commands
+
+```sh
+cd web
+node .design-sync/gen-css.mjs                      # refresh tokens from THEME
+node .ds-sync/package-build.mjs   --config .design-sync/config.json --node-modules ./node_modules --entry ./.design-sync/entry.jsx --out ./ds-bundle
+DS_CHROMIUM_PATH="C:/Program Files/Google/Chrome/Application/chrome.exe" \
+  node .ds-sync/package-validate.mjs ./ds-bundle
+```

--- a/web/.design-sync/base.css
+++ b/web/.design-sync/base.css
@@ -1,0 +1,42 @@
+/* Generated from src/constants/theme.js by .design-sync/gen-css.mjs — do not hand-edit.
+   SplitIQ ships no stylesheet of its own: components carry inline styles and
+   index.html paints the ground before React mounts. This file is the design
+   system's token layer plus that ground, so every design built with SplitIQ
+   starts on the same dark surface the app uses. */
+:root {
+  --color-bg: #08080d;
+  --color-surface: #1a1a2e;
+  --color-raised: #2a2a48;
+  --color-field: #08080d;
+  --color-border: #4a4a68;
+  --color-text: #e8e8f0;
+  --color-muted: #7e7e9a;
+  --color-cyan: #00d4ff;
+  --color-green: #34d399;
+  --color-gold: #ffd700;
+  --color-orange: #ff6b35;
+  --color-red: #ff2d55;
+  --color-purple: #a78bfa;
+  --color-pink: #f472b6;
+  --color-teal: #2dd4bf;
+  --color-surfaceAlt: #1e1e30;
+  --color-neutral: #3a3a4a;
+  --color-textSubtle: #aaaacc;
+  --color-textFaint: #6c6c88;
+  --color-textDim: #5a5a74;
+  --color-divider: #3e3e5a;
+  --color-grey: #888888;
+  --color-white: #ffffff;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  /* !important: SplitIQ is a dark-only surface — index.html paints this ground
+     before React mounts, and preview-card templates default their body to
+     white, which would render every component on the wrong ground. */
+  background: var(--color-bg) !important;
+  color: var(--color-text) !important;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+}

--- a/web/.design-sync/config.json
+++ b/web/.design-sync/config.json
@@ -1,0 +1,59 @@
+{
+  "projectId": "8edb6124-729f-4d6c-9e32-6ba955e2a6b4",
+  "shape": "package",
+  "pkg": "splitiq",
+  "globalName": "SplitIQ",
+  "entry": ".design-sync/entry.jsx",
+  "srcDir": "src",
+  "cssEntry": ".design-sync/base.css",
+  "docsDir": ".design-sync/docs",
+  "componentSrcMap": {
+    "LogEntry": "src/components/LogEntry.jsx",
+    "WorkoutItem": "src/components/WorkoutItem.jsx",
+    "WorkoutTarget": "src/components/WorkoutTarget.jsx",
+    "LiveMetric": "src/components/LiveMetric.jsx",
+    "ErrorFallback": "src/components/ErrorFallback.jsx",
+    "ErgTooltip": "src/components/ErgTooltip.jsx",
+    "LoadTooltip": "src/components/LoadTooltip.jsx",
+    "StrengthTooltip": "src/components/StrengthTooltip.jsx",
+    "PaceTrendChart": "src/components/PaceTrendChart.jsx",
+    "PaceTooltip": "src/components/PaceTrendChart.jsx",
+    "BottomTabBar": "src/components/mobile/BottomTabBar.jsx"
+  },
+  "dtsPropsFor": {
+    "LogEntry": "/** The log row. `type` keys the colour + icon maps (C / ICON). */\nentry: {\n  /** e.g. \"Z2 Aerobic\" | \"Threshold\" | \"Upper Strength\" | \"Cycling\". */\n  type?: string;\n  label?: string;\n  /** Short display date, e.g. \"6/19\". */\n  date?: string;\n  duration?: string;\n  srpe?: number;\n  /** PR count — renders the 🏆 badge when set. */\n  prs?: number;\n  exercises?: Array<{ name?: string; weight?: string; volume?: string; e1rm?: string; pr?: boolean }>;\n  coachNote?: string;\n  /** \"planned\" switches the left rail to a dashed accent. */\n  status?: string;\n  /** Renders the erg metric grid instead of the exercise table. */\n  _isErg?: boolean;\n  distance_m?: number | null;\n  avg_watts?: number | null;\n  avg_hr?: number | null;\n};\n/** Fades the row to 50% opacity. */\ndone?: boolean;",
+    "WorkoutItem": "/** null renders the empty-day placeholder. */\nsession?: {\n  /** Drives the accent colour via workoutAccent(). */\n  label?: string;\n  done?: boolean;\n  /** e.g. \"AM\" | \"PM\". */\n  slot?: string;\n  note?: string;\n  fuel?: string;\n  meal?: { pre?: string; post?: string };\n} | null;\n/** Left day rail, e.g. { top: \"MON\", big: \"1\", bottom: \"wk4\" }. */\nrail?: { top?: string; big?: string; bottom?: string };\n/** Marks today — tints the row and prints \"● TODAY\". */\nhighlight?: boolean;\n/** @default true */\nshowRail?: boolean;",
+    "WorkoutTarget": "/** Falsy renders the \"NO PLANNED SESSION TODAY\" placeholder. */\nsession?: {\n  label?: string;\n  /** Minutes. */\n  duration?: number | string;\n  srpe?: number | string;\n  notes?: string;\n} | null;",
+    "LiveMetric": "/** Small uppercase tracked caption above the value. */\nlabel?: string;\n/** null or undefined prints \"--\". */\nvalue?: string | number | null;\n/** Optional unit caption below the value. */\nunit?: string;\n/** Value colour. @default THEME.cyan */\naccent?: string;\n/** @default \"normal\" */\nsize?: 'large' | 'normal' | 'small';\n/** Drops the tile to 35% opacity. */\ndimmed?: boolean;",
+    "ErrorFallback": "/** Wired to the TRY AGAIN button — Sentry's boundary reset. */\nresetError?: () => void;",
+    "ErgTooltip": "/** Supplied by Recharts — true while the tooltip is open. */\nactive?: boolean;\n/** Supplied by Recharts. The hovered datum is `payload[0].payload`. */\npayload?: Array<{ payload: Record<string, unknown>; stroke?: string; value?: unknown }>;\n/** Supplied by Recharts — the category-axis value for the hovered point. */\nlabel?: string | number;",
+    "LoadTooltip": "/** Supplied by Recharts — true while the tooltip is open. */\nactive?: boolean;\n/** Supplied by Recharts. The hovered datum is `payload[0].payload`. */\npayload?: Array<{ payload: Record<string, unknown>; stroke?: string; value?: unknown }>;\n/** Supplied by Recharts — the category-axis value for the hovered point. */\nlabel?: string | number;",
+    "StrengthTooltip": "/** Supplied by Recharts — true while the tooltip is open. */\nactive?: boolean;\n/** Supplied by Recharts. The hovered datum is `payload[0].payload`. */\npayload?: Array<{ payload: Record<string, unknown>; stroke?: string; value?: unknown }>;\n/** Supplied by Recharts — the category-axis value for the hovered point. */\nlabel?: string | number;",
+    "PaceTooltip": "/** Supplied by Recharts — true while the tooltip is open. */\nactive?: boolean;\n/** Supplied by Recharts. The hovered datum is `payload[0].payload`. */\npayload?: Array<{ payload: Record<string, unknown>; stroke?: string; value?: unknown }>;\n/** Supplied by Recharts — the category-axis value for the hovered point. */\nlabel?: string | number;",
+    "PaceTrendChart": "/** Enriched sessions, newest first — reversed internally; entries without pace_500m are dropped. */\ndata?: Array<{\n  /** Seconds per 500m. */\n  pace_500m?: number | null;\n  pace_500m_str?: string;\n  avg_watts?: number | null;\n  zone?: string;\n  /** Renders a filled dot instead of a hollow ring. */\n  hardPush?: boolean;\n  date_display?: string;\n}>;\n/** Zone bands drawn behind the line — the app passes PACE_ZONES. */\npaceZones?: Array<{ zone?: string; paceFloor?: number; paceCeil?: number; color?: string }>;\n/** @default 180 */\nheight?: number;\n/** @default true */\nshowBands?: boolean;",
+    "BottomTabBar": "/** Active tab id: 'analytics' | 'erg' | 'log' | 'strength' | 'recovery' | 'coach'. */\nactiveTab?: string;\n/** Receives the tab id that was pressed. */\nonTabChange?: (tabId: string) => void;"
+  },
+  "overrides": {
+    "ErrorFallback": {
+      "cardMode": "single",
+      "viewport": "420x520"
+    },
+    "BottomTabBar": {
+      "cardMode": "single",
+      "viewport": "420x180"
+    },
+    "PaceTrendChart": {
+      "cardMode": "column"
+    },
+    "LogEntry": {
+      "cardMode": "column"
+    },
+    "WorkoutItem": {
+      "cardMode": "column"
+    },
+    "LiveMetric": {
+      "cardMode": "column"
+    }
+  },
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/web/.design-sync/conventions.md
+++ b/web/.design-sync/conventions.md
@@ -1,0 +1,105 @@
+## How SplitIQ is built
+
+SplitIQ is the training dashboard for a single rower — erg, strength and bike.
+It is a **dark-only, data-dense, monospace-numeral** surface. Designs that look
+like a light-mode SaaS app are wrong for it.
+
+### Setup: no provider, one stylesheet
+
+There is **no ThemeProvider, context, or router** to wrap anything in. Every
+component is self-contained and renders correctly on its own. The only setup is
+linking `styles.css` — that is what paints the dark ground and defines the
+tokens. Without it components still render, but on a white page, which is wrong.
+
+### The styling idiom: inline styles + CSS variables
+
+**This system has no CSS classes.** Every component styles itself with inline
+`style` objects read from a `THEME` object. Do not write `className` on a
+SplitIQ component and do not invent class names like `.card` or `.btn-primary` —
+nothing will resolve them. The components also do **not** accept `className`,
+`style`, `sx`, or any styling escape hatch: their appearance is controlled only
+by the semantic props in each `<Name>.d.ts` (`accent`, `size`, `dimmed`,
+`highlight`, `done`, …).
+
+For your **own** layout glue around them, use the CSS custom properties from
+`styles.css`, or import the same values as a JS object:
+
+```js
+const { THEME } = window.SplitIQ;   // THEME.cyan === '#00d4ff'
+```
+
+Token names are identical in both forms (`--color-<key>` / `THEME.<key>`), and
+the keys keep their camelCase:
+
+| Group | Tokens |
+|---|---|
+| Ground | `bg` `surface` `surfaceAlt` `raised` `field` |
+| Lines | `border` `divider` `neutral` |
+| Text | `text` `textSubtle` `textFaint` `textDim` `muted` `grey` `white` |
+| Accents | `cyan` `green` `gold` `orange` `red` `purple` `pink` `teal` |
+
+Accents carry meaning — do not pick them decoratively. `cyan` is erg/aerobic and
+the primary accent, `green` is done/healthy/UT1, `gold` is threshold or a target
+prompt, `orange` is elevated load, `red` is error or redline, `purple` is upper
+strength, `teal` is cycling, `grey`/`neutral` is rest.
+
+### Two more exports you will want
+
+- `C` and `ICON` — session-type maps keyed by the same nine strings
+  (`'Z2 Aerobic'`, `'Threshold'`, `'VO₂ Intervals'`, `'Sharpener'`, `'Rest'`,
+  `'Upper Strength'`, `'Lower Strength'`, `'Combined'`, `'Cycling'`). Use these
+  keys as `entry.type` so `LogEntry` colours itself correctly.
+- `PACE_ZONES` — the real training-zone table `PaceTrendChart` draws bands from.
+
+### Where the truth is
+
+Read the real files before styling — they beat this summary:
+
+- `_ds/<folder>/styles.css` and the `_ds_bundle.css` it imports — the tokens and
+  the page ground, verbatim.
+- `components/<group>/<Name>/<Name>.prompt.md` — what each component is for,
+  which props change its appearance, and a worked example.
+- `components/<group>/<Name>/<Name>.d.ts` — the exact prop contract.
+
+Groups: `session` (LogEntry, WorkoutItem, WorkoutTarget), `metrics`
+(LiveMetric), `charts` (PaceTrendChart), `tooltips` (ErgTooltip, LoadTooltip,
+StrengthTooltip, PaceTooltip), `feedback` (ErrorFallback), `mobile`
+(BottomTabBar).
+
+### A typical screen
+
+Library components for the data, your own inline styles in the same idiom for
+the frame around them:
+
+```jsx
+const { LiveMetric, LogEntry, THEME } = window.SplitIQ;
+
+<div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 16 }}>
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      background: THEME.surface,
+      border: `1px solid ${THEME.border}`,
+      borderRadius: 10,
+      padding: '22px 26px',
+    }}
+  >
+    <LiveMetric label="SPLIT" value="2:04.1" unit="/500M" size="large" />
+    <LiveMetric label="WATTS" value={151} unit="W" />
+    <LiveMetric label="HR" value={139} unit="BPM" accent={THEME.green} />
+  </div>
+
+  <div style={{ fontSize: 9, letterSpacing: 2, color: THEME.muted }}>THIS WEEK</div>
+  <LogEntry
+    entry={{
+      type: 'Z2 Aerobic', _isErg: true, label: 'UT2 60min', date: '6/19',
+      duration: '60min', srpe: 5, distance_m: 13850, avg_watts: 138, avg_hr: 132,
+    }}
+  />
+</div>
+```
+
+Note the house details: tiny uppercase tracked section labels (`fontSize: 9`,
+`letterSpacing: 2`, `color: muted`), 6–10px radii, 1px `border` hairlines on
+`surface`/`raised` panels, and numbers in the monospace face.

--- a/web/.design-sync/docs/BottomTabBar.md
+++ b/web/.design-sync/docs/BottomTabBar.md
@@ -1,0 +1,18 @@
+---
+category: Navigation
+---
+
+# BottomTabBar
+
+The mobile bottom navigation. Six fixed tabs — Analytics, Live, Log, Strength,
+Recovery, Coach — each an emoji glyph over a small tracked caption. The tab list
+is internal to the component; it is not configurable by props.
+
+The active tab is bolded and switched to `THEME.green`; inactive tabs stay muted.
+The bar is `position: fixed` to the bottom of the viewport at `z-index: 100`,
+56px tall, and pads itself with `env(safe-area-inset-bottom)` for notched
+devices — so page content underneath needs its own bottom padding to clear it.
+
+```jsx
+<BottomTabBar activeTab="log" onTabChange={setTab} />
+```

--- a/web/.design-sync/docs/ErgTooltip.md
+++ b/web/.design-sync/docs/ErgTooltip.md
@@ -1,0 +1,17 @@
+---
+category: Tooltips
+---
+
+# ErgTooltip
+
+Recharts tooltip for the erg watts chart. Pass it as the `content` of a Recharts
+`<Tooltip>` — Recharts supplies `active` and `payload`, and the component returns
+`null` whenever the tooltip is inactive or the payload is empty.
+
+It reads `payload[0].payload` and prints the date and distance as the eyebrow,
+the average watts in cyan as the headline, and the 500m pace beneath, tagged
+either `hard push` or `Z2`.
+
+```jsx
+<Tooltip content={<ErgTooltip />} />
+```

--- a/web/.design-sync/docs/ErrorFallback.md
+++ b/web/.design-sync/docs/ErrorFallback.md
@@ -1,0 +1,17 @@
+---
+category: Feedback
+---
+
+# ErrorFallback
+
+The full-screen crash screen rendered by the Sentry error boundary when a render
+throws. Deliberately dependency-free and self-contained so it can never itself
+throw — it imports nothing but the theme.
+
+Fills the viewport (`min-height: 100vh`) on the app background, centred: a red
+`SOMETHING WENT WRONG` headline, a short reassurance that the error was reported,
+and a green `TRY AGAIN` button wired to `resetError`. Carries `role="alert"`.
+
+```jsx
+<ErrorFallback resetError={() => window.location.reload()} />
+```

--- a/web/.design-sync/docs/LiveMetric.md
+++ b/web/.design-sync/docs/LiveMetric.md
@@ -1,0 +1,21 @@
+---
+category: Metrics
+---
+
+# LiveMetric
+
+The readout primitive for a single number — used across the live erg screen and
+the summary tiles. Renders a small uppercase tracked label, the value in the
+monospace face, and an optional unit caption.
+
+Three sizes are built in: `large` (52px value, the hero number), `normal` (34px,
+the default) and `small` (22px, for supporting stats). `accent` colours the value
+and defaults to `THEME.cyan` — pass `THEME.green`, `THEME.gold`, `THEME.orange`
+or `THEME.red` to carry status. `dimmed` drops the whole tile to 35% opacity for
+metrics that aren't live yet; a null or undefined `value` prints `--`.
+
+```jsx
+<LiveMetric label="SPLIT" value="1:58.4" unit="/500M" size="large" />
+<LiveMetric label="WATTS" value={214} unit="W" accent={THEME.gold} />
+<LiveMetric label="HR" value={null} unit="BPM" size="small" dimmed />
+```

--- a/web/.design-sync/docs/LoadTooltip.md
+++ b/web/.design-sync/docs/LoadTooltip.md
@@ -1,0 +1,17 @@
+---
+category: Tooltips
+---
+
+# LoadTooltip
+
+Recharts tooltip for the training-load chart — the CTL / ATL / TSB stack.
+
+CTL is labelled cyan, ATL orange, and **TSB is colour-coded by value**: green
+above +10, gold down to -10, orange down to -30, red below that. TSB is printed
+with an explicit `+` when positive. A TSS row is appended below a divider only
+when that day actually carried load (`tss > 0`), and an optional `note` is
+appended to the date eyebrow.
+
+```jsx
+<Tooltip content={<LoadTooltip />} />
+```

--- a/web/.design-sync/docs/LogEntry.md
+++ b/web/.design-sync/docs/LogEntry.md
@@ -1,0 +1,42 @@
+---
+category: Session
+---
+
+# LogEntry
+
+One row in the training log. Collapsed it shows the modality icon, the session
+label, date, duration and sRPE; clicking the row expands it to the detail body.
+
+The whole appearance is driven by `entry.type`, which is looked up in the `C`
+(colour) and `ICON` maps from the design system — `Z2 Aerobic`, `Threshold`,
+`VO₂ Intervals`, `Sharpener`, `Rest`, `Upper Strength`, `Lower Strength`,
+`Combined`, `Cycling`. An unknown type falls back to grey with a `•` icon.
+
+Two detail bodies exist and the entry picks one:
+
+- **Erg** (`entry._isErg`) — expands to a metric grid of distance, average watts
+  and average heart rate. A planned erg row carries null metrics, so it shows
+  the prescription (label + `coachNote`) instead of the grid.
+- **Strength** — expands to an exercise table (name, weight, volume, e1RM), with
+  a 🏆 badge in the header when `entry.prs` is set.
+
+`entry.status === 'planned'` switches the left accent rail from solid to dashed.
+`done` fades the whole row to 50% opacity.
+
+```jsx
+<LogEntry
+  entry={{
+    type: 'Z2 Aerobic',
+    _isErg: true,
+    label: 'UT2 60min',
+    date: '6/19',
+    duration: '60min',
+    srpe: 6,
+    distance_m: 12000,
+    avg_watts: 150,
+    avg_hr: 140,
+    coachNote: 'steady aerobic',
+  }}
+  done
+/>
+```

--- a/web/.design-sync/docs/PaceTooltip.md
+++ b/web/.design-sync/docs/PaceTooltip.md
@@ -1,0 +1,16 @@
+---
+category: Tooltips
+---
+
+# PaceTooltip
+
+Recharts tooltip for `PaceTrendChart`. Prints the display date, the formatted
+500m split as the cyan headline, and a caption line with average watts and the
+training zone.
+
+It is already wired as the chart's tooltip content, so you only need it directly
+when building a chart of your own over the same enriched-session shape.
+
+```jsx
+<Tooltip content={<PaceTooltip />} />
+```

--- a/web/.design-sync/docs/PaceTrendChart.md
+++ b/web/.design-sync/docs/PaceTrendChart.md
@@ -1,0 +1,28 @@
+---
+category: Charts
+---
+
+# PaceTrendChart
+
+The erg pace trend — a Recharts `ComposedChart` plotting `pace_500m` over time
+with the training zones drawn behind it as translucent reference bands.
+
+The Y axis is **inverted** (faster pace is higher on the chart) and its domain is
+computed from the data plus the zone edges, so the bands and the line always
+share a frame. Points are drawn by `CustomDot`: a hollow cyan ring normally, a
+filled cyan disc when `hardPush` is set on that session. Hovering a point opens
+`PaceTooltip`.
+
+`data` is a list of enriched sessions ordered newest-first — the component
+reverses it internally and drops any entry without `pace_500m`. `paceZones` comes
+from `PACE_ZONES` in the app's training config; pass `showBands={false}` to plot
+the bare line. `height` defaults to 180 and the width always fills the parent, so
+give it a sized container.
+
+```jsx
+<PaceTrendChart
+  data={sessions}
+  paceZones={PACE_ZONES}
+  height={220}
+/>
+```

--- a/web/.design-sync/docs/StrengthTooltip.md
+++ b/web/.design-sync/docs/StrengthTooltip.md
@@ -1,0 +1,16 @@
+---
+category: Tooltips
+---
+
+# StrengthTooltip
+
+Recharts tooltip for the strength e1RM chart. Prints the date as the eyebrow and
+the estimated one-rep max in kg as the headline.
+
+Unlike the other tooltips it takes its headline colour from `payload[0].stroke`,
+so the number matches the colour of the series being hovered — which is what
+makes it readable on a multi-lift chart.
+
+```jsx
+<Tooltip content={<StrengthTooltip />} />
+```

--- a/web/.design-sync/docs/WorkoutItem.md
+++ b/web/.design-sync/docs/WorkoutItem.md
@@ -1,0 +1,33 @@
+---
+category: Session
+---
+
+# WorkoutItem
+
+A single day in the programme calendar. The optional left `rail` carries the day
+marker (`top` / `big` / `bottom` — e.g. `MON` / `1` / `wk4`), and the body shows
+the session label with its slot and completion tick.
+
+The accent colour is derived from the session label text by `workoutAccent`, so
+"Upper 1" reads purple, "Lower 2" green, threshold work gold, intervals orange,
+and anything restorative neutral grey. Erg aerobic is the cyan default.
+
+The row is only expandable when the session actually has detail (`note`, `fuel`
+or `meal`); without it the cursor stays default and clicking does nothing. Pass
+`highlight` to mark today — it tints the row and prints a `● TODAY` marker.
+`session={null}` renders the empty-day placeholder.
+
+```jsx
+<WorkoutItem
+  session={{
+    label: 'Upper 1',
+    done: true,
+    slot: 'AM',
+    note: 'Bench + pull focus',
+    fuel: 'Oats + whey pre',
+    meal: { pre: 'Banana', post: 'Rice + chicken' },
+  }}
+  rail={{ top: 'MON', big: '1', bottom: 'wk4' }}
+  highlight
+/>
+```

--- a/web/.design-sync/docs/WorkoutTarget.md
+++ b/web/.design-sync/docs/WorkoutTarget.md
@@ -1,0 +1,23 @@
+---
+category: Session
+---
+
+# WorkoutTarget
+
+The collapsed prescription banner for today's planned session — a gold `TARGET`
+eyebrow, the session label, and a disclosure caret. Expanding it reveals the
+prescribed duration, the sRPE target, and the coach note.
+
+With no session it degrades to the muted `NO PLANNED SESSION TODAY` line rather
+than rendering nothing, so the slot in the layout stays stable.
+
+```jsx
+<WorkoutTarget
+  session={{
+    label: 'UT1 45min',
+    duration: 45,
+    srpe: 5,
+    notes: 'Hold 150-160W. Rate 20-22. Stop if the hamstring talks.',
+  }}
+/>
+```

--- a/web/.design-sync/entry.jsx
+++ b/web/.design-sync/entry.jsx
@@ -1,0 +1,20 @@
+// design-sync entry: the named public surface of SplitIQ's shared UI layer.
+// The app's components are default exports; this barrel gives them stable named
+// exports so the design bundle can expose them on window.SplitIQ.
+export { default as LogEntry } from '../src/components/LogEntry.jsx';
+export { default as WorkoutItem } from '../src/components/WorkoutItem.jsx';
+export { default as WorkoutTarget } from '../src/components/WorkoutTarget.jsx';
+export { default as LiveMetric } from '../src/components/LiveMetric.jsx';
+export { default as ErrorFallback } from '../src/components/ErrorFallback.jsx';
+export { default as ErgTooltip } from '../src/components/ErgTooltip.jsx';
+export { default as LoadTooltip } from '../src/components/LoadTooltip.jsx';
+export { default as StrengthTooltip } from '../src/components/StrengthTooltip.jsx';
+export {
+  default as PaceTrendChart,
+  PaceTooltip,
+} from '../src/components/PaceTrendChart.jsx';
+export { default as BottomTabBar } from '../src/components/mobile/BottomTabBar.jsx';
+
+export { THEME } from '../src/constants/theme.js';
+export { C, ICON } from '../src/constants/ui.js';
+export { PACE_ZONES } from '../src/constants/trainingConfig.js';

--- a/web/.design-sync/gen-css.mjs
+++ b/web/.design-sync/gen-css.mjs
@@ -1,0 +1,30 @@
+// Regenerates .design-sync/base.css from the app's own THEME. Re-run whenever
+// src/constants/theme.js changes:  node .design-sync/gen-css.mjs
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { THEME } from '../src/constants/theme.js';
+import { cssVars } from '../src/utils/themeCss.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = `/* Generated from src/constants/theme.js by .design-sync/gen-css.mjs — do not hand-edit.
+   SplitIQ ships no stylesheet of its own: components carry inline styles and
+   index.html paints the ground before React mounts. This file is the design
+   system's token layer plus that ground, so every design built with SplitIQ
+   starts on the same dark surface the app uses. */
+${cssVars(THEME)}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  /* !important: SplitIQ is a dark-only surface — index.html paints this ground
+     before React mounts, and preview-card templates default their body to
+     white, which would render every component on the wrong ground. */
+  background: var(--color-bg) !important;
+  color: var(--color-text) !important;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+}
+`;
+writeFileSync(join(here, 'base.css'), css);
+console.error(`  base.css: ${Object.keys(THEME).length} tokens from src/constants/theme.js`);

--- a/web/.design-sync/previews/BottomTabBar.tsx
+++ b/web/.design-sync/previews/BottomTabBar.tsx
@@ -1,0 +1,35 @@
+import { BottomTabBar, THEME } from 'splitiq';
+
+// BottomTabBar is position:fixed. The preview card's cell already establishes a
+// containing block (transform), so the bar pins to the cell rather than the
+// page — which is how it reads inside a phone frame in the real app.
+const Phone = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      position: 'relative',
+      transform: 'translateZ(0)',
+      height: 150,
+      background: THEME.bg,
+      border: `1px solid ${THEME.border}`,
+      borderRadius: 10,
+      overflow: 'hidden',
+    }}
+  >
+    <div style={{ padding: '14px 16px', fontSize: 11, color: THEME.muted, letterSpacing: 1 }}>
+      APP CONTENT
+    </div>
+    {children}
+  </div>
+);
+
+export const LogTabActive = () => (
+  <Phone>
+    <BottomTabBar activeTab="log" onTabChange={() => {}} />
+  </Phone>
+);
+
+export const LiveTabActive = () => (
+  <Phone>
+    <BottomTabBar activeTab="erg" onTabChange={() => {}} />
+  </Phone>
+);

--- a/web/.design-sync/previews/ErgTooltip.tsx
+++ b/web/.design-sync/previews/ErgTooltip.tsx
@@ -1,0 +1,26 @@
+import { ErgTooltip } from 'splitiq';
+
+// Rendered directly with the payload shape Recharts hands its tooltip content,
+// which is how the app's own tests exercise it — a hovering chart can't be
+// captured statically.
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ padding: 20, display: 'flex', gap: 16, flexWrap: 'wrap' }}>{children}</div>
+);
+
+export const SteadyStateSession = () => (
+  <Frame>
+    <ErgTooltip
+      active
+      payload={[{ payload: { date: '7/04', dist: '13.8km', watts: 140, pace: 136.1, hardPush: false } }]}
+    />
+  </Frame>
+);
+
+export const HardPushSession = () => (
+  <Frame>
+    <ErgTooltip
+      active
+      payload={[{ payload: { date: '7/09', dist: '8.0km', watts: 172, pace: 124.8, hardPush: true } }]}
+    />
+  </Frame>
+);

--- a/web/.design-sync/previews/ErrorFallback.tsx
+++ b/web/.design-sync/previews/ErrorFallback.tsx
@@ -1,0 +1,3 @@
+import { ErrorFallback } from 'splitiq';
+
+export const CrashScreen = () => <ErrorFallback resetError={() => {}} />;

--- a/web/.design-sync/previews/LiveMetric.tsx
+++ b/web/.design-sync/previews/LiveMetric.tsx
@@ -1,0 +1,56 @@
+import { LiveMetric, THEME } from 'splitiq';
+
+const Row = ({ children, gap = 28 }: { children: React.ReactNode; gap?: number }) => (
+  <div style={{ display: 'flex', alignItems: 'flex-end', gap, padding: 20 }}>
+    {children}
+  </div>
+);
+
+export const Sizes = () => (
+  <Row>
+    <LiveMetric label="SPLIT" value="1:58.4" unit="/500M" size="large" />
+    <LiveMetric label="WATTS" value={214} unit="W" size="normal" />
+    <LiveMetric label="RATE" value={22} unit="SPM" size="small" />
+  </Row>
+);
+
+export const StatusAccents = () => (
+  <Row>
+    <LiveMetric label="UT2" value={128} unit="W" accent={THEME.cyan} />
+    <LiveMetric label="UT1" value={154} unit="W" accent={THEME.green} />
+    <LiveMetric label="AT" value={186} unit="W" accent={THEME.gold} />
+    <LiveMetric label="OVER CP" value={231} unit="W" accent={THEME.orange} />
+    <LiveMetric label="REDLINE" value={268} unit="W" accent={THEME.red} />
+  </Row>
+);
+
+export const LiveErgReadout = () => (
+  <div style={{ padding: 20 }}>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-end',
+        justifyContent: 'space-between',
+        gap: 24,
+        background: THEME.surface,
+        border: `1px solid ${THEME.border}`,
+        borderRadius: 10,
+        padding: '22px 26px',
+      }}
+    >
+      <LiveMetric label="SPLIT" value="2:04.1" unit="/500M" size="large" />
+      <LiveMetric label="WATTS" value={151} unit="W" />
+      <LiveMetric label="HR" value={139} unit="BPM" accent={THEME.green} />
+      <LiveMetric label="RATE" value={20} unit="SPM" size="small" />
+      <LiveMetric label="DIST" value="8,240" unit="M" size="small" />
+    </div>
+  </div>
+);
+
+export const AwaitingSignal = () => (
+  <Row>
+    <LiveMetric label="SPLIT" value={null} unit="/500M" size="large" dimmed />
+    <LiveMetric label="WATTS" value={null} unit="W" dimmed />
+    <LiveMetric label="HR" value={null} unit="BPM" size="small" dimmed />
+  </Row>
+);

--- a/web/.design-sync/previews/LoadTooltip.tsx
+++ b/web/.design-sync/previews/LoadTooltip.tsx
@@ -1,0 +1,30 @@
+import { LoadTooltip } from 'splitiq';
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ padding: 20, display: 'flex', gap: 16, flexWrap: 'wrap' }}>{children}</div>
+);
+
+// TSB is colour-coded by value, so the four bands are the variant axis.
+export const TsbBands = () => (
+  <Frame>
+    <LoadTooltip active payload={[{ payload: { date: '7/02', ctl: 41, atl: 26, tsb: 15, tss: 0 } }]} />
+    <LoadTooltip active payload={[{ payload: { date: '7/05', ctl: 43, atl: 47, tsb: -4, tss: 78 } }]} />
+    <LoadTooltip active payload={[{ payload: { date: '7/08', ctl: 45, atl: 65, tsb: -20, tss: 104 } }]} />
+    <LoadTooltip active payload={[{ payload: { date: '7/10', ctl: 46, atl: 84, tsb: -38, tss: 131 } }]} />
+  </Frame>
+);
+
+export const WithDayNote = () => (
+  <Frame>
+    <LoadTooltip
+      active
+      payload={[{ payload: { date: '7/11', note: 'FIFO deload', ctl: 45, atl: 31, tsb: 14, tss: 42 } }]}
+    />
+  </Frame>
+);
+
+export const RestDay = () => (
+  <Frame>
+    <LoadTooltip active payload={[{ payload: { date: '7/12', ctl: 44, atl: 27, tsb: 17, tss: 0 } }]} />
+  </Frame>
+);

--- a/web/.design-sync/previews/LogEntry.tsx
+++ b/web/.design-sync/previews/LogEntry.tsx
@@ -1,0 +1,87 @@
+import { LogEntry } from 'splitiq';
+
+const Stack = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: 20, maxWidth: 620 }}>
+    {children}
+  </div>
+);
+
+export const ErgSession = () => (
+  <Stack>
+    <LogEntry
+      entry={{
+        type: 'Z2 Aerobic',
+        _isErg: true,
+        label: 'UT2 60min steady',
+        date: '6/19',
+        duration: '60min',
+        srpe: 5,
+        distance_m: 13850,
+        avg_watts: 138,
+        avg_hr: 132,
+        coachNote: 'Held 20spm throughout. Hamstring quiet.',
+      }}
+    />
+  </Stack>
+);
+
+export const StrengthSession = () => (
+  <Stack>
+    <LogEntry
+      entry={{
+        type: 'Upper Strength',
+        label: 'Upper 1',
+        date: '6/18',
+        duration: '48min',
+        srpe: 7,
+        prs: 2,
+        exercises: [
+          { name: 'Bench Press', weight: '80kg', volume: '2400', e1rm: '95', pr: true },
+          { name: 'Chest-Supported Row', weight: '60kg', volume: '2160', e1rm: '74' },
+          { name: 'Overhead Press', weight: '45kg', volume: '1080', e1rm: '55', pr: true },
+        ],
+      }}
+    />
+  </Stack>
+);
+
+export const PlannedSession = () => (
+  <Stack>
+    <LogEntry
+      entry={{
+        type: 'Z2 Aerobic',
+        _isErg: true,
+        status: 'planned',
+        label: 'UT1 45min @ 150-160W',
+        date: '6/21',
+        duration: '45min',
+        distance_m: null,
+        avg_watts: null,
+        avg_hr: null,
+        coachNote: 'Rate 20-22. Back off if TSB drops below -20.',
+      }}
+    />
+  </Stack>
+);
+
+export const SessionTypes = () => (
+  <Stack>
+    <LogEntry entry={{ type: 'Z2 Aerobic', _isErg: true, label: 'UT2 60min', date: '6/19', duration: '60min', srpe: 5, distance_m: 13850, avg_watts: 138, avg_hr: 132 }} />
+    <LogEntry entry={{ type: 'Lower Strength', label: 'Lower 2 - quad unilateral', date: '6/17', duration: '52min', srpe: 7 }} />
+    <LogEntry entry={{ type: 'Cycling', label: 'Z2 spin 40min', date: '6/16', duration: '40min', srpe: 4 }} />
+    <LogEntry entry={{ type: 'Rest', label: 'Rest day', date: '6/15' }} />
+  </Stack>
+);
+
+export const CompletedAndFaded = () => (
+  <Stack>
+    <LogEntry
+      entry={{ type: 'Upper Strength', label: 'Upper 2', date: '6/14', duration: '45min', srpe: 6, prs: 1 }}
+      done
+    />
+    <LogEntry
+      entry={{ type: 'Z2 Aerobic', _isErg: true, label: 'UT2 50min', date: '6/13', duration: '50min', srpe: 5, distance_m: 11400, avg_watts: 134, avg_hr: 128 }}
+      done
+    />
+  </Stack>
+);

--- a/web/.design-sync/previews/PaceTooltip.tsx
+++ b/web/.design-sync/previews/PaceTooltip.tsx
@@ -1,0 +1,19 @@
+import { PaceTooltip } from 'splitiq';
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ padding: 20, display: 'flex', gap: 16, flexWrap: 'wrap' }}>{children}</div>
+);
+
+export const ZoneSessions = () => (
+  <Frame>
+    <PaceTooltip active payload={[{ payload: { date_display: '6/19', pace_500m_str: '2:21.2', avg_watts: 128, zone: 'UT2' } }]} />
+    <PaceTooltip active payload={[{ payload: { date_display: '7/06', pace_500m_str: '2:12.4', avg_watts: 151, zone: 'UT1' } }]} />
+    <PaceTooltip active payload={[{ payload: { date_display: '7/09', pace_500m_str: '2:04.8', avg_watts: 172, zone: 'TR' } }]} />
+  </Frame>
+);
+
+export const MissingWatts = () => (
+  <Frame>
+    <PaceTooltip active payload={[{ payload: { date_display: '5/28', pace_500m_str: '2:18.6', avg_watts: null } }]} />
+  </Frame>
+);

--- a/web/.design-sync/previews/PaceTrendChart.tsx
+++ b/web/.design-sync/previews/PaceTrendChart.tsx
@@ -1,0 +1,55 @@
+import { PaceTrendChart, PACE_ZONES, THEME } from 'splitiq';
+
+// Newest-first, as the app supplies it — the component reverses internally.
+const SESSIONS = [
+  { date_display: '7/09', pace_500m: 124.8, pace_500m_str: '2:04.8', avg_watts: 172, zone: 'TR', hardPush: true },
+  { date_display: '7/06', pace_500m: 132.4, pace_500m_str: '2:12.4', avg_watts: 151, zone: 'UT1' },
+  { date_display: '7/04', pace_500m: 136.1, pace_500m_str: '2:16.1', avg_watts: 140, zone: 'UT2' },
+  { date_display: '7/01', pace_500m: 134.7, pace_500m_str: '2:14.7', avg_watts: 144, zone: 'UT1' },
+  { date_display: '6/28', pace_500m: 129.2, pace_500m_str: '2:09.2', avg_watts: 158, zone: 'AT', hardPush: true },
+  { date_display: '6/25', pace_500m: 137.9, pace_500m_str: '2:17.9', avg_watts: 136, zone: 'UT2' },
+  { date_display: '6/22', pace_500m: 139.5, pace_500m_str: '2:19.5', avg_watts: 132, zone: 'UT2' },
+  { date_display: '6/19', pace_500m: 141.2, pace_500m_str: '2:21.2', avg_watts: 128, zone: 'UT2' },
+];
+
+const Panel = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <div style={{ padding: 20 }}>
+    <div
+      style={{
+        background: THEME.surface,
+        border: `1px solid ${THEME.border}`,
+        borderRadius: 10,
+        padding: '16px 14px 10px',
+      }}
+    >
+      <div style={{ fontSize: 9, letterSpacing: 2, color: THEME.muted, padding: '0 4px 10px' }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  </div>
+);
+
+export const WithZoneBands = () => (
+  <Panel title="500M PACE TREND">
+    <PaceTrendChart data={SESSIONS} paceZones={PACE_ZONES} height={200} />
+  </Panel>
+);
+
+export const LineOnly = () => (
+  <Panel title="500M PACE TREND — NO BANDS">
+    <PaceTrendChart data={SESSIONS} paceZones={PACE_ZONES} height={200} showBands={false} />
+  </Panel>
+);
+
+export const Compact = () => (
+  <Panel title="LAST 4 SESSIONS">
+    <PaceTrendChart data={SESSIONS.slice(0, 4)} paceZones={PACE_ZONES} height={140} />
+  </Panel>
+);
+
+export const NoData = () => (
+  <Panel title="500M PACE TREND — NO SESSIONS YET">
+    <PaceTrendChart data={[]} paceZones={PACE_ZONES} height={140} />
+  </Panel>
+);

--- a/web/.design-sync/previews/StrengthTooltip.tsx
+++ b/web/.design-sync/previews/StrengthTooltip.tsx
@@ -1,0 +1,21 @@
+import { StrengthTooltip, THEME } from 'splitiq';
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ padding: 20, display: 'flex', gap: 16, flexWrap: 'wrap' }}>{children}</div>
+);
+
+// The headline colour comes from payload[0].stroke, so it matches whichever
+// lift series is being hovered on a multi-lift chart.
+export const PerLiftSeriesColour = () => (
+  <Frame>
+    <StrengthTooltip active payload={[{ stroke: THEME.purple, payload: { date: '7/08', e1rm: 95 } }]} />
+    <StrengthTooltip active payload={[{ stroke: THEME.green, payload: { date: '7/08', e1rm: 142 } }]} />
+    <StrengthTooltip active payload={[{ stroke: THEME.cyan, payload: { date: '7/08', e1rm: 74 } }]} />
+  </Frame>
+);
+
+export const SingleLift = () => (
+  <Frame>
+    <StrengthTooltip active payload={[{ stroke: THEME.purple, payload: { date: '7/15', e1rm: 97.5 } }]} />
+  </Frame>
+);

--- a/web/.design-sync/previews/WorkoutItem.tsx
+++ b/web/.design-sync/previews/WorkoutItem.tsx
@@ -1,0 +1,65 @@
+import { WorkoutItem } from 'splitiq';
+
+const Stack = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: 20, maxWidth: 620 }}>
+    {children}
+  </div>
+);
+
+export const ProgrammeWeek = () => (
+  <Stack>
+    <WorkoutItem
+      session={{ label: 'Upper 1', done: true, slot: 'AM', note: 'Bench + pull focus' }}
+      rail={{ top: 'MON', big: '1', bottom: 'wk4' }}
+    />
+    <WorkoutItem
+      session={{ label: 'UT2 60min', done: true, slot: 'PM' }}
+      rail={{ top: 'TUE', big: '2', bottom: 'wk4' }}
+    />
+    <WorkoutItem
+      session={{ label: 'Lower 1 - RDL led', slot: 'AM', note: 'RDL 4x6 @ RPE 7. Stop at any hamstring signal.' }}
+      rail={{ top: 'WED', big: '3', bottom: 'wk4' }}
+      highlight
+    />
+    <WorkoutItem
+      session={{ label: 'Z2 spin 40min', slot: 'PM' }}
+      rail={{ top: 'THU', big: '4', bottom: 'wk4' }}
+    />
+    <WorkoutItem session={null} rail={{ top: 'FRI', big: '5', bottom: 'wk4' }} />
+  </Stack>
+);
+
+export const TodayWithDetail = () => (
+  <Stack>
+    <WorkoutItem
+      session={{
+        label: 'Lower 2 - quad unilateral',
+        slot: 'AM',
+        note: 'Split squat 3x8 each side, leg press back-off.',
+        fuel: 'Oats + whey pre',
+        meal: { pre: 'Banana', post: 'Rice + chicken' },
+      }}
+      rail={{ top: 'SAT', big: '6', bottom: 'wk4' }}
+      highlight
+    />
+  </Stack>
+);
+
+export const AccentByLabel = () => (
+  <Stack>
+    <WorkoutItem session={{ label: 'Upper 1' }} rail={{ top: 'MON', big: '1' }} />
+    <WorkoutItem session={{ label: 'Lower 1' }} rail={{ top: 'TUE', big: '2' }} />
+    <WorkoutItem session={{ label: 'Rate ladder 8x500m' }} rail={{ top: 'WED', big: '3' }} />
+    <WorkoutItem session={{ label: 'VO2 intervals 5x4min' }} rail={{ top: 'THU', big: '4' }} />
+    <WorkoutItem session={{ label: 'UT2 60min' }} rail={{ top: 'FRI', big: '5' }} />
+    <WorkoutItem session={{ label: 'Yoga + foam roll' }} rail={{ top: 'SAT', big: '6' }} />
+  </Stack>
+);
+
+export const WithoutRail = () => (
+  <Stack>
+    <WorkoutItem session={{ label: 'Upper 1', done: true, slot: 'AM' }} />
+    <WorkoutItem session={{ label: 'UT2 60min', slot: 'PM' }} />
+    <WorkoutItem session={null} />
+  </Stack>
+);

--- a/web/.design-sync/previews/WorkoutTarget.tsx
+++ b/web/.design-sync/previews/WorkoutTarget.tsx
@@ -1,0 +1,37 @@
+import { WorkoutTarget } from 'splitiq';
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ padding: 20, maxWidth: 560 }}>{children}</div>
+);
+
+export const TodaysTarget = () => (
+  <Frame>
+    <WorkoutTarget
+      session={{
+        label: 'UT1 45min @ 150-160W',
+        duration: 45,
+        srpe: 5,
+        notes: 'Rate 20-22. Hold the low end for the first 15min, then settle.',
+      }}
+    />
+  </Frame>
+);
+
+export const StrengthTarget = () => (
+  <Frame>
+    <WorkoutTarget
+      session={{
+        label: 'Lower 1 - RDL led',
+        duration: 55,
+        srpe: 7,
+        notes: 'RDL 4x6 @ RPE 7, split squat 3x8 each side. Stop at any hamstring signal.',
+      }}
+    />
+  </Frame>
+);
+
+export const NoPlannedSession = () => (
+  <Frame>
+    <WorkoutTarget session={null} />
+  </Frame>
+);


### PR DESCRIPTION
## What

Adds the [design-sync](https://claude.ai/design) inputs so Claude Design builds mockups from SplitIQ's **real** components instead of generic ones — and so future re-syncs are reproducible rather than hand-redone.

Design project: https://claude.ai/design/p/8edb6124-729f-4d6c-9e32-6ba955e2a6b4

## Why it needed this much wiring

This repo is an **app, not a component library** — no library build, no `dist/` entry, no `.d.ts`, no Storybook. The converter's defaults assume a published package, so the gaps are closed by config rather than by editing any app source:

| File | Closes |
|---|---|
| `entry.jsx` | Components are default exports; the converter's synth entry uses `export *`, which drops defaults. This barrel gives them named exports. |
| `gen-css.mjs` → `base.css` | The app ships no stylesheet (inline styles + runtime-injected vars). This generates the token layer + app ground from `theme.js`. |
| `config.json` `dtsPropsFor` | Plain JSX yields no extractable types — ts-morph emitted `[key: string]: unknown` for all 11. Prop contracts are hand-written from the real destructured params. |
| `docs/*.md` | Per-component usage docs; `category:` frontmatter sets the DS pane groups. |
| `previews/*.tsx` | 33 authored preview cells built from the components' own tests and the real training model. |
| `conventions.md` | Prepended to the generated README and inlined into the design agent's prompt: the no-classes inline-style idiom, the token vocabulary, and what each accent *means*. |

## Verification

- `package-validate.mjs` exits 0; render check **11/11 clean** — 0 bad, 0 thin, 0 floor cards.
- Every preview cell graded against the absolute rubric; all `good`.
- Re-run of the driver reports **11/11 grades carried forward, 0 cleared** — the next sync will be incremental.

## Scope

Touches **no application code**. Everything is under `web/.design-sync/` plus five `.gitignore` lines for generated output. `LogSessionForm` is deliberately excluded — it constructs a Supabase client at module scope, which throws in a browser IIFE bundle; the reason and the fix are recorded in `NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)