### PR TITLE
fix: build the Coach's training context on the client and actually send it (#199)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ coach use), and the context store (Code↔Coach shared memory, added by #94):
 | `exercises`         | Exercise library — 873 rows, **text ids**                            |
 | `exercise_media`    | Demo media per exercise (reference content, not user data)           |
 | `exercise_prefs`    | Per-user, per-exercise preferences (e.g. rest seconds)               |
-| `coach_messages`    | Legacy/experimental in-app chat rail (see Coaching data model)       |
+| `coach_messages`    | In-app Coach chat rail (see Coaching data model)                     |
 | `backup_snapshots`  | Daily full-DB JSON snapshots (backup cron)                           |
 | `coach_log`         | **Context store** — append-only diary + decision record (Coach's content) |
 | `anchors`           | **Context store** — current calibration + phase state (one live row/key)  |
@@ -364,8 +364,18 @@ The **integration model was ratified 2026-07-01**: Coach (Claude in chat) operat
 natively via the **Supabase MCP connector, writing directly to the DB** (`source='coach'`)
 — reading vitals, and inserting/updating `sessions`, `strength_workouts`, etc. This
 is the live coaching rail, so **Code and Coach share one source of truth: this file
-plus the schema above.** The in-app Anthropic-API path (`coach_messages` table) was
-trialed and set aside — treat it as legacy/experimental unless revived.
+plus the schema above.**
+
+The in-app Anthropic-API path (`coach_messages` table, the Coach tab) was revived on
+2026-08-22 by #199. **The client assembles the training context and posts it**:
+`buildTrainingContext` in `web/src/hooks/useCoach.js` composes load, readiness,
+today's prescription and the recent microcycle from the same tested utilities the
+dashboard itself uses (`calcTrainingLoad`/`sessionLoad`, `computeReadiness`,
+`COMPLETED_STATUSES`, `toISODate`), and `coach-chat` is a thin Anthropic proxy that
+holds no data logic of its own. It used to rebuild that context server-side against
+column names `vitals` does not have and a `status` filter no row matched, so the
+Coach silently ran on an empty context — **do not reintroduce a second builder in the
+edge function.**
 
 **Bridge discipline persists** even though Code holds repo + schema + deploy: Scott
 authorises consequential/destructive/schema changes; review structure before material

--- a/supabase/functions/coach-chat/index.ts
+++ b/supabase/functions/coach-chat/index.ts
@@ -3,17 +3,15 @@
 // Required secrets (set via Supabase Dashboard → Edge Functions → Secrets):
 //   ANTHROPIC_API_KEY  — Anthropic API key
 //
-// SUPABASE_URL and SUPABASE_ANON_KEY are injected automatically by Supabase.
-//
 // Deployed with JWT verification ON (default). The caller must send
 // Authorization: Bearer <supabase-session-token>.
-
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
+
+const MAX_CONTEXT_CHARS = 8000;
 
 const MODEL_MAP: Record<string, string> = {
   haiku: 'claude-haiku-4-5-20251001',
@@ -47,95 +45,6 @@ RESPONSE STYLE
 - If you're uncertain, say so — don't fabricate.
 - Stay within current phase. Don't prescribe intensity workouts until Build 1.`;
 
-async function buildContext(supabase: ReturnType<typeof createClient>): Promise<string> {
-  const today = new Date().toISOString().split('T')[0];
-
-  const [{ data: tssRows }, { data: sessionRows }, { data: vitalsRows }] = await Promise.all([
-    supabase
-      .from('sessions')
-      .select('date, duration, srpe')
-      .eq('status', 'logged')
-      .gt('srpe', 0)
-      .gt('duration', 0)
-      .order('date', { ascending: true }),
-    supabase
-      .from('sessions')
-      .select('date, type, label, duration, srpe, status')
-      .order('date', { ascending: false })
-      .limit(10),
-    supabase
-      .from('vitals')
-      .select('date, rhr, hrv, sleep')
-      .order('date', { ascending: false })
-      .limit(30),
-  ]);
-
-  const lines = [`CURRENT TRAINING DATA (as of ${today}):`];
-
-  // CTL / ATL / TSB via impulse-response model (mirrors trainingLoad.js)
-  if (tssRows && tssRows.length > 0) {
-    const CTL_K = Math.exp(-1 / 42);
-    const ATL_K = Math.exp(-1 / 7);
-    const tssMap: Record<string, number> = {};
-    for (const r of tssRows) {
-      tssMap[r.date] = Math.round((r.duration * r.srpe) / 60);
-    }
-    const startDate = new Date(tssRows[0].date);
-    const endDate = new Date(today);
-    let ctl = 0, atl = 0;
-    for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
-      const key = d.toISOString().split('T')[0];
-      const tss = tssMap[key] ?? 0;
-      ctl = ctl * CTL_K + tss * (1 - CTL_K);
-      atl = atl * ATL_K + tss * (1 - ATL_K);
-    }
-    const finalCtl = Math.round(ctl * 10) / 10;
-    const finalAtl = Math.round(atl * 10) / 10;
-    const tsb = Math.round((ctl - atl) * 10) / 10;
-    const tsbSignal = tsb > 5 ? 'GREEN' : tsb > -10 ? 'AMBER' : 'RED';
-    lines.push(`TSB: ${tsb} (${tsbSignal}) | CTL: ${finalCtl} | ATL: ${finalAtl}`);
-  }
-
-  // Readiness from vitals (mirrors computeReadiness in recoveryAnalytics.js)
-  if (vitalsRows && vitalsRows.length > 0) {
-    const latest = vitalsRows[0];
-    const rhrVals = vitalsRows.filter((r) => r.rhr != null).map((r) => Number(r.rhr));
-    const hrvVals = vitalsRows.filter((r) => r.hrv != null).map((r) => Number(r.hrv));
-    const rhrBaseline = rhrVals.length >= 14 ? rhrVals.reduce((s, v) => s + v, 0) / rhrVals.length : 57;
-    const hrvBaseline = hrvVals.length >= 14 ? hrvVals.reduce((s, v) => s + v, 0) / hrvVals.length : 30;
-    let score = 100;
-    if (latest.rhr != null) score -= Math.max(0, latest.rhr - rhrBaseline) * 4;
-    if (latest.hrv != null) score -= Math.max(0, hrvBaseline - latest.hrv) * 1.5;
-    if (latest.sleep != null) score -= latest.sleep < 7 ? (7 - latest.sleep) * 8 : 0;
-    const readinessScore = Math.round(Math.min(100, Math.max(0, score)));
-    const readinessLabel = readinessScore >= 80 ? 'READY' : readinessScore >= 60 ? 'CAUTION' : 'FATIGUED';
-    const rhr = latest.rhr ?? '—';
-    const hrv = latest.hrv ?? '—';
-    const sleep = latest.sleep ?? '—';
-    lines.push(`Readiness: ${readinessScore}/100 ${readinessLabel} | RHR: ${rhr} | HRV: ${hrv}ms | Sleep: ${sleep}h`);
-  }
-
-  // Today's planned session + recent logged sessions
-  if (sessionRows && sessionRows.length > 0) {
-    const todayPlanned = sessionRows.find((s) => s.status === 'planned' && s.date === today);
-    if (todayPlanned) {
-      const label = todayPlanned.label ? ` — ${todayPlanned.label}` : '';
-      lines.push(`Today's session: ${todayPlanned.type}${label}`);
-    }
-    const recentLogged = sessionRows.filter((s) => s.status === 'logged').slice(0, 5);
-    if (recentLogged.length > 0) {
-      lines.push('Recent sessions (newest first):');
-      for (const s of recentLogged) {
-        const dur = s.duration ? ` ${s.duration}min` : '';
-        const rpe = s.srpe ? ` sRPE ${s.srpe}` : '';
-        lines.push(`  ${s.date}: ${s.type}${dur}${rpe}`);
-      }
-    }
-  }
-
-  return lines.join('\n');
-}
-
 Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: CORS_HEADERS });
