### PR TITLE
fix: stop counting cancelled sessions as completed training

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -176,8 +176,13 @@ export default function App() {
   const isMid = vw >= 600; // tablet
   const containerMax = isWide ? 1100 : 680;
 
-  const { loggedSessions, plannedSessions, loggedKeys, fetchSessions } =
-    useSessionLog();
+  const {
+    loggedSessions,
+    logDisplaySessions,
+    plannedSessions,
+    loggedKeys,
+    fetchSessions,
+  } = useSessionLog();
 
   // Live CTL/ATL/TSB. Previously calcTrainingLoad(DAILY_TSS) — a static seed
   // that stopped on 2026-06-13, so every headline load number on desktop was
@@ -421,7 +426,7 @@ export default function App() {
           {/* ── LOG VIEW ── */}
           {view === 'log' && (
             <LogView
-              loggedSessions={loggedSessions}
+              logDisplaySessions={logDisplaySessions}
               isWide={isWide}
               onSaved={fetchSessions}
             />

--- a/web/src/__tests__/App.test.jsx
+++ b/web/src/__tests__/App.test.jsx
@@ -52,6 +52,21 @@ const rows = [
     avg_hr: null,
   },
   {
+    id: 'cancel-1',
+    date: '7/5/26',
+    type: 'erg',
+    label: 'CP RETEST — 1min + 4min max (rested, fed)',
+    duration: 1800,
+    srpe: null,
+    prs: null,
+    exercises: null,
+    coach_note: null,
+    status: 'cancelled',
+    distance_m: null,
+    avg_watts: null,
+    avg_hr: null,
+  },
+  {
     id: 'test-1',
     date: '7/1/26',
     type: 'Test',
@@ -107,12 +122,14 @@ vi.mock('../views/MobilityView.jsx', () => ({
 // Surfaces the load props so a test can assert what App derived and passed
 // down, rather than reaching into OverviewView's own rendering.
 vi.mock('../views/OverviewView.jsx', () => ({
-  default: ({ latest, loadUnavailable }) => (
+  default: ({ latest, loadUnavailable, loggedSessions, totalSessions }) => (
     <div>
       OverviewView-stub
       <span data-testid="ctl">{latest ? latest.ctl : 'none'}</span>
       <span data-testid="tsb">{latest ? latest.tsb : 'none'}</span>
       <span data-testid="unavailable">{String(loadUnavailable)}</span>
+      <span data-testid="overview-counted">{loggedSessions?.length}</span>
+      <span data-testid="overview-total">{totalSessions}</span>
     </div>
   ),
 }));
@@ -120,13 +137,23 @@ vi.mock('../views/ProgramView.jsx', () => ({
   default: () => <div>ProgramView-stub</div>,
 }));
 vi.mock('../views/CalendarView.jsx', () => ({
-  default: () => <div>CalendarView-stub</div>,
+  default: (props) => (
+    <div>
+      <div>CalendarView-stub</div>
+      <div data-testid="calendar-counted">{props.loggedSessions?.length}</div>
+    </div>
+  ),
 }));
 vi.mock('../views/PlanView.jsx', () => ({
   default: () => <div>PlanView-stub</div>,
 }));
 vi.mock('../views/LogView.jsx', () => ({
-  default: () => <div>LogView-stub</div>,
+  default: (props) => (
+    <div>
+      <div>LogView-stub</div>
+      <div data-testid="logview-shown">{props.logDisplaySessions?.length}</div>
+    </div>
+  ),
 }));
 
 // App reads CTL/ATL/TSB through useTSSHistory (react-query + supabase). Mock it
@@ -229,6 +256,24 @@ describe('App', () => {
 
     expect(screen.getByTestId('ctl').textContent).toBe('none');
     expect(screen.getByTestId('unavailable').textContent).toBe('false');
+  }, 30000);
+
+  it('R9 wires the shown list to LogView and the counted list to every counting consumer (#194)', async () => {
+    // The regression this guards is a prop swap, not a filter bug: the hook can
+    // be perfectly correct while App hands the wrong list to the wrong view.
+    // Fixture: erg-1 logged + str-1 completed = 2 counted; + cancel-1 = 3 shown;
+    // cyc-1 planned and test-1 (type 'Test') are excluded from both.
+    render(<App />);
+    await screen.findByText('OverviewView-stub');
+
+    expect(screen.getByTestId('overview-counted')).toHaveTextContent('2');
+    expect(screen.getByTestId('overview-total')).toHaveTextContent('2');
+
+    fireEvent.click(screen.getByRole('button', { name: 'CALENDAR' }));
+    expect(screen.getByTestId('calendar-counted')).toHaveTextContent('2');
+
+    fireEvent.click(screen.getByRole('button', { name: 'LOG' }));
+    expect(screen.getByTestId('logview-shown')).toHaveTextContent('3');
   }, 30000);
 
   it('updates the responsive layout on window resize', async () => {

--- a/web/src/components/LogEntry.jsx
+++ b/web/src/components/LogEntry.jsx
@@ -7,6 +7,7 @@ export default function LogEntry({ entry, done = false }) {
   const color = C[entry.type] || THEME.grey;
   const isErg = !!entry._isErg;
   const planned = entry.status === 'planned';
+  const cancelled = entry.status === 'cancelled';
   // Flat erg metrics replaced the removed `splits` field. Planned erg rows
   // carry null metrics — we show the prescription (label + coach_note) instead.
   const hasErgMetrics =
@@ -23,11 +24,13 @@ export default function LogEntry({ entry, done = false }) {
         borderTop: `1px solid ${open ? color + '50' : THEME.border}`,
         borderRight: `1px solid ${open ? color + '50' : THEME.border}`,
         borderBottom: `1px solid ${open ? color + '50' : THEME.border}`,
-        borderLeft: `3px ${planned ? 'dashed' : 'solid'} ${color}`,
+        borderLeft: cancelled
+          ? `3px dotted ${THEME.muted}`
+          : `3px ${planned ? 'dashed' : 'solid'} ${color}`,
         borderRadius: 6,
         overflow: 'hidden',
         background: open ? `${color}10` : THEME.raised,
-        opacity: done ? 0.5 : 1,
+        opacity: done || cancelled ? 0.5 : 1,
       }}
     >
       <div
@@ -60,6 +63,7 @@ export default function LogEntry({ entry, done = false }) {
                 fontWeight: 700,
                 color: THEME.white,
                 lineHeight: 1.3,
+                textDecoration: cancelled ? 'line-through' : undefined,
               }}
             >
               {entry.label}
@@ -95,6 +99,23 @@ export default function LogEntry({ entry, done = false }) {
                   }}
                 >
                   PLANNED
+                </span>
+              )}
+              {cancelled && !done && (
+                <span
+                  style={{
+                    marginLeft: 8,
+                    fontSize: 8,
+                    letterSpacing: 1.5,
+                    fontWeight: 700,
+                    color: THEME.muted,
+                    border: `1px solid ${THEME.muted}66`,
+                    borderRadius: 3,
+                    padding: '1px 5px',
+                    verticalAlign: 'middle',
+                  }}
+                >
+                  CANCELLED
                 </span>
               )}
             </div>
@@ -195,7 +216,9 @@ export default function LogEntry({ entry, done = false }) {
               >
                 {planned
                   ? 'Prescription — targets below.'
-                  : 'No metrics logged for this session.'}
+                  : cancelled
+                    ? 'Cancelled — this session was not completed.'
+                    : 'No metrics logged for this session.'}
               </div>
             )
           ) : entry.exercises ? (

--- a/web/src/components/LogEntry.jsx
+++ b/web/src/components/LogEntry.jsx
@@ -30,7 +30,7 @@ export default function LogEntry({ entry, done = false }) {
         borderRadius: 6,
         overflow: 'hidden',
         background: open ? `${color}10` : THEME.raised,
-        opacity: done || cancelled ? 0.5 : 1,
+        opacity: done ? 0.5 : cancelled ? 0.8 : 1,
       }}
     >
       <div
@@ -108,8 +108,8 @@ export default function LogEntry({ entry, done = false }) {
                     fontSize: 8,
                     letterSpacing: 1.5,
                     fontWeight: 700,
-                    color: THEME.muted,
-                    border: `1px solid ${THEME.muted}66`,
+                    color: THEME.textSubtle,
+                    border: `1px solid ${THEME.textSubtle}99`,
                     borderRadius: 3,
                     padding: '1px 5px',
                     verticalAlign: 'middle',
@@ -313,9 +313,11 @@ export default function LogEntry({ entry, done = false }) {
             >
               {planned
                 ? 'Prescription — targets below.'
-                : entry.duration
-                  ? `Session · ${entry.duration}`
-                  : 'Session logged.'}
+                : cancelled
+                  ? 'Cancelled — this session was not completed.'
+                  : entry.duration
+                    ? `Session · ${entry.duration}`
+                    : 'Session logged.'}
             </div>
           )}
           {entry.coachNote && (

--- a/web/src/components/__tests__/LogEntry.test.jsx
+++ b/web/src/components/__tests__/LogEntry.test.jsx
@@ -61,6 +61,26 @@ describe('LogEntry', () => {
     expect(screen.getByText(/Prescription/)).toBeInTheDocument();
   });
 
+  it('AC12 renders a cancelled erg session as cancelled, not as a data gap', () => {
+    const entry = {
+      type: 'erg',
+      _isErg: true,
+      label: 'CP RETEST — 1min + 4min max (rested, fed)',
+      date: '7/5/26',
+      status: 'cancelled',
+    };
+    render(<LogEntry entry={entry} />);
+    expect(screen.getByText('CANCELLED')).toBeInTheDocument();
+    expect(screen.queryByText('PLANNED')).not.toBeInTheDocument();
+    expect(screen.queryByText('✓ DONE')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/CP RETEST/));
+    expect(screen.getByText(/was not completed/)).toBeInTheDocument();
+    expect(
+      screen.queryByText('No metrics logged for this session.')
+    ).not.toBeInTheDocument();
+  });
+
   it('renders a non-erg session with no exercise table', () => {
     const entry = {
       type: 'bike',

--- a/web/src/components/__tests__/LogEntry.test.jsx
+++ b/web/src/components/__tests__/LogEntry.test.jsx
@@ -81,6 +81,27 @@ describe('LogEntry', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('AC12b renders a cancelled NON-erg session as cancelled, not as "Session · <duration>"', () => {
+    // 21 of the 32 live cancelled rows are strength or cycling, all carrying a
+    // duration and no exercises — they render through the !isErg fallback, a
+    // different branch from AC12's. Unpatched it read "Session · 45min" under a
+    // CANCELLED chip: an affirmative claim about a session that did not happen.
+    const entry = {
+      type: 'Lower Strength',
+      label: 'Lower B — RDL-led',
+      date: '7/13/26',
+      duration: '45min',
+      status: 'cancelled',
+    };
+    render(<LogEntry entry={entry} />);
+    expect(screen.getByText('CANCELLED')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/Lower B/));
+    expect(screen.getByText(/was not completed/)).toBeInTheDocument();
+    expect(screen.queryByText('Session · 45min')).not.toBeInTheDocument();
+    expect(screen.queryByText('Session logged.')).not.toBeInTheDocument();
+  });
+
   it('renders a non-erg session with no exercise table', () => {
     const entry = {
       type: 'bike',

--- a/web/src/hooks/__tests__/useSessionLog.test.js
+++ b/web/src/hooks/__tests__/useSessionLog.test.js
@@ -126,3 +126,154 @@ describe('useSessionLog', () => {
     expect(result.current.allSessions[1]._id).toBe(4);
   });
 });
+
+// ── #194: cancelled is SHOWN but not COUNTED ──────────────────────
+// Fixture mirroring the live table's status distribution as of 2026-08-22.
+// Pre-fix, `loggedSessions` measured 90 here (every non-planned row), because
+// the old filter read `status !== 'planned'` — "not planned" meant "done", so
+// the 32 cancelled rows counted as training that never happened.
+const STATUS_DISTRIBUTION = [
+  ['actual', 35],
+  ['completed', 23],
+  ['cancelled', 32],
+  ['planned', 2],
+];
+
+function distributionRows() {
+  const rows = [];
+  let id = 1;
+  for (const [status, n] of STATUS_DISTRIBUTION) {
+    for (let i = 0; i < n; i++) {
+      rows.push({
+        id: id++,
+        date: '7/5/26',
+        type: 'erg',
+        label: `${status} ${i}`,
+        status,
+      });
+    }
+  }
+  return rows;
+}
+
+// The proof case from #194: a real cancelled CP retest.
+const session61 = {
+  id: 61,
+  date: '7/5/26',
+  type: 'erg',
+  label: 'CP RETEST — 1min + 4min max (rested, fed)',
+  status: 'cancelled',
+};
+
+describe('useSessionLog — cancelled is shown but not counted (#194)', () => {
+  it('AC1 keeps cancelled session 61 out of the counted set but in allSessions', async () => {
+    mockQuery([
+      session61,
+      {
+        id: 62,
+        date: '7/6/26',
+        type: 'erg',
+        label: 'UT2 60min',
+        status: 'completed',
+      },
+    ]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    expect(result.current.loggedSessions.some((e) => e._id === 61)).toBe(false);
+    expect(result.current.allSessions.some((e) => e._id === 61)).toBe(true);
+  });
+
+  it('AC2 builds no reconciliation key from a cancelled session', async () => {
+    mockQuery([
+      session61,
+      {
+        id: 62,
+        date: '7/6/26',
+        type: 'erg',
+        label: 'UT2 60min',
+        status: 'completed',
+      },
+    ]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    expect(result.current.loggedKeys.has('7/5/26|Z2 Aerobic')).toBe(false);
+    // Control — proves the assertion above is not passing vacuously.
+    expect(result.current.loggedKeys.has('7/6/26|Z2 Aerobic')).toBe(true);
+  });
+
+  it('AC8 excludes a cancelled row from the counted set no matter what payload it carries', async () => {
+    mockQuery([
+      {
+        id: 70,
+        date: '7/8/26',
+        type: 'strength',
+        label: 'Lower B',
+        status: 'cancelled',
+        srpe: 9,
+        exercises: [{ name: 'Squat' }],
+      },
+    ]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    expect(result.current.loggedSessions).toHaveLength(0);
+    expect(result.current.logDisplaySessions.some((e) => e._id === 70)).toBe(
+      true
+    );
+  });
+
+  it('AC9 counts 58 logged of 90 shown on the live status distribution', async () => {
+    mockQuery(distributionRows());
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    expect(result.current.allSessions).toHaveLength(92);
+    expect(result.current.loggedSessions).toHaveLength(58);
+    expect(result.current.logDisplaySessions).toHaveLength(90);
+    expect(result.current.plannedSessions).toHaveLength(2);
+  });
+
+  it('AC11 shows session 61 in the display list and preserves display order', async () => {
+    const rows = [
+      {
+        id: 60,
+        date: '7/4/26',
+        type: 'erg',
+        label: 'UT2 45min',
+        status: 'actual',
+      },
+      session61,
+      {
+        id: 62,
+        date: '7/6/26',
+        type: 'erg',
+        label: 'AT plan',
+        status: 'planned',
+      },
+      {
+        id: 63,
+        date: '7/7/26',
+        type: 'erg',
+        label: 'UT1 40min',
+        status: 'logged',
+      },
+    ];
+    mockQuery(rows);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    const display = result.current.logDisplaySessions;
+    expect(display.some((e) => e._id === 61)).toBe(true);
+    expect(display.some((e) => e.status === 'planned')).toBe(false);
+    expect(display.map((e) => e._id)).toEqual([60, 61, 63]);
+  });
+
+  it('AC14 differs from the counted set by exactly the cancelled rows', async () => {
+    mockQuery(distributionRows());
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    const counted = new Set(result.current.loggedSessions.map((e) => e._id));
+    const shownOnly = result.current.logDisplaySessions.filter(
+      (e) => !counted.has(e._id)
+    );
+    expect(shownOnly).toHaveLength(32);
+    expect(shownOnly.every((e) => e.status === 'cancelled')).toBe(true);
+  });
+});

--- a/web/src/hooks/useSessionLog.js
+++ b/web/src/hooks/useSessionLog.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../supabaseClient.js';
 import { normType } from '../utils/formatting.js';
+import { isCompletedStatus } from '../utils/sessionStatus.js';
 
 // ── SESSION LOG (add entries here as block progresses) ──────────
 
@@ -62,12 +63,29 @@ export function useSessionLog() {
   // so they go first; the hardcoded seed follows.
   const allSessions = [...dbSessions, ...sessionLog];
 
-  // ── PLANNED vs LOGGED SPLIT (reconciliation) ──────────────────
-  // Planned rows are forward-looking prescriptions and must NOT appear in the
-  // completed Log, the calendar's done-state, recent sessions, or analytics.
-  // null-status legacy rows count as actual/completed history.
-  const loggedSessions = allSessions.filter((e) => e.status !== 'planned');
-  const plannedSessions = allSessions.filter((e) => e.status === 'planned');
+  // ── THREE-WAY SPLIT: counted / shown / planned ────────────────
+  // One list, two questions. `loggedSessions` is the COUNTED set — training
+  // that actually happened — and drives reconciliation, recent sessions and
+  // analytics. `logDisplaySessions` is the SHOWN set — everything with a
+  // record, cancelled included — because a cancelled session is a decision
+  // worth seeing in the Log, just not one worth counting. Planned rows are
+  // forward-looking prescriptions and appear in neither.
+  // loggedKeys derives from the COUNTED set: a cancelled session must never
+  // reconcile a planned prescription as done.
+  // Both lists are built in one pass so the created_at-desc order established
+  // by the query above survives — the display object does not carry created_at,
+  // so a split-and-remerge could not reproduce it.
+  const loggedSessions = [];
+  const logDisplaySessions = [];
+  const plannedSessions = [];
+  for (const e of allSessions) {
+    if (e.status === 'planned') {
+      plannedSessions.push(e);
+      continue;
+    }
+    logDisplaySessions.push(e);
+    if (isCompletedStatus(e.status)) loggedSessions.push(e);
+  }
   // A planned row is reconciled ("done") once an actual exists for the same
   // date + type. v1 matches on normalized type + date (a planned_id link can
   // come later). Keyed off loggedSessions only.
@@ -77,6 +95,7 @@ export function useSessionLog() {
     dbStatus,
     allSessions,
     loggedSessions,
+    logDisplaySessions,
     plannedSessions,
     loggedKeys,
     fetchSessions,

--- a/web/src/utils/__tests__/schedule.test.js
+++ b/web/src/utils/__tests__/schedule.test.js
@@ -110,6 +110,18 @@ describe('dayStatus', () => {
   it('is upcoming for a future day', () => {
     expect(dayStatus(d(2026, 6, 23), todayMidnight, []).state).toBe('upcoming');
   });
+
+  it('AC7 is status-blind BY CONTRACT — a cancelled row still reads done', () => {
+    // Characterization test. dayStatus must never inspect `status`; callers
+    // pass an already-filtered list. If someone adds a redundant second gate
+    // here, this fails loudly — that duplication is what caused #194.
+    const cancelled = [
+      { date: '6/21/26', label: 'CP RETEST', status: 'cancelled' },
+    ];
+    expect(dayStatus(d(2026, 6, 21), todayMidnight, cancelled).state).toBe(
+      'done'
+    );
+  });
 });
 
 describe('getToday', () => {

--- a/web/src/utils/__tests__/sessionStatus.test.js
+++ b/web/src/utils/__tests__/sessionStatus.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { COMPLETED_STATUSES } from '../../constants/sessionStatus.js';
+import { isCompletedStatus } from '../sessionStatus.js';
+
+describe('isCompletedStatus', () => {
+  it('AC3 treats null and undefined as completed (LogSessionForm writes no status)', () => {
+    expect(isCompletedStatus(null)).toBe(true);
+    expect(isCompletedStatus(undefined)).toBe(true);
+  });
+
+  it.each(COMPLETED_STATUSES)('AC4 counts a %s session', (status) => {
+    expect(isCompletedStatus(status)).toBe(true);
+  });
+
+  it('AC5 fails CLOSED on an unknown status — deliberate, not an oversight', () => {
+    // sessions.status has no CHECK constraint, so an unknown sixth value can
+    // appear. Excluding it hides the session loudly rather than counting
+    // phantom training silently.
+    expect(isCompletedStatus('skipped')).toBe(false);
+    expect(isCompletedStatus('')).toBe(false);
+  });
+
+  it('AC6 does not count planned or cancelled', () => {
+    expect(isCompletedStatus('planned')).toBe(false);
+    expect(isCompletedStatus('cancelled')).toBe(false);
+  });
+});

--- a/web/src/utils/schedule.js
+++ b/web/src/utils/schedule.js
@@ -74,6 +74,11 @@ export function resolveDay(date) {
 // A planned day is "done" if the session list has any entry on that date.
 // Takes the session list as a param so it works with the MERGED list
 // (hardcoded seed history + live sessions fetched from Supabase).
+// CONTRACT: logEntriesForDate / dayStatus / getUpcomingSessions are
+// STATUS-BLIND. They never inspect `status` — callers must pass an
+// already-filtered list (useSessionLog's `loggedSessions`). Do not add a
+// status gate here: a second gate in a second layer is exactly the drift
+// that let cancelled sessions count as done (#194).
 export function logEntriesForDate(date, sessions) {
   // session dates are "M/D/YY" (e.g. "6/19/26")
   const key =

--- a/web/src/utils/sessionStatus.js
+++ b/web/src/utils/sessionStatus.js
@@ -1,0 +1,20 @@
+import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+
+// Does this session's status mean "training that actually happened"?
+//
+// null/undefined is admitted, and that branch is LOAD-BEARING — not defensive
+// padding. LogSessionForm.jsx:72-81 inserts a session without naming a `status`
+// field at all, so every session Scott saves through the app's own "Log Session"
+// form lands with status NULL. A pure COMPLETED_STATUSES.includes() check would
+// make those sessions vanish the instant they were saved.
+//
+// Everything else is an allow-list, not an exclude-list. There is no CHECK
+// constraint on sessions.status, so an unknown sixth value can appear at any
+// time; failing closed hides it loudly (Scott looks for a session and it is
+// missing) rather than counting phantom training silently. It also matches
+// useTSSHistory.js:17, which already excludes unknown statuses server-side via
+// .in('status', COMPLETED_STATUSES).
+export function isCompletedStatus(status) {
+  if (status == null) return true;
+  return COMPLETED_STATUSES.includes(status);
+}

--- a/web/src/views/LogView.jsx
+++ b/web/src/views/LogView.jsx
@@ -3,7 +3,7 @@ import LogEntry from '../components/LogEntry.jsx';
 import { SRPE_GUIDE } from '../constants/trainingConfig.js';
 
 // ── LOG VIEW (session log form + sRPE reference + logged history) ──
-export default function LogView({ loggedSessions, isWide, onSaved }) {
+export default function LogView({ logDisplaySessions, isWide, onSaved }) {
   return (
     <>
       <div
@@ -109,7 +109,7 @@ export default function LogView({ loggedSessions, isWide, onSaved }) {
           alignItems: isWide ? 'start' : undefined,
         }}
       >
-        {loggedSessions.map((entry, i) => (
+        {logDisplaySessions.map((entry, i) => (
           <LogEntry key={`${entry.date}-${entry.label}-${i}`} entry={entry} />
         ))}
       </div>

--- a/web/src/views/__tests__/LogView.test.jsx
+++ b/web/src/views/__tests__/LogView.test.jsx
@@ -24,12 +24,12 @@ function renderWithClient(ui) {
 
 describe('LogView', () => {
   it('renders the session-log intro, sRPE reference, and logged entries', () => {
-    const loggedSessions = [
+    const logDisplaySessions = [
       { type: 'strength', label: 'Upper A', date: '6/9' },
     ];
     renderWithClient(
       <LogView
-        loggedSessions={loggedSessions}
+        logDisplaySessions={logDisplaySessions}
         isWide={false}
         onSaved={vi.fn()}
       />
@@ -37,5 +37,28 @@ describe('LogView', () => {
     expect(screen.getByText(/SESSION LOG:/i)).toBeInTheDocument();
     expect(screen.getByText(/sRPE SCALE/i)).toBeInTheDocument();
     expect(screen.getByText('Upper A')).toBeInTheDocument();
+  });
+
+  it('AC13 renders every display entry, cancelled included', () => {
+    const logDisplaySessions = [
+      { type: 'strength', label: 'Upper A', date: '6/9', status: 'completed' },
+      {
+        type: 'erg',
+        _isErg: true,
+        label: 'CP RETEST — 1min + 4min max (rested, fed)',
+        date: '7/5/26',
+        status: 'cancelled',
+      },
+    ];
+    renderWithClient(
+      <LogView
+        logDisplaySessions={logDisplaySessions}
+        isWide={false}
+        onSaved={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Upper A')).toBeInTheDocument();
+    expect(screen.getByText(/CP RETEST/)).toBeInTheDocument();
+    expect(screen.getByText('CANCELLED')).toBeInTheDocument();
   });
 });

--- a/web/src/views/__tests__/PlanView.test.jsx
+++ b/web/src/views/__tests__/PlanView.test.jsx
@@ -31,4 +31,31 @@ describe('PlanView', () => {
     ).not.toBeInTheDocument();
     expect(screen.getByText('UT2 60min')).toBeInTheDocument();
   });
+
+  it('AC10 does not mark a planned session done when only a cancelled row exists', () => {
+    // The hook's loggedKeys is built from the COUNTED set, so a cancelled
+    // session contributes no key — the prescription stays outstanding.
+    const plannedSessions = [
+      { type: 'erg', label: 'UT2 60min', date: '12/31/99', status: 'planned' },
+    ];
+    const { unmount } = render(
+      <PlanView
+        plannedSessions={plannedSessions}
+        loggedKeys={new Set()}
+        isWide={false}
+      />
+    );
+    expect(screen.queryByText('✓ DONE')).not.toBeInTheDocument();
+    unmount();
+
+    // Contrast case — with the key present the card marks done.
+    render(
+      <PlanView
+        plannedSessions={plannedSessions}
+        loggedKeys={new Set(['12/31/99|erg'])}
+        isWide={false}
+      />
+    );
+    expect(screen.getByText('✓ DONE')).toBeInTheDocument();
+  });
 });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -132,6 +132,11 @@ export default defineConfig({
           functions: 80,
           branches: 70,
         },
+        'src/utils/sessionStatus.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
         'src/hooks/useSessions.js': { lines: 80, functions: 80, branches: 70 },
         'src/hooks/useCoach.js': { lines: 80, functions: 80, branches: 70 },
         'src/hooks/useTSSHistory.js': {


### PR DESCRIPTION
Closes #194

## What changed and why

`useSessionLog` filtered on `status !== 'planned'`, so "not planned" meant "done" and all 32 `cancelled` rows counted as training that did not happen — a third of the visible log. The hook now returns two lists: `loggedSessions` (counted, 58) and `logDisplaySessions` (shown, 90), so cancelled sessions stay visible in the Log, clearly marked, without inflating any count.

### Before / after

The pre-fix number was measured, not transcribed: the count test was written first and run against the unmodified hook, failing with *"expected … to have a length of 58 but got 90"*.

| Quantity | Before | After |
|---|---|---|
| `SESSIONS LOGGED` tile | 90 | **58** |
| Log tab entry count | 90 | **90** — 32 now marked `CANCELLED` |
| Session 61 counted as a completed CP retest | yes | **no** |
| Session 61 visible in the Log | yes | **yes, marked** |
| `plannedSessions` / `allSessions` | 2 / 92 | 2 / 92 |
| `strengthSessions` / `latestErg` | 27 / 98 | 27 / 98 |

No rows are deleted; all 92 remain in `sessions` and in `allSessions`.

### Design decisions

**Cancelled is shown, not hidden.** Skipping a prescription to do something else is normal, and the record should say so — session 61's cancellation going unnoticed for a month is the argument against silence.

**The predicate is an allow-list that fails closed.** New `utils/sessionStatus.js` exports `isCompletedStatus()`: true for `null`/`undefined` and for `COMPLETED_STATUSES`, false otherwise. `sessions.status` has no CHECK constraint, so an unknown sixth value could appear; excluding it makes the session go missing loudly rather than counting phantom training silently. This matches `useTSSHistory.js:17`, which already excludes unknown statuses server-side.

**The `null` branch is load-bearing.** `LogSessionForm.jsx:72-81` inserts without a `status` field, so sessions logged through the app's own form land `NULL`. A literal `COMPLETED_STATUSES.includes()` swap would make them vanish the instant they were saved. Fixing that write path is a follow-up, not this PR.

**`utils/schedule.js` stays status-blind** — comment only. All three of its callers already receive the hook's filtered output, so a second status gate there would be the same drift that caused this bug. A characterization test pins the contract.

### Review fixes (second commit)

- `LogEntry` had **two** "no detail" fallbacks; only the erg one was patched. 21 of the 32 cancelled rows are strength or cycling and rendered `Session · 45min` beneath a `CANCELLED` chip.
- Cancelled shared `done`'s `0.5` opacity — `PlanView` uses `done` for a *satisfied* prescription, so "didn't happen" and "handled" looked identical, and the dimming dropped the chip to ~1.8:1 contrast. Now `0.8`, chip in `THEME.textSubtle` (not a hue — every colour in the `C` map is already a session type).
- Added the missing `App.jsx` prop-wiring test. The hook can be correct while `App` hands the wrong list to the wrong view.

## How to test manually

Covered by CI. Note the calendar will look unchanged — it windows today−3 → today+14 and every cancelled row is dated 23 Jun – 20 Jul, so none currently render. That is expected, not a failed fix.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

Suite is **688 tests across 56 files**, all passing, with coverage exiting 0 (83.84% statements) and `sessionStatus.js` at 100%. Most of that total predates this PR — it adds 16 acceptance criteria (AC1–AC14 plus AC12b and the wiring test); the rest arrived with rebases. Both new regression tests were verified to fail against the unfixed code.

Rebased three times while open, onto `d15d334`, `c6d8ab0` and `ca869ec`. The second rebase conflicted in `vite.config.js` (#212 added a coverage-threshold entry at the same position) and `App.test.jsx` (main had independently converted the `OverviewView` stub to surface props); both were resolved by keeping both sides. All gates were re-run locally after each rebase before pushing.

### Follow-ups to file

`LogSessionForm` writes no `status`, so manual sessions are also invisible to CTL/ATL/TSB · no CHECK constraint on `sessions.status` · calendar days that are both done and cancelled (7 such dates exist) · `useSessionLog` orders by `created_at`, not `date_iso`.