### PR TITLE
feat: compute training load from power when sRPE was never captured

### DIFF
--- a/web/src/hooks/__tests__/useTSSHistory.test.js
+++ b/web/src/hooks/__tests__/useTSSHistory.test.js
@@ -6,6 +6,7 @@ import React from 'react';
 const fromMock = vi.fn();
 const inMock = vi.fn();
 const orderMock = vi.fn();
+const orMock = vi.fn();
 
 vi.mock('../../supabaseClient.js', () => ({
   supabase: {
@@ -25,27 +26,57 @@ function makeWrapper() {
   return Wrapper;
 }
 
-function mockQuery(data, error = null) {
-  const chain = {
-    select: () => chain,
-    eq: () => chain,
-    in: (...args) => {
-      inMock(...args);
-      return chain;
-    },
-    gt: () => chain,
-    order: (...args) => {
-      orderMock(...args);
-      return Promise.resolve({ data, error });
-    },
-  };
-  fromMock.mockReturnValue(chain);
+// useTSSHistory now reads CP/FTP through useAnchors, so both hooks call
+// supabase.from(). Branch by table so the anchors query and the sessions query
+// each resolve independently.
+function mockQuery(data, error = null, { cp = 205, ftp = 250 } = {}) {
+  fromMock.mockImplementation((table) => {
+    if (table === 'anchors') {
+      const rows = [];
+      if (cp != null)
+        rows.push({
+          key: 'rowing_cp',
+          value: String(cp),
+          status: 'provisional',
+        });
+      if (ftp != null)
+        rows.push({
+          key: 'bike_ftp',
+          value: String(ftp),
+          status: 'unvalidated',
+        });
+      const anchorChain = {
+        select: () => anchorChain,
+        is: () => Promise.resolve({ data: rows, error: null }),
+      };
+      return anchorChain;
+    }
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      in: (...args) => {
+        inMock(...args);
+        return chain;
+      },
+      gt: () => chain,
+      or: (...args) => {
+        orMock(...args);
+        return chain;
+      },
+      order: (...args) => {
+        orderMock(...args);
+        return Promise.resolve({ data, error });
+      },
+    };
+    return chain;
+  });
 }
 
 beforeEach(() => {
   fromMock.mockReset();
   inMock.mockReset();
   orderMock.mockReset();
+  orMock.mockReset();
 });
 
 describe('useTSSHistory', () => {
@@ -156,6 +187,90 @@ describe('useTSSHistory', () => {
       '2026-06-01',
       '2026-06-10',
     ]);
+  });
+
+  it('keeps sessions carrying EITHER sRPE or watts, not just sRPE', async () => {
+    mockQuery([]);
+    const { result } = renderHook(() => useTSSHistory(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(orMock).toHaveBeenCalledWith('srpe.gt.0,avg_watts.gt.0');
+  });
+
+  it('derives load from watts when sRPE was never captured', async () => {
+    // 152 W against CP 205 for 60min: (152/205)^2 * 10 * 1h = 5.50 -> 5
+    mockQuery([
+      {
+        date: '8/6/26',
+        duration: '60:00',
+        srpe: null,
+        type: 'erg',
+        avg_watts: 152,
+      },
+    ]);
+    const { result } = renderHook(() => useTSSHistory(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data[0].tss).toBe(5);
+  });
+
+  it('measures bike watts against FTP, not rowing CP', async () => {
+    // 196 W against FTP 250 for 60min = 6.1 -> 6. Against CP 205 it would be 9.
+    mockQuery([
+      {
+        date: '7/1/26',
+        duration: '60:00',
+        srpe: null,
+        type: 'cycling',
+        avg_watts: 196,
+      },
+    ]);
+    const { result } = renderHook(() => useTSSHistory(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data[0].tss).toBe(6);
+  });
+
+  it('prefers a real sRPE over the power fallback', async () => {
+    // sRPE 7 for 60min = 7; the power model would say 5 for the same row.
+    mockQuery([
+      {
+        date: '7/3/26',
+        duration: '60:00',
+        srpe: 7,
+        type: 'erg',
+        avg_watts: 150,
+      },
+    ]);
+    const { result } = renderHook(() => useTSSHistory(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data[0].tss).toBe(7);
+  });
+
+  it('degrades to zero when the CP anchor is unreachable rather than inventing one', async () => {
+    mockQuery(
+      [
+        {
+          date: '8/6/26',
+          duration: '60:00',
+          srpe: null,
+          type: 'erg',
+          avg_watts: 152,
+        },
+      ],
+      null,
+      { cp: null }
+    );
+    const { result } = renderHook(() => useTSSHistory(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data[0].tss).toBe(0);
   });
 
   it('throws (isError) when supabase returns an error', async () => {

--- a/web/src/hooks/useTSSHistory.js
+++ b/web/src/hooks/useTSSHistory.js
@@ -1,28 +1,46 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
-import { parseDurationMinutes } from '../utils/duration.js';
+import { sessionLoad } from '../utils/trainingLoad.js';
 import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+import { useAnchors } from './useAnchors.js';
 
 export function useTSSHistory() {
-  return useQuery({
+  const { cp, ftp } = useAnchors();
+
+  const query = useQuery({
     queryKey: ['tss-history'],
     queryFn: async () => {
       const { data, error } = await supabase
         .from('sessions')
-        .select('date, duration, srpe')
+        .select('date, duration, srpe, type, avg_watts')
         .in('status', COMPLETED_STATUSES)
-        .gt('srpe', 0)
+        // Not .gt('srpe', 0): that dropped every session without a hand-entered
+        // sRPE before it ever reached the client, which is all of the
+        // Strava-backfilled history. Keep anything carrying either signal and
+        // let sessionLoad decide which one to use.
+        .or('srpe.gt.0,avg_watts.gt.0')
         // date_iso, not the lexically-sorting TEXT date (#187). This ordering
         // is a contract, not a correctness requirement: calcTrainingLoad keys a
         // map by date and walks day-by-day, so CTL/ATL/TSB are unaffected by
         // input order. Do not re-file the old ordering as a CTL bug.
         .order('date_iso', { ascending: true, nullsFirst: false });
       if (error) throw error;
-      return (data ?? []).map((s) => ({
-        date: s.date,
-        tss: Math.round((parseDurationMinutes(s.duration) * s.srpe) / 60),
-      }));
+      return data ?? [];
     },
     staleTime: 300_000,
   });
+
+  // Derived outside the queryFn so a revalidated CP/FTP anchor recomputes the
+  // whole series without a refetch.
+  const data = useMemo(
+    () =>
+      (query.data ?? []).map((s) => ({
+        date: s.date,
+        tss: sessionLoad(s, { cp, ftp }),
+      })),
+    [query.data, cp, ftp]
+  );
+
+  return { ...query, data };
 }

--- a/web/src/utils/__tests__/trainingLoad.test.js
+++ b/web/src/utils/__tests__/trainingLoad.test.js
@@ -1,5 +1,100 @@
 import { describe, it, expect } from 'vitest';
-import { calcTrainingLoad, deriveTargets } from '../trainingLoad.js';
+import {
+  calcTrainingLoad,
+  deriveTargets,
+  sessionLoad,
+} from '../trainingLoad.js';
+
+const ANCHORS = { cp: 205, ftp: 250 };
+
+describe('sessionLoad', () => {
+  it('uses sRPE when it exists: an hour at sRPE 7 is 7', () => {
+    expect(sessionLoad({ duration: '60:00', srpe: 7 }, ANCHORS)).toBe(7);
+  });
+
+  it('scales sRPE by duration', () => {
+    expect(sessionLoad({ duration: '30:00', srpe: 8 }, ANCHORS)).toBe(4);
+  });
+
+  it('prefers sRPE over watts when a session carries both', () => {
+    const both = { duration: '60:00', srpe: 7, type: 'erg', avg_watts: 150 };
+    expect(sessionLoad(both, ANCHORS)).toBe(7);
+    expect(sessionLoad({ ...both, srpe: null }, ANCHORS)).toBe(5);
+  });
+
+  it('falls back to power when sRPE is missing', () => {
+    // (152/205)^2 * 10 = 5.50 for one hour
+    expect(
+      sessionLoad(
+        { duration: '60:00', srpe: null, type: 'erg', avg_watts: 152 },
+        ANCHORS
+      )
+    ).toBe(5);
+  });
+
+  it('puts an hour at threshold at 10 — the sRPE 10 equivalent', () => {
+    expect(
+      sessionLoad(
+        { duration: '60:00', srpe: null, type: 'erg', avg_watts: 205 },
+        ANCHORS
+      )
+    ).toBe(10);
+  });
+
+  it('reads an easy paddle as genuinely easy', () => {
+    // 118 W recovery for 21:13 -> 0.354h * 3.31 = 1.2
+    expect(
+      sessionLoad(
+        { duration: '21:13', srpe: null, type: 'erg', avg_watts: 118 },
+        ANCHORS
+      )
+    ).toBe(1);
+  });
+
+  it('measures bike watts against FTP and rowing watts against CP', () => {
+    const ride = { duration: '60:00', srpe: null, avg_watts: 196 };
+    expect(sessionLoad({ ...ride, type: 'cycling' }, ANCHORS)).toBe(6);
+    expect(sessionLoad({ ...ride, type: 'bike' }, ANCHORS)).toBe(6);
+    // Same watts judged against the lower rowing CP would overstate the ride.
+    expect(sessionLoad({ ...ride, type: 'erg' }, ANCHORS)).toBe(9);
+  });
+
+  it('gives strength sessions no power model', () => {
+    expect(
+      sessionLoad(
+        { duration: '50:08', srpe: null, type: 'strength', avg_watts: 200 },
+        ANCHORS
+      )
+    ).toBe(0);
+  });
+
+  it('degrades to zero when the anchor is missing rather than inventing one', () => {
+    const s = { duration: '60:00', srpe: null, type: 'erg', avg_watts: 152 };
+    expect(sessionLoad(s, { cp: null, ftp: 250 })).toBe(0);
+    expect(sessionLoad(s, {})).toBe(0);
+    expect(sessionLoad(s)).toBe(0);
+  });
+
+  it('returns zero for a session with neither signal', () => {
+    expect(
+      sessionLoad({ duration: '45:00', srpe: null, type: 'erg' }, ANCHORS)
+    ).toBe(0);
+    expect(
+      sessionLoad(
+        { duration: '45:00', srpe: null, type: 'erg', avg_watts: 0 },
+        ANCHORS
+      )
+    ).toBe(0);
+  });
+
+  it('returns zero for an unparseable or absent duration', () => {
+    expect(
+      sessionLoad({ duration: 'garbage', srpe: 7, type: 'erg' }, ANCHORS)
+    ).toBe(0);
+    expect(sessionLoad({ srpe: 7 }, ANCHORS)).toBe(0);
+    expect(sessionLoad(undefined, ANCHORS)).toBe(0);
+  });
+});
 
 const CTL_K = Math.exp(-1 / 42);
 const ATL_K = Math.exp(-1 / 7);

--- a/web/src/utils/trainingLoad.js
+++ b/web/src/utils/trainingLoad.js
@@ -1,4 +1,50 @@
 import { toISODate } from './dateFormat.js';
+import { parseDurationMinutes } from './duration.js';
+
+// Which calibration anchor a session's watts should be measured against.
+// Rowing watts against rowing CP, bike watts against bike FTP — comparing bike
+// power to CP would overstate every ride. Anything else (strength, mobility)
+// has no power model at all.
+function thresholdFor(type, cp, ftp) {
+  const t = (type ?? '').toLowerCase();
+  if (t.includes('erg') || t.includes('row')) return cp;
+  if (t.includes('bike') || t.includes('cycl') || t.includes('ride'))
+    return ftp;
+  return null;
+}
+
+// Load for one session, in the app's "sRPE-hours" unit: an hour at sRPE r
+// contributes r.
+//
+// sRPE wins whenever it exists. When it does not — every Strava-backfilled
+// session, because sRPE is subjective and was never captured after the fact —
+// fall back to power: intensity factor (avg watts / threshold), squared per the
+// standard TrainingPeaks model, scaled so an hour at threshold reads 10, i.e.
+// an hour at sRPE 10. Without this fallback those sessions contribute nothing
+// and the CTL/ATL/TSB curve coasts on whatever was last rated by hand.
+//
+// Known offset, deliberately NOT calibrated away: on the two sessions carrying
+// both signals (150 W, sRPE 7) power reads ~24% below the sRPE figure. At 73%
+// of CP an RPE of 7 is genuinely elevated, and that gap is read as fatigue in
+// this project's own coaching notes. Tuning a factor to close it on n=2 would
+// erase the signal rather than measure it.
+export function sessionLoad(session, { cp, ftp } = {}) {
+  const minutes = parseDurationMinutes(session?.duration);
+  if (!(minutes > 0)) return 0;
+  const hours = minutes / 60;
+
+  if (session.srpe > 0) return Math.round(hours * session.srpe);
+
+  const threshold = thresholdFor(session.type, cp, ftp);
+  const watts = session.avg_watts;
+  // A missing anchor degrades to zero rather than a hardcoded default: useAnchors
+  // returns null when it cannot resolve one, and inventing a threshold here would
+  // silently rewrite history the next time CP is revalidated.
+  if (!(threshold > 0) || !(watts > 0)) return 0;
+
+  const intensity = watts / threshold;
+  return Math.round(hours * intensity * intensity * 10);
+}
 
 export function calcTrainingLoad(tssData, endDate) {
   const CTL_K = Math.exp(-1 / 42);


### PR DESCRIPTION
Your CTL/ATL/TSB have been running on almost nothing since **3 July**.

`useTSSHistory` filtered on `.gt('srpe', 0)`, and `srpe` is null on **42 of 58** completed sessions — every Strava-backfilled row, because sRPE is subjective and cannot be recovered after the fact. Those rows were dropped in SQL before they ever reached the client, so only **2 of the 16** sessions since 1 July fed the training-load curve.

## The fix

A new `sessionLoad()` in `web/src/utils/trainingLoad.js`: use sRPE when it exists, otherwise fall back to power — intensity factor (`avg_watts / threshold`) squared per the standard TrainingPeaks model, scaled so an hour at threshold reads 10.

That scaling is the important part. The existing formula produces "sRPE-hours" (an hour at sRPE 7 → 7), so the power value has to land on the *same* unit or the CTL curve becomes a mix of two incompatible scales. An hour at threshold reading 10 is the sRPE-10 equivalent.

Rowing measures against **rowing CP (205 W)**, bike against **bike FTP (250 W)** — both already live in `anchors`. Using CP for both would overstate every ride by ~50%.

The SQL filter becomes `.or('srpe.gt.0,avg_watts.gt.0')`, which is the actual reason the rows were missing.

## Effect on live data, 1 July onward

| Date | Type | Before | After |
|---|---|---:|---:|
| 7/01 | erg (sRPE 7) | 7 | **7** |
| 7/01 | cycling 196 W | 0 | 8 |
| 7/03 | erg (sRPE 7) | 5 | **5** |
| 7/11 | erg 142 W | 0 | 4 |
| 7/13 | erg 159 W | 0 | 5 |
| 7/14 | erg 147 W | 0 | 5 |
| 7/16 | erg 166 W | 0 | 7 |
| 7/20 | strength | 0 | 0 |
| 7/21 | cycling (Zwift, no power) | 0 | 0 |
| 7/24 | erg 89 W | 0 | 1 |
| 7/26 | erg 155 W | 0 | 4 |
| 7/27 | erg 118 W recovery | 0 | 1 |
| 7/30 | erg 143 W | 0 | 4 |
| 8/02 | erg 153 W | 0 | 4 |
| 8/04 | erg 151 W | 0 | 4 |
| 8/06 | erg 152 W | 0 | 5 |

14 of 16 restored. **The two rows that already carried sRPE are unchanged** — existing history is preserved exactly, not recomputed. The remaining zeros are the strength session and the Zwift ride, neither of which has power data at all.

## One judgement call worth challenging

On the only two sessions carrying *both* signals (150 W, sRPE 7), the power model reads **~24% lower** — 5.35 against 7. I did **not** calibrate that away.

At 73% of CP an RPE of 7 is genuinely elevated, and this project's own coaching note on the 7/3 session reads exactly that gap as fatigue ("endurance by power despite RPE7; RPE + HR drift read as fatigue"). Fitting a scaling factor to close it on n=2 would convert a fatigue signal into a calibration constant and destroy it permanently. The consequence is a small step in CTL where hand-rated sessions meet power-derived ones — visible, but honest.

If you'd rather they line up, that's a one-line change to the multiplier and worth a deliberate decision.

## Notes

- Load is derived in a `useMemo` rather than the `queryFn`, so revalidating CP recomputes the whole series without a refetch (same pattern as `useErgSessions`).
- A missing anchor degrades to 0 rather than falling back to a hardcoded threshold — matching `useAnchors`' existing "never silently reuse a stale constant" contract. Covered by a test.
- **574 tests pass**, lint clean, build exits 0. Coverage: `trainingLoad.js` 100% lines, `useTSSHistory.js` 100% lines. Global lines 79.92 → **80.14**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