@@ -149,7 +58,11 @@ Deno.serve(async (req: Request) => {
     });
   }
 
-  let body: { messages: Array<{ role: string; content: string }>; model?: string };
+  let body: {
+    messages: Array<{ role: string; content: string }>;
+    model?: string;
+    context?: string;
+  };
   try {
     body = await req.json();
   } catch {
@@ -159,7 +72,7 @@ Deno.serve(async (req: Request) => {
     });
   }
 
-  const { messages, model = 'sonnet' } = body;
+  const { messages, model = 'sonnet', context } = body;
   if (!Array.isArray(messages) || messages.length === 0) {
     return new Response(JSON.stringify({ error: 'messages array required' }), {
       status: 400,
@@ -167,19 +80,29 @@ Deno.serve(async (req: Request) => {
     });
   }
 
-  // Build training context by querying the DB with the user's JWT (respects RLS)
-  const authHeader = req.headers.get('Authorization') ?? '';
-  const jwt = authHeader.replace('Bearer ', '');
-  const supabase = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_ANON_KEY')!,
-    { global: { headers: { Authorization: `Bearer ${jwt}` } } }
-  );
-  const context = await buildContext(supabase);
+  // The training context is assembled client-side by buildTrainingContext in
+  // web/src/hooks/useCoach.js and posted here. It used to be rebuilt in this
+  // function, against column names that do not exist on vitals, a status
+  // filter matching none of the rows, and an ISO-vs-"M/D/YY" date comparison
+  // that could never be true — so it always collapsed to a bare header line
+  // and the Coach ran blind (#199). The client already derives all of it with
+  // tested code; this function no longer duplicates any of it.
+  //
+  // Capped rather than validated: this is the athlete's own authenticated
+  // browser posting his own data back, so there is nothing to escalate — but
+  // an unbounded string spliced into a system prompt still gets a bound.
+  const trainingContext =
+    typeof context === 'string'
+      ? context.trim().slice(0, MAX_CONTEXT_CHARS)
+      : '';
 
   const resolvedModel = MODEL_MAP[model] ?? MODEL_MAP.sonnet;
-  const systemPrompt = context
-    ? `${COACH_SYSTEM_PROMPT}\n\nCURRENT TRAINING DATA:\n${context}`
+  // An older cached bundle posts no context. It still gets a working coach,
+  // just an uninformed one.
+  // No "CURRENT TRAINING DATA:" wrapper — buildTrainingContext already opens
+  // with its own dated header, and prepending one duplicated it.
+  const systemPrompt = trainingContext
+    ? `${COACH_SYSTEM_PROMPT}\n\n${trainingContext}`
     : COACH_SYSTEM_PROMPT;
 
   const upstream = await fetch('https://api.anthropic.com/v1/messages', {

--- a/web/src/hooks/__tests__/useCoach.test.js
+++ b/web/src/hooks/__tests__/useCoach.test.js
@@ -41,10 +41,13 @@ describe('buildTrainingContext', () => {
     expect(result).toContain('ATL: 42.3');
   });
 
+  // Boundaries are the dashboard's own (>10 / >-10), on the classic-TSS scale
+  // #208 rescaled sessionLoad to. Pinned so the Coach cannot drift away from
+  // what App.jsx, MobileAnalytics and LoadTooltip show for the same number.
   it('labels TSB signal correctly', () => {
     expect(
       buildTrainingContext(
-        { tsb: 10, ctl: 30, atl: 20 },
+        { tsb: 25, ctl: 30, atl: 20 },
         null,
         0,
         'READY',
@@ -72,6 +75,22 @@ describe('buildTrainingContext', () => {
         null
       )
     ).toContain('RED');
+  });
+
+  it('puts the GREEN/AMBER boundary at 10, matching the dashboard', () => {
+    const at = (tsb) =>
+      buildTrainingContext(
+        { tsb, ctl: 30, atl: 30 },
+        null,
+        0,
+        'READY',
+        [],
+        null
+      );
+    expect(at(11)).toContain('GREEN');
+    expect(at(10)).toContain('AMBER');
+    expect(at(-10)).toContain('RED');
+    expect(at(-9)).toContain('AMBER');
   });
 
   it('includes readiness and vitals when present', () => {

--- a/web/src/hooks/__tests__/useCoach.test.js
+++ b/web/src/hooks/__tests__/useCoach.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 // Mock supabaseClient so the import of useCoach.js doesn't fail at module load time
 vi.mock('../../supabaseClient.js', () => ({
@@ -24,7 +24,7 @@ vi.mock('../useVitals.js', () => ({
   }),
 }));
 
-import { buildTrainingContext } from '../useCoach.js';
+import { buildTrainingContext, todayISO } from '../useCoach.js';
 
 // buildTrainingContext is a pure exported function — no mocking needed
 describe('buildTrainingContext', () => {
@@ -129,5 +129,37 @@ describe('buildTrainingContext', () => {
     expect(result).not.toContain('Readiness:');
     expect(result).not.toContain("Today's session:");
     expect(result).not.toContain('Recent sessions');
+  });
+});
+
+// The header date and the "today's session" match both key off todayISO. It
+// reads LOCAL calendar fields, not toISOString(): Perth is UTC+8, so a UTC
+// day would name yesterday for the whole Perth morning — precisely when
+// readiness is checked and today's prescription asked about.
+describe('todayISO', () => {
+  const realTZ = globalThis.process.env.TZ;
+
+  afterEach(() => {
+    globalThis.process.env.TZ = realTZ;
+    vi.useRealTimers();
+  });
+
+  it('reports the local day, not the UTC one, when the two differ', () => {
+    globalThis.process.env.TZ = 'Australia/Perth';
+    vi.useFakeTimers();
+    // 04:00 Thursday in Perth is still Wednesday in UTC.
+    vi.setSystemTime(new Date('2026-08-21T20:00:00Z'));
+
+    expect(todayISO()).toBe('2026-08-22');
+    expect(new Date().toISOString().split('T')[0]).toBe('2026-08-21');
+  });
+
+  it('feeds the context header the local day', () => {
+    globalThis.process.env.TZ = 'Australia/Perth';
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-21T20:00:00Z'));
+
+    const result = buildTrainingContext(null, null, 0, 'READY', [], null);
+    expect(result).toContain('CURRENT TRAINING DATA (as of 2026-08-22):');
   });
 });

--- a/web/src/hooks/__tests__/useCoach.test.js
+++ b/web/src/hooks/__tests__/useCoach.test.js
@@ -102,6 +102,49 @@ describe('buildTrainingContext', () => {
     expect(result).toContain('Sleep: 6.8h');
   });
 
+  // #218 made computeReadiness return { score: null, status: 'NO DATA' } when
+  // there is no RHR to score, precisely so absent data stops reaching the Coach
+  // as a fabricated verdict. Interpolating that would read "null/100".
+  it('never renders a null readiness score as a number', () => {
+    const vitals = { rhr: null, hrv: 27, sleep: 6.8 };
+    const result = buildTrainingContext(
+      null,
+      vitals,
+      null,
+      'NO DATA',
+      [],
+      null
+    );
+    expect(result).toContain('Readiness: unavailable (NO DATA)');
+    expect(result).not.toContain('null');
+    expect(result).not.toContain('/100');
+    // The vitals it does have are still reported.
+    expect(result).toContain('HRV: 27ms');
+    expect(result).toContain('Sleep: 6.8h');
+  });
+
+  it('marks a partial readiness score as partial', () => {
+    const vitals = { rhr: 58, hrv: null, sleep: null };
+    const result = buildTrainingContext(
+      null,
+      vitals,
+      72,
+      'CAUTION',
+      [],
+      null,
+      true
+    );
+    expect(result).toContain('Readiness: 72/100 CAUTION (partial');
+    expect(result).toContain('scored without HRV or sleep');
+  });
+
+  it('does not mark a complete readiness score as partial', () => {
+    const vitals = { rhr: 58, hrv: 27, sleep: 6.8 };
+    const result = buildTrainingContext(null, vitals, 68, 'CAUTION', [], null);
+    expect(result).toContain('Readiness: 68/100 CAUTION |');
+    expect(result).not.toContain('partial');
+  });
+
   it('uses em dashes for missing vitals fields', () => {
     const vitals = { rhr: null, hrv: null, sleep: null };
     const result = buildTrainingContext(null, vitals, 0, 'FATIGUED', [], null);

--- a/web/src/hooks/__tests__/useCoachWiring.test.js
+++ b/web/src/hooks/__tests__/useCoachWiring.test.js
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// A separate file from useCoach.test.js on purpose: that one mocks
+// @tanstack/react-query wholesale to exercise buildTrainingContext as a pure
+// function, and vi.mock is file-scoped and hoisted, so a test that needs the
+// real hook machinery cannot live alongside it.
+
+const insertMock = vi.fn(() => Promise.resolve({ error: null }));
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: () => ({
+      insert: (...args) => insertMock(...args),
+      select: () => ({
+        order: () => ({
+          limit: () => Promise.resolve({ data: [], error: null }),
+        }),
+      }),
+      delete: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    }),
+    auth: {
+      getSession: () =>
+        Promise.resolve({ data: { session: { access_token: 'test-token' } } }),
+      getUser: () => Promise.resolve({ data: { user: { id: 'u1' } } }),
+    },
+  },
+}));
+
+let sessionRows = [];
+let vitalsState = {
+  latest: null,
+  readinessScore: 0,
+  readinessLabel: 'FATIGUED',
+};
+let tssRows = [];
+
+vi.mock('../useSessions.js', () => ({
+  useSessions: () => ({ data: sessionRows }),
+}));
+vi.mock('../useVitals.js', () => ({ useVitals: () => vitalsState }));
+vi.mock('../useTSSHistory.js', () => ({
+  useTSSHistory: () => ({ data: tssRows }),
+}));
+
+import { useCoach, todayISO } from '../useCoach.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+// The hook streams the response body, so fetch has to hand back a real
+// ReadableStream carrying SSE frames or sendMessage never settles.
+function stubFetch() {
+  const fetchMock = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      body: {
+        getReader() {
+          const frames = [
+            'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"ok"}}\n',
+            'data: {"type":"message_stop"}\n',
+          ];
+          let i = 0;
+          return {
+            read() {
+              if (i >= frames.length) return Promise.resolve({ done: true });
+              return Promise.resolve({
+                done: false,
+                value: new globalThis.TextEncoder().encode(frames[i++]),
+              });
+            },
+          };
+        },
+      },
+    })
+  );
+  globalThis.fetch = fetchMock;
+  return fetchMock;
+}
+
+// Posted body of the single coach-chat request.
+async function sendAndReadBody(fetchMock) {
+  const { result } = renderHook(() => useCoach(), { wrapper: makeWrapper() });
+  await act(async () => {
+    await result.current.sendMessage('how is my load?');
+  });
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+  const [url, init] = fetchMock.mock.calls[0];
+  return { url, body: JSON.parse(init.body) };
+}
+
+beforeEach(() => {
+  sessionRows = [];
+  tssRows = [];
+  vitalsState = { latest: null, readinessScore: 0, readinessLabel: 'FATIGUED' };
+  insertMock.mockClear();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete globalThis.fetch;
+});
+
+describe('useCoach sends the training context', () => {
+  it('posts a non-empty context string to coach-chat', async () => {
+    const fetchMock = stubFetch();
+    const { url, body } = await sendAndReadBody(fetchMock);
+
+    expect(url).toContain('/functions/v1/coach-chat');
+    expect(typeof body.context).toBe('string');
+    expect(body.context.length).toBeGreaterThan(0);
+    expect(body.context).toContain('CURRENT TRAINING DATA');
+    expect(body.messages).toHaveLength(1);
+  });
+
+  it('carries load, readiness and recent sessions when the data is there', async () => {
+    tssRows = [
+      { date: '8/18/26', tss: 40 },
+      { date: '8/19/26', tss: 55 },
+    ];
+    vitalsState = {
+      latest: { rhr: 58, hrv: 27, sleep: 6.8 },
+      readinessScore: 68,
+      readinessLabel: 'CAUTION',
+    };
+    sessionRows = [
+      {
+        date: '8/19/26',
+        type: 'Z2 Aerobic',
+        duration: 60,
+        srpe: 4,
+        status: 'completed',
+      },
+      {
+        date: '8/18/26',
+        type: 'Upper Strength',
+        duration: 45,
+        srpe: 6,
+        status: 'actual',
+      },
+    ];
+
+    const fetchMock = stubFetch();
+    const { body } = await sendAndReadBody(fetchMock);
+
+    expect(body.context).toContain('TSB:');
+    expect(body.context).toContain('CTL:');
+    expect(body.context).toContain('Readiness: 68/100 CAUTION');
+    expect(body.context).toContain('RHR: 58');
+    expect(body.context).toContain('Recent sessions (newest first):');
+    expect(body.context).toContain('2026-08-19: Z2 Aerobic 60min sRPE 4');
+    expect(body.context).toContain('2026-08-18: Upper Strength 45min sRPE 6');
+  });
+
+  it('parses the free-text duration column instead of interpolating it', async () => {
+    sessionRows = [
+      {
+        date: '8/20/26',
+        type: 'Erg',
+        duration: '45:00',
+        srpe: 5,
+        status: 'completed',
+      },
+      {
+        date: '8/19/26',
+        type: 'Bike',
+        duration: '1h4m',
+        srpe: 4,
+        status: 'completed',
+      },
+      { date: '8/18/26', type: 'Row', duration: '57m', status: 'actual' },
+      {
+        date: '8/17/26',
+        type: 'Rest',
+        duration: 'not-a-duration',
+        status: 'completed',
+      },
+    ];
+
+    const fetchMock = stubFetch();
+    const { body } = await sendAndReadBody(fetchMock);
+
+    expect(body.context).toContain('2026-08-20: Erg 45min sRPE 5');
+    expect(body.context).toContain('2026-08-19: Bike 64min sRPE 4');
+    expect(body.context).toContain('2026-08-18: Row 57min');
+    expect(body.context).toContain('2026-08-17: Rest');
+    expect(body.context).not.toContain('45:00min');
+    expect(body.context).not.toContain('1h4mmin');
+    expect(body.context).not.toContain('NaN');
+  });
+
+  it('leaves cancelled and planned rows out of recent sessions', async () => {
+    sessionRows = [
+      {
+        date: '8/20/26',
+        type: 'Ghost Row',
+        duration: 60,
+        srpe: 5,
+        status: 'cancelled',
+      },
+      {
+        date: '8/19/26',
+        type: 'Future Row',
+        duration: 60,
+        srpe: 5,
+        status: 'planned',
+      },
+      {
+        date: '8/18/26',
+        type: 'Z2 Aerobic',
+        duration: 60,
+        srpe: 4,
+        status: 'completed',
+      },
+    ];
+
+    const fetchMock = stubFetch();
+    const { body } = await sendAndReadBody(fetchMock);
+
+    expect(body.context).toContain('2026-08-18: Z2 Aerobic');
+    expect(body.context).not.toContain('Ghost Row');
+    expect(body.context).not.toContain('Future Row');
+  });
+
+  it('caps recent sessions at one microcycle', async () => {
+    sessionRows = Array.from({ length: 20 }, (_, i) => ({
+      date: `8/${20 - i}/26`,
+      type: `Session${i}`,
+      duration: 30,
+      srpe: 5,
+      status: 'completed',
+    }));
+
+    const fetchMock = stubFetch();
+    const { body } = await sendAndReadBody(fetchMock);
+
+    const listed = body.context
+      .split('\n')
+      .filter((l) => /^ {2}\d{4}-/.test(l));
+    expect(listed).toHaveLength(8);
+    expect(body.context).toContain('Session0');
+    expect(body.context).toContain('Session7');
+    expect(body.context).not.toContain('Session8');
+  });
+
+  // The regression this issue is really about: sessions.date is TEXT "M/D/YY",
+  // and the old server-side builder compared it to an ISO day, so today's
+  // prescription could never be found.
+  it("matches today's planned session across the M/D/YY vs ISO boundary", async () => {
+    const iso = todayISO();
+    const [y, m, d] = iso.split('-');
+    const logDate = `${Number(m)}/${Number(d)}/${y.slice(2)}`;
+    sessionRows = [
+      {
+        date: logDate,
+        type: 'Z2 Aerobic',
+        label: '60min easy',
+        status: 'planned',
+      },
+    ];
+
+    const fetchMock = stubFetch();
+    const { body } = await sendAndReadBody(fetchMock);
+
+    expect(body.context).toContain("Today's session: Z2 Aerobic — 60min easy");
+  });
+
+  it('ignores a planned session dated another day', async () => {
+    sessionRows = [
+      { date: '1/2/26', type: 'Z2 Aerobic', label: 'stale', status: 'planned' },
+    ];
+
+    const fetchMock = stubFetch();
+    const { body } = await sendAndReadBody(fetchMock);
+
+    expect(body.context).not.toContain("Today's session:");
+  });
+
+  it('still sends a well-formed request when every source is empty', async () => {
+    const fetchMock = stubFetch();
+    const { body } = await sendAndReadBody(fetchMock);
+
+    expect(body.context).toContain('CURRENT TRAINING DATA');
+    expect(body.context).not.toContain('TSB:');
+    expect(body.context).not.toContain('Readiness:');
+    expect(body.context).not.toContain('Recent sessions');
+    expect(body.context).not.toContain('undefined');
+    expect(body.context).not.toContain('NaN');
+  });
+});

--- a/web/src/hooks/useCoach.js
+++ b/web/src/hooks/useCoach.js
@@ -5,7 +5,10 @@ import { useTSSHistory } from './useTSSHistory.js';
 import { useVitals } from './useVitals.js';
 import { useSessions } from './useSessions.js';
 import { calcTrainingLoad } from '../utils/trainingLoad.js';
-import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+import {
+  COMPLETED_STATUSES,
+  PLANNED_STATUS,
+} from '../constants/sessionStatus.js';
 import { toISODate, toLogDate } from '../utils/dateFormat.js';
 import { parseDurationMinutes } from '../utils/duration.js';
 
@@ -124,8 +127,9 @@ export function useCoach() {
       // Both sides through toISODate: sessions.date is TEXT "M/D/YY", so
       // comparing it to an ISO day directly never matches.
       todayPlanned:
-        rows.find((s) => s.status === 'planned' && toISODate(s.date) === iso) ??
-        null,
+        rows.find(
+          (s) => s.status === PLANNED_STATUS && toISODate(s.date) === iso
+        ) ?? null,
     };
   }, [sessionsQuery.data]);
 

--- a/web/src/hooks/useCoach.js
+++ b/web/src/hooks/useCoach.js
@@ -33,7 +33,8 @@ export function buildTrainingContext(
   readinessScore,
   readinessLabel,
   recentSessions,
-  todayPlanned
+  todayPlanned,
+  readinessPartial = false
 ) {
   const today = todayISO();
   const lines = [`CURRENT TRAINING DATA (as of ${today}):`];
@@ -55,9 +56,20 @@ export function buildTrainingContext(
     const rhr = latestVitals.rhr != null ? latestVitals.rhr : '—';
     const hrv = latestVitals.hrv != null ? latestVitals.hrv : '—';
     const sleep = latestVitals.sleep != null ? latestVitals.sleep : '—';
-    lines.push(
-      `Readiness: ${readinessScore}/100 ${readinessLabel} | RHR: ${rhr} | HRV: ${hrv}ms | Sleep: ${sleep}h`
-    );
+    // computeReadiness returns a null score with status NO DATA when there is
+    // no RHR to score (#218). Interpolating that reads "null/100", and the
+    // whole point of that change was that absent data must not reach the Coach
+    // dressed as a verdict — the old code scored a missing row 0 FATIGUED and
+    // it was believed. Report the raw vitals and say the score is missing.
+    // `partial` marks a score computed without HRV or sleep; the Coach is told
+    // so it can weight the number accordingly rather than treat it as complete.
+    const verdict =
+      readinessScore == null
+        ? `Readiness: unavailable (${readinessLabel})`
+        : `Readiness: ${readinessScore}/100 ${readinessLabel}${
+            readinessPartial ? ' (partial — scored without HRV or sleep)' : ''
+          }`;
+    lines.push(`${verdict} | RHR: ${rhr} | HRV: ${hrv}ms | Sleep: ${sleep}h`);
   }
 
   if (todayPlanned) {
@@ -178,7 +190,8 @@ export function useCoach() {
         vitals.readinessScore,
         vitals.readinessLabel,
         recentSessions,
-        todayPlanned
+        todayPlanned,
+        vitals.readiness?.partial ?? false
       );
 
       const {

--- a/web/src/hooks/useCoach.js
+++ b/web/src/hooks/useCoach.js
@@ -36,8 +36,13 @@ export function buildTrainingContext(
   const lines = [`CURRENT TRAINING DATA (as of ${today}):`];
 
   if (latestLoad) {
+    // Boundaries match the dashboard's own bands (App.jsx, MobileAnalytics,
+    // LoadTooltip) so the Coach and the screen never disagree about the same
+    // number. They are classic-TSS values — #208 rescaled sessionLoad from
+    // sRPE-hours, and the old GREEN cut of 5 was a pre-rescale figure that
+    // would now read "fresh" over most of the dashboard's neutral band.
     const tsbSignal =
-      latestLoad.tsb > 5 ? 'GREEN' : latestLoad.tsb > -10 ? 'AMBER' : 'RED';
+      latestLoad.tsb > 10 ? 'GREEN' : latestLoad.tsb > -10 ? 'AMBER' : 'RED';
     lines.push(
       `TSB: ${latestLoad.tsb} (${tsbSignal}) | CTL: ${latestLoad.ctl} | ATL: ${latestLoad.atl}`
     );

--- a/web/src/hooks/useCoach.js
+++ b/web/src/hooks/useCoach.js
@@ -1,8 +1,28 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
 import { useTSSHistory } from './useTSSHistory.js';
 import { useVitals } from './useVitals.js';
+import { useSessions } from './useSessions.js';
+import { calcTrainingLoad } from '../utils/trainingLoad.js';
+import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+import { toISODate, toLogDate } from '../utils/dateFormat.js';
+import { parseDurationMinutes } from '../utils/duration.js';
+
+// One microcycle, with room for the two-a-day Wednesday — a training week runs
+// to more than seven rows. The questions this context serves ("how's my
+// training load looking", "is it safe to add intensity today") are answered by
+// that window; the rest of useSessions' 50 is history CTL/ATL already
+// compresses, costing prompt tokens without changing the answer.
+const RECENT_SESSION_COUNT = 8;
+
+// The local calendar day, not the UTC one. Perth is UTC+8, so
+// toISOString() names yesterday for the whole Perth morning — exactly when
+// readiness is checked and today's session asked about. toLogDate reads local
+// date fields; toISODate converts its M/D/YY back to ISO.
+export function todayISO() {
+  return toISODate(toLogDate(new Date()));
+}
 
 export function buildTrainingContext(
   latestLoad,
@@ -12,7 +32,7 @@ export function buildTrainingContext(
   recentSessions,
   todayPlanned
 ) {
-  const today = new Date().toISOString().split('T')[0];
+  const today = todayISO();
   const lines = [`CURRENT TRAINING DATA (as of ${today}):`];
 
   if (latestLoad) {
@@ -40,9 +60,14 @@ export function buildTrainingContext(
   if (recentSessions?.length) {
     lines.push('Recent sessions (newest first):');
     recentSessions.forEach((s) => {
-      const dur = s.duration ? ` ${s.duration}min` : '';
+      // sessions.duration is free text — "45:00", "60min", "1h4m" — so it has
+      // to be parsed, not interpolated, or the prompt reads "45:00min".
+      const mins = parseDurationMinutes(s.duration);
+      const dur = mins > 0 ? ` ${Math.round(mins)}min` : '';
       const rpe = s.srpe ? ` sRPE ${s.srpe}` : '';
-      lines.push(`  ${s.date}: ${s.type}${dur}${rpe}`);
+      // ISO to match the header line: sessions.date is TEXT "M/D/YY", and
+      // day/month order is ambiguous to a reader that isn't told which it is.
+      lines.push(`  ${toISODate(s.date) || s.date}: ${s.type}${dur}${rpe}`);
     });
   }
 
@@ -77,6 +102,27 @@ export function useCoach() {
 
   const tssQuery = useTSSHistory();
   const vitals = useVitals();
+  const sessionsQuery = useSessions();
+
+  const latestLoad = useMemo(() => {
+    const series = calcTrainingLoad(tssQuery.data ?? []);
+    return series[series.length - 1] ?? null;
+  }, [tssQuery.data]);
+
+  const { recentSessions, todayPlanned } = useMemo(() => {
+    const rows = sessionsQuery.data ?? [];
+    const iso = todayISO();
+    return {
+      recentSessions: rows
+        .filter((s) => COMPLETED_STATUSES.includes(s.status))
+        .slice(0, RECENT_SESSION_COUNT),
+      // Both sides through toISODate: sessions.date is TEXT "M/D/YY", so
+      // comparing it to an ISO day directly never matches.
+      todayPlanned:
+        rows.find((s) => s.status === 'planned' && toISODate(s.date) === iso) ??
+        null,
+    };
+  }, [sessionsQuery.data]);
 
   const setModel = (m) => {
     setModelState(m);
@@ -113,6 +159,19 @@ export function useCoach() {
         .slice(-10)
         .map((m) => ({ role: m.role, content: m.content }));
 
+      // Assembled here, not in the edge function: every input is already
+      // derived by tested client utilities (sessionLoad's power fallback,
+      // COMPLETED_STATUSES, computeReadiness, the live CP/FTP anchors), and
+      // rebuilding that in Deno is what left the Coach contextless.
+      const context = buildTrainingContext(
+        latestLoad,
+        vitals.latest,
+        vitals.readinessScore,
+        vitals.readinessLabel,
+        recentSessions,
+        todayPlanned
+      );
+
       const {
         data: { session },
       } = await supabase.auth.getSession();
@@ -124,7 +183,7 @@ export function useCoach() {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${session.access_token}`,
         },
-        body: JSON.stringify({ messages: apiMessages, model }),
+        body: JSON.stringify({ messages: apiMessages, model, context }),
       });
 
       if (!res.ok) {
@@ -228,6 +287,6 @@ export function useCoach() {
     sendMessage,
     clearHistory,
     vitals,
-    tssQuery,
+    latestLoad,
   };
 }

--- a/web/src/views/CoachView.jsx
+++ b/web/src/views/CoachView.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
 import { useCoach } from '../hooks/useCoach.js';
-import { calcTrainingLoad } from '../utils/trainingLoad.js';
 import { THEME } from '../constants/theme.js';
 
 const C = {
@@ -57,15 +56,11 @@ export default function CoachView() {
     sendMessage,
     clearHistory,
     vitals,
-    tssQuery,
+    latestLoad,
   } = useCoach();
   const [input, setInput] = useState('');
   const bottomRef = useRef(null);
   const textareaRef = useRef(null);
-
-  const tssData = tssQuery.data ?? [];
-  const loadData = tssData.length ? calcTrainingLoad(tssData) : [];
-  const latestLoad = loadData[loadData.length - 1] ?? null;
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });

--- a/web/src/views/__tests__/CoachView.test.jsx
+++ b/web/src/views/__tests__/CoachView.test.jsx
@@ -22,15 +22,11 @@ const mockCoachState = {
   sendMessage: mockSendMessage,
   clearHistory: mockClearHistory,
   vitals: { latest: null, readinessScore: 0, readinessLabel: 'FATIGUED' },
-  tssQuery: { data: [] },
+  latestLoad: null,
 };
 
 vi.mock('../../hooks/useCoach.js', () => ({
   useCoach: () => mockCoachState,
-}));
-
-vi.mock('../../utils/trainingLoad.js', () => ({
-  calcTrainingLoad: () => [],
 }));
 
 import CoachView from '../CoachView.jsx';
@@ -44,6 +40,8 @@ function resetCoachState(overrides = {}) {
       isStreaming: false,
       error: null,
       model: 'sonnet',
+      latestLoad: null,
+      vitals: { latest: null, readinessScore: 0, readinessLabel: 'FATIGUED' },
     },
     overrides
   );
@@ -55,6 +53,19 @@ beforeEach(() => {
 });
 
 describe('CoachView', () => {
+  // The only behaviour that moved when latestLoad stopped being derived here
+  // and started arriving from useCoach (#199).
+  it('renders the load and readiness badge from the hook', () => {
+    resetCoachState({
+      latestLoad: { tsb: -8.2, ctl: 34.1, atl: 42.3 },
+      vitals: { latest: {}, readinessScore: 68, readinessLabel: 'CAUTION' },
+    });
+    render(<CoachView />);
+    expect(screen.getByText(/TSB -8\.2/)).toBeTruthy();
+    expect(screen.getByText(/CTL 34\.1/)).toBeTruthy();
+    expect(screen.getByText(/Readiness 68 CAUTION/)).toBeTruthy();
+  });
+
   it('renders starter prompt chips when messages is empty', () => {
     render(<CoachView />);
     expect(screen.getByText("How's my training load looking?")).toBeTruthy();

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -99,12 +99,13 @@ export default defineConfig({
       //   measured: lines 48.98 / functions 46.81 / branches 40.38
       thresholds: {
         // Global floor — ratcheted up as extractions land tests (measured
-        // lines 79.92 / functions 77.47 / branches 74.49 on 2026-08-21, after
-        // the sessions date_iso ordering fix (#187) added the first
-        // useSessions.js tests; ~4 points headroom for denominator drift).
-        lines: 75,
-        functions: 73,
-        branches: 70,
+        // lines 84.31 / functions 79.33 / branches 76.31 on 2026-08-22, after
+        // wiring the Coach training context (#199) put useCoach.sendMessage
+        // under test for the first time; ~4 points headroom for denominator
+        // drift).
+        lines: 80,
+        functions: 75,
+        branches: 72,
         // Commercial-baseline gate (80/80/70) for new/extracted code, applied
         // per-file as it lands. The global floor above ratchets toward this as
         // the monolith is decomposed and its exclusions fall away.
@@ -132,6 +133,7 @@ export default defineConfig({
           branches: 70,
         },
         'src/hooks/useSessions.js': { lines: 80, functions: 80, branches: 70 },
+        'src/hooks/useCoach.js': { lines: 80, functions: 80, branches: 70 },
         'src/hooks/useTSSHistory.js': {
           lines: 80,
           functions: 80,


### PR DESCRIPTION
Closes #199

## What changed and why

`buildTrainingContext` is now called by `useCoach` and posted to `coach-chat`, and the edge function's own ~90-line `buildContext` is deleted rather than repaired.

### The diagnosis in #199 was incomplete

The issue is right that the Coach gets no context, but the client-side dead code is only half of it. `coach-chat` has its **own** `buildContext` that runs on every request — and all four of its sections are broken against the real schema, so it returns the literal string `CURRENT TRAINING DATA (as of 2026-08-22):` and nothing else. Verified against production (`swdrueaserjzhuxnzmeu`, deployed v9):

| Section | Why it never renders |
|---|---|
| `TSB / CTL / ATL` | Filters `.eq('status','logged')` — **zero** of the 92 session rows have that status (35 `actual`, 23 `completed`, 32 `cancelled`, 2 `planned`). Even with rows it would read 0: `tssMap` is keyed by the TEXT `M/D/YY` date while the accumulator loop looks up ISO keys. |
| `Readiness / RHR / HRV / Sleep` | Selects `date, rhr, hrv, sleep` from `vitals`. Those columns **do not exist** — they are `rhr_bpm, hrv_ms, sleep_hours`. PostgREST 400s, and `const [{ data: vitalsRows }] = await Promise.all(...)` destructures only `data` and never checks `error`, so the failure is silent. |
| `Today's session` | Compares `s.date === today` — TEXT `"8/22/26"` against ISO `"2026-08-22"`. |
| `Recent sessions` | Same absent `'logged'` status, over a top-10 ordered by the lexically-sorting TEXT `date` (the #187 bug). |

### Why the client owns it now

Every one of those calculations already exists on the client, correct and under test: `sessionLoad`'s power fallback (#202), `calcTrainingLoad`, `COMPLETED_STATUSES`, `computeReadiness`, the live CP/FTP anchors, and `useSessions`' `date_iso` ordering (#187). Repairing the Deno copy would have been a third implementation of the same maths in a file with no tests and outside the coverage gate — which is exactly how it rotted unnoticed. `coach-chat` is now a thin Anthropic proxy holding no data logic.

### Bugs fixed in the builder itself

Three defects survived only because the existing tests fed synthetic data:

- **`sessions.duration` is free text** (`"45:00"`, `"60min"`, `"1h4m"`), so `` `${s.duration}min` `` rendered `45:00min`. Now parsed via the existing `parseDurationMinutes`.
- **Recent-session dates printed raw `M/D/YY`** next to an ISO header, leaving day/month order ambiguous to the model. Both are ISO now.
- **The header date came from `toISOString()`**, i.e. UTC — which names *yesterday* for the whole Perth morning, precisely when readiness is checked and today's session asked about. Reads local calendar fields now, matching `toLogDate`'s documented rationale.

### Decisions taken (with Scott, before any code)

- **`recentSessions`**: `COMPLETED_STATUSES` only, capped at 8 — a training week's worth of rows. The filter matters most for `cancelled`, which would otherwise dominate the list at 32 rows.
- **`todayPlanned`**: matched with `toISODate` on both sides.
- **Scope**: wiring only. Driving the prompt off live state is #209.

## How to test manually

Open the Coach tab and ask "How's my training load looking?" — the reply should quote real CTL/ATL/TSB and name recent sessions rather than giving generic advice. Cross-check the numbers against the Analytics tab. In devtools, the `coach-chat` request body should carry a populated `context`.

**Deploy note:** the edge function is a separate manual step and is *not* done by merging. Ordering does not matter — an old cached PWA bundle against the new function sends no context and gets the base prompt; the new bundle against the old function has its context ignored. Both degrade to today's behaviour, neither errors.

Worth noting: the deployed v9 was pushed as a bare single file and has never matched the repo copy (it used the service-role key + an explicit `user_id` filter). That drift disappears with `buildContext`, and this deploy makes the repo the source of truth for the first time. There is no CI check for edge-function drift — filed as #210.

## Correction to an earlier version of this description

An earlier revision said the prompt's `Current phase: Base (Jun–Aug 2026)` "expires in 9 days". That was wrong. Checking the live `anchors` table shows it was **already superseded on 2026-08-20** — `current_phase` is now `maintenance`, confirmed, with the note *"Health and consistency only — no progression targets, no adherence measurement."* The drift is live, not pending, and it is broader than the CP number: phase, block, intensity rules, TID model and progression cadence in `COACH_SYSTEM_PROMPT` all contradict the anchors. That is now tracked as **#209**, which also gives the Coach the `coach_log` decision history so it knows *why* things changed.

This matters for sequencing: once this PR merges and the function deploys, the Coach starts receiving real data against a frozen doctrine — making it more confidently wrong, not less. #209 should follow closely.

## Checklist

- [x] CI is green (lint, test, build) — 587 tests pass, 0 lint errors, Prettier clean, build succeeds
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [ ] No unexpected console errors in the browser — needs the preview deploy

**Test coverage:** new `useCoachWiring.test.js` (8 cases) asserts the context actually reaches the `fetch` body — the issue's explicit requirement — plus status filtering, the 8-row cap, free-text duration parsing, and the `M/D/YY`-vs-ISO `todayPlanned` match as a direct regression test. It is a separate file from `useCoach.test.js` because that one mocks `@tanstack/react-query` wholesale and `vi.mock` is hoisted and file-scoped. Two `todayISO` cases pin the local-vs-UTC day under a faked Perth clock. `CoachView` gains its first badge test.

**Coverage gate:** `useCoach.js` measures 83.47 lines / 82.35 functions / 74.68 branches and takes the standard 80/80/70 per-file gate. Global floor ratchets 75/73/70 → 80/75/72.

**Accepted gap:** the edge function has no tests — there is no Deno harness in this repo and adding one is out of scope. After this change the only logic left in it is trim/truncate/concat; everything that can be wrong now lives in `useCoach.js` under the coverage gate.