### PR TITLE
fix: reconcile displayed CP with the live anchor (#176)

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -16,10 +16,6 @@ import LogView from './views/LogView.jsx';
 import ErgTooltip from './components/ErgTooltip.jsx';
 import { calcTrainingLoad } from './utils/trainingLoad.js';
 import {
-  CALIBRATION_STATUS,
-  CRITICAL_POWER,
-  POWER_DURATION,
-  FTP_TEST,
   DAILY_TSS,
   RHR_BASELINE,
   HRV_BASELINE,

--- a/web/src/components/__tests__/PaceTrendChart.test.jsx
+++ b/web/src/components/__tests__/PaceTrendChart.test.jsx
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 import PaceTrendChart, { PaceTooltip, CustomDot } from '../PaceTrendChart.jsx';
-import { PACE_ZONES } from '../../constants/trainingConfig.js';
+import { derivePaceZones } from '../../constants/trainingConfig.js';
+
+// Fixture zones. Derived here rather than imported, because there is no static
+// PACE_ZONES export any more — the app derives bands from the live CP anchor.
+const PACE_ZONES = derivePaceZones(205);
 
 describe('PaceTrendChart', () => {
   it('renders without crashing with empty data', () => {

--- a/web/src/constants/__tests__/trainingConfig.test.js
+++ b/web/src/constants/__tests__/trainingConfig.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import * as trainingConfig from '../trainingConfig.js';
+import {
+  CALIBRATION_STATUS,
+  CRITICAL_POWER,
+  FTP_TEST,
+  deriveCalibrationStatus,
+  derivePaceZones,
+} from '../trainingConfig.js';
+
+const loadModelRow = (rows) => rows.find((r) => r.key === 'load-model');
+
+describe('CP is never mirrored as a static constant', () => {
+  it('CRITICAL_POWER carries no cpEstimate', () => {
+    expect(CRITICAL_POWER).not.toHaveProperty('cpEstimate');
+  });
+
+  it('exports no static PACE_ZONES that could diverge from the live bands', () => {
+    expect(trainingConfig).not.toHaveProperty('PACE_ZONES');
+  });
+
+  it('no static calibration row quotes a hardcoded CP wattage', () => {
+    const copy = CALIBRATION_STATUS.map(
+      (r) => `${r.metric} ${r.basis} ${r.upgrade}`
+    ).join(' ');
+    expect(copy).not.toMatch(/\b190\s*W\b/i);
+    expect(copy).not.toMatch(/CP\/FTP est\./i);
+  });
+
+  it('the CP test card carries no past-dated "when"', () => {
+    expect(FTP_TEST.when).not.toMatch(/Jun|Jul/);
+  });
+});
+
+describe('deriveCalibrationStatus', () => {
+  it('quotes the live CP and its status when the anchor is available', () => {
+    const rows = deriveCalibrationStatus({
+      cp: 205,
+      cpAvailable: true,
+      cpStatus: 'provisional',
+    });
+    expect(loadModelRow(rows).basis).toBe(
+      'CP 205W (provisional), strength TSS ±30%, CTL needs 42d'
+    );
+  });
+
+  it('reflects a confirmed anchor without changing the wattage source', () => {
+    const rows = deriveCalibrationStatus({
+      cp: 212,
+      cpAvailable: true,
+      cpStatus: 'confirmed',
+    });
+    expect(loadModelRow(rows).basis).toMatch(/^CP 212W \(confirmed\),/);
+  });
+
+  it('says the anchor is unavailable rather than falling back to a stale CP', () => {
+    const rows = deriveCalibrationStatus({ cp: null, cpAvailable: false });
+    expect(loadModelRow(rows).basis).toMatch(/^CP anchor unavailable,/);
+    expect(loadModelRow(rows).basis).not.toMatch(/\d+W/);
+  });
+
+  it('treats a missing context the same as an unavailable anchor', () => {
+    expect(loadModelRow(deriveCalibrationStatus()).basis).toMatch(
+      /^CP anchor unavailable,/
+    );
+  });
+
+  it('labels an available anchor with an unknown status explicitly', () => {
+    const rows = deriveCalibrationStatus({ cp: 205, cpAvailable: true });
+    expect(loadModelRow(rows).basis).toBe(
+      'CP 205W (status unknown), strength TSS ±30%, CTL needs 42d'
+    );
+  });
+
+  it('leaves every other row untouched', () => {
+    const rows = deriveCalibrationStatus({
+      cp: 205,
+      cpAvailable: true,
+      cpStatus: 'provisional',
+    });
+    expect(rows).toHaveLength(CALIBRATION_STATUS.length);
+    for (const [i, row] of rows.entries()) {
+      if (row.key === 'load-model') continue;
+      expect(row).toBe(CALIBRATION_STATUS[i]);
+    }
+  });
+
+  it('does not mutate the source array', () => {
+    const before = loadModelRow(CALIBRATION_STATUS).basis;
+    deriveCalibrationStatus({ cp: 205, cpAvailable: true });
+    expect(loadModelRow(CALIBRATION_STATUS).basis).toBe(before);
+  });
+
+  it('does not upgrade the confidence tier — that is #181, not this', () => {
+    const rows = deriveCalibrationStatus({
+      cp: 205,
+      cpAvailable: true,
+      cpStatus: 'confirmed',
+    });
+    expect(loadModelRow(rows).tier).toBe(2);
+    expect(loadModelRow(rows).conf).toBe('Estimated');
+  });
+});
+
+describe('derivePaceZones', () => {
+  it('scales the bands with the CP it is given', () => {
+    const at190 = derivePaceZones(190).find((z) => z.zone === 'AT');
+    const at205 = derivePaceZones(205).find((z) => z.zone === 'AT');
+    expect(at205.wattsLow).toBeGreaterThan(at190.wattsLow);
+    expect(at205.wattsHigh).toBeGreaterThan(at190.wattsHigh);
+  });
+
+  it('puts UT2/UT1/AT where the live 205W anchor implies', () => {
+    const zones = derivePaceZones(205);
+    const band = (z) => {
+      const found = zones.find((x) => x.zone === z);
+      return [found.wattsLow, found.wattsHigh];
+    };
+    expect(band('UT2')).toEqual([113, 144]);
+    expect(band('UT1')).toEqual([144, 164]);
+    expect(band('AT')).toEqual([164, 185]);
+  });
+});

--- a/web/src/constants/trainingConfig.js
+++ b/web/src/constants/trainingConfig.js
@@ -1,4 +1,5 @@
-// Training science constants — update after CP test (1 Jul) or athlete baseline changes.
+// Training science constants — static reference data only. Live calibration values
+// (CP/FTP) come from the `anchors` table via useAnchors(); never mirror one here.
 
 import { wattsToPace500 } from '../utils/pace.js';
 
@@ -41,6 +42,9 @@ export const SRPE_GUIDE = [
   },
 ];
 
+// Static calibration rows. The load-model row's `basis` quotes the CP anchor, so
+// it is left anchor-free here and resolved at render time by
+// deriveCalibrationStatus() — never bake a CP number into this array.
 export const CALIBRATION_STATUS = [
   {
     metric: 'Power @ HR130',
@@ -86,13 +90,13 @@ export const CALIBRATION_STATUS = [
     upgrade: 'Intake-vs-weight regression at end of calibration (~Jun 24)',
   },
   {
+    key: 'load-model',
     metric: 'TSS / CTL / ATL / TSB',
     tier: 2,
     conf: 'Estimated',
     color: '#ffd700',
-    basis:
-      'CP/FTP est. 190W (untested), strength TSS ±30%, CTL needs 42d (have ~3wk)',
-    upgrade: '4-min CP test (1 Jul) → real anchor recalibrates everything',
+    basis: 'strength TSS ±30%, CTL needs 42d',
+    upgrade: 'A rested CP retest → real anchor recalibrates everything',
   },
   {
     metric: 'Daily net calories',
@@ -144,8 +148,26 @@ export const CALIBRATION_STATUS = [
   },
 ];
 
+// Resolve the calibration rows against the live CP anchor. Pure — callers pass the
+// `{ cp, cpAvailable, cpStatus }` shape from useAnchors(). When the anchor is
+// unavailable the row says so; it never falls back to a stale hardcoded CP.
+// Confidence tiers are deliberately untouched here — see #181.
+export function deriveCalibrationStatus({
+  cp,
+  cpAvailable = false,
+  cpStatus = null,
+} = {}) {
+  return CALIBRATION_STATUS.map((row) => {
+    if (row.key !== 'load-model') return row;
+    const anchor = cpAvailable
+      ? `CP ${cp}W (${cpStatus ?? 'status unknown'})`
+      : 'CP anchor unavailable';
+    return { ...row, basis: `${anchor}, ${row.basis}` };
+  });
+}
+
 export const CRITICAL_POWER = {
-  cpEstimate: 190, // W — provisional (= current FTP placeholder). 30min test confirms.
+  // No cpEstimate — CP is read live from `anchors.rowing_cp` via useAnchors().
   wPrime: null, // J — anaerobic reserve. Needs a short max effort (1-min) to model.
   northStar: '2k pace', // rowing's true benchmark — race-pace zones key off this
   status:
@@ -196,7 +218,7 @@ export const POWER_DURATION = [
 ];
 
 export const FTP_TEST = {
-  when: '~2 weeks out — fresh day, ideal post-FIFO return (~Jun 24+)',
+  when: 'Overdue — take the next genuinely fresh day, not the back end of a hard block',
   protocol:
     '30min continuous at the hardest STEADY pace you can hold the full 30 (not a sprint). CP ≈ 95% of the 30min avg power. This is a Critical Power test in rowing terms. Or 4×8min progressive steps to map HR-power.',
   prereq:
@@ -304,9 +326,10 @@ const ZONE_POWER_PCT = [
   { zone: 'AN', pctLow: 1.05, pctHigh: 1.3 },
 ];
 
-// Derive the power/pace zone bands from a Critical Power value. Pure — the live
-// app path calls this with the current `anchors.rowing_cp`; PACE_ZONES below is a
-// static fallback keyed off the seed constant for non-live contexts.
+// Derive the power/pace zone bands from a Critical Power value. Pure — callers
+// pass the current `anchors.rowing_cp` (see ErgView). There is deliberately no
+// static PACE_ZONES export: a second set of bands keyed off a seed constant would
+// silently diverge from the live one.
 export function derivePaceZones(cp) {
   return ZONE_POWER_PCT.map(({ zone, pctLow, pctHigh }) => {
     const hz = HR_ZONES.find((z) => z.zone === zone);
@@ -322,5 +345,3 @@ export function derivePaceZones(cp) {
     };
   });
 }
-
-export const PACE_ZONES = derivePaceZones(CRITICAL_POWER.cpEstimate);

--- a/web/src/views/ErgView.jsx
+++ b/web/src/views/ErgView.jsx
@@ -16,7 +16,7 @@ import {
   CRITICAL_POWER,
   POWER_DURATION,
   FTP_TEST,
-  CALIBRATION_STATUS,
+  deriveCalibrationStatus,
   derivePaceZones,
   HR130_POWER,
 } from '../constants/trainingConfig.js';
@@ -223,6 +223,11 @@ export default function ErgView({ tsbNow, ctlNow }) {
   // Live Critical Power from the anchors context store (no hardcoded fallback).
   const { cp, cpStatus, cpAvailable } = useAnchors();
   const paceZones = cpAvailable ? derivePaceZones(cp) : [];
+  const calibrationStatus = deriveCalibrationStatus({
+    cp,
+    cpAvailable,
+    cpStatus,
+  });
 
   const hr130Now =
     [...HR130_POWER].filter((p) => !p.setupArtifact).pop()?.watts ?? null;
@@ -1131,59 +1136,63 @@ export default function ErgView({ tsbNow, ctlNow }) {
                   ? 'ESTIMATED — WIDE BARS'
                   : 'FRAGILE — SKEPTICISM'}
             </div>
-            {CALIBRATION_STATUS.filter((c) => c.tier === tier).map((c) => (
-              <div
-                key={c.metric}
-                style={{
-                  background: '#08080d',
-                  borderLeft: `2px solid ${c.color}`,
-                  borderRadius: 3,
-                  padding: '7px 10px',
-                  marginBottom: 4,
-                }}
-              >
+            {calibrationStatus
+              .filter((c) => c.tier === tier)
+              .map((c) => (
                 <div
+                  key={c.metric}
                   style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'baseline',
+                    background: '#08080d',
+                    borderLeft: `2px solid ${c.color}`,
+                    borderRadius: 3,
+                    padding: '7px 10px',
+                    marginBottom: 4,
                   }}
                 >
-                  <span
+                  <div
                     style={{
-                      fontSize: 11,
-                      fontWeight: 700,
-                      color: '#e8e8f0',
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'baseline',
                     }}
                   >
-                    {c.metric}
-                  </span>
-                  <span style={{ fontSize: 9, color: c.color }}>{c.conf}</span>
-                </div>
-                <div
-                  style={{
-                    fontSize: 9,
-                    color: '#7e7e9a',
-                    lineHeight: 1.4,
-                    marginTop: 2,
-                  }}
-                >
-                  {c.basis}
-                </div>
-                {c.upgrade !== '—' && (
+                    <span
+                      style={{
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: '#e8e8f0',
+                      }}
+                    >
+                      {c.metric}
+                    </span>
+                    <span style={{ fontSize: 9, color: c.color }}>
+                      {c.conf}
+                    </span>
+                  </div>
                   <div
                     style={{
                       fontSize: 9,
-                      color: '#00d4ff99',
+                      color: '#7e7e9a',
                       lineHeight: 1.4,
                       marginTop: 2,
                     }}
                   >
-                    ↑ {c.upgrade}
+                    {c.basis}
                   </div>
-                )}
-              </div>
-            ))}
+                  {c.upgrade !== '—' && (
+                    <div
+                      style={{
+                        fontSize: 9,
+                        color: '#00d4ff99',
+                        lineHeight: 1.4,
+                        marginTop: 2,
+                      }}
+                    >
+                      ↑ {c.upgrade}
+                    </div>
+                  )}
+                </div>
+              ))}
           </div>
         ))}
         <div

--- a/web/src/views/__tests__/ErgView.test.jsx
+++ b/web/src/views/__tests__/ErgView.test.jsx
@@ -206,4 +206,52 @@ describe('ErgView', () => {
     const { getByText } = renderView();
     expect(getByText('SESSIONS / WK').nextSibling.textContent).toBe('0');
   });
+
+  describe('CP display tracks the live anchor', () => {
+    beforeEach(() => {
+      useErgSessionsMock.mockReturnValue({ data: [], isLoading: false });
+    });
+
+    it('shows the live CP in the calibration panel, not a stale constant', () => {
+      const { container } = renderView();
+      expect(container.textContent).toContain('CP 205W (provisional)');
+      expect(container.textContent).not.toContain('CP/FTP est. 190W');
+    });
+
+    // POWER_DURATION's predicted-watts column still carries pre-anchor estimates
+    // (incl. "~180–190W") — that table belongs to #180, so these assertions are
+    // scoped to the two surfaces that present a *current* CP.
+    it('never presents 190W as the current CP', () => {
+      const { container } = renderView();
+      expect(container.textContent).not.toContain('CP/FTP est. 190W');
+      expect(container.textContent).not.toMatch(/CRITICAL POWER190W/);
+    });
+
+    it('follows the anchor when it changes rather than staying pinned', () => {
+      useAnchorsMock.mockReturnValue({
+        cp: 212,
+        cpStatus: 'confirmed',
+        cpAvailable: true,
+      });
+      const { container } = renderView();
+      expect(container.textContent).toContain('CP 212W (confirmed)');
+    });
+
+    it('says the anchor is unavailable instead of falling back silently', () => {
+      useAnchorsMock.mockReturnValue({
+        cp: null,
+        cpStatus: null,
+        cpAvailable: false,
+      });
+      const { container } = renderView();
+      expect(container.textContent).toContain('CP anchor unavailable');
+      expect(container.textContent).toContain('CP unavailable');
+      expect(container.textContent).not.toContain('CP/FTP est. 190W');
+    });
+
+    it('does not show a past-dated CP test window', () => {
+      const { container } = renderView();
+      expect(container.textContent).not.toContain('~Jun 24+');
+    });
+  });
 });


### PR DESCRIPTION
Closes #176 (Sprint 5 · T3).

## Problem

`anchors.rowing_cp` has been 205 W provisional since 07-01, but the app kept showing 190 W — a seed constant — as the current CP. `ErgView` already read the anchor correctly for the CP tile and pace bands; the contradiction came entirely from static copy sitting alongside it.

## What changed

| Surface | Before | After |
|---|---|---|
| `CRITICAL_POWER.cpEstimate` | `190` | removed — CP is only ever read live |
| `PACE_ZONES` (static export) | bands derived from the 190 seed | removed — a second set of bands that could diverge from the live path |
| `CALIBRATION_STATUS` load-model row | `'CP/FTP est. 190W (untested), …'` | resolved at render from the anchor |
| `FTP_TEST.when` | `'… (~Jun 24+)'` | undated; states the test is overdue |
| `App.jsx` | 4 unused imports of these constants | removed |

New pure resolver in `constants/trainingConfig.js`:

```js
deriveCalibrationStatus({ cp, cpAvailable, cpStatus })
```

`ErgView` feeds it straight from `useAnchors()`. Available → `CP 205W (provisional), strength TSS ±30%, CTL needs 42d`. Unavailable → `CP anchor unavailable, …` — never a silent 190.

`PACE_ZONES`' only consumer outside the module was `PaceTrendChart.test.jsx`, which now derives its own fixture.

## Acceptance criteria

1. ✅ Conflicting static copy is live-anchor-driven or undated.
2. ✅ Unreachable anchor reads "unavailable" — no silent 190 fallback (`useAnchors` already returns `cp: null`; the new row text follows it).
3. ✅ No new hardcoded numeric CP.
4. ✅ No remaining `190` presented as a current CP.

## Deliberately out of scope

- **Confidence tiers stay put.** Upgrading `conf`/`tier` when a benchmark lands is #181, and there's a test asserting this PR does *not* do it.
- **`POWER_DURATION.predW` untouched** (incl. the 30-min row's `~180–190`). That table belongs to #180, and re-deriving the ranges off a new CP is a training-science call, not a display fix. The `190` there is a predicted test wattage, not a current-CP claim — the `ErgView` test comments explain why the assertions are scoped around it.
- No writes to `anchors`.

## Verification

- `npm test` — **595 passed** (52 files), up from 576; +19 new.
- `npm run lint` — 0 errors (3 pre-existing warnings).
- `npm run build` — clean.
- Coverage 79.8 % stmts / 74.8 % branch / 80.2 % lines, comfortably over the ratchet floor.

New tests cover: available / confirmed / unavailable / missing-context / unknown-status anchors, source-array immutability, tiers *not* upgrading, and `ErgView` rendering the live number and following it when it changes.

## Noted while in here (not fixed)

- `ZONE_POWER_PCT` puts AT at 0.80–0.90 × CP → **164–185 W** at CP 205, but `CLAUDE.md` documents **AT 164–205 W**. One of the two is wrong; it's a doctrine question, not a display bug.
- Two more past-dated strings survive in non-CP copy: the TDEE row's `(~Jun 24)` and `ErgView`'s closing `Calibration ends ~Jun 24`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)