### PR TITLE
fix: make all three session-insert paths invalidate the same queries (#195)

### DIFF
--- a/web/src/components/LogSessionForm.jsx
+++ b/web/src/components/LogSessionForm.jsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
 import { THEME } from '../constants/theme.js';
 import { toLogDate } from '../utils/dateFormat.js';
+import { invalidateSessionQueries } from '../utils/invalidateSessionQueries.js';
 
 export default function LogSessionForm({ onSaved }) {
   const queryClient = useQueryClient();
@@ -82,7 +83,7 @@ export default function LogSessionForm({ onSaved }) {
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      invalidateSessionQueries(queryClient);
       setMsg({ type: 'ok', text: 'Saved! Session added to your log.' });
       reset();
       if (onSaved) onSaved();

--- a/web/src/components/__tests__/LogSessionForm.test.jsx
+++ b/web/src/components/__tests__/LogSessionForm.test.jsx
@@ -83,6 +83,8 @@ describe('LogSessionForm', () => {
 
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['erg-sessions'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tss-history'] });
     expect(onSaved).toHaveBeenCalledTimes(1);
 
     const row = insertMock.mock.calls[0][0];

--- a/web/src/hooks/__tests__/useOfflineQueue.test.js
+++ b/web/src/hooks/__tests__/useOfflineQueue.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
 
 // Mock the supabase client before importing the hook under test.
 const insertMock = vi.fn();
@@ -19,6 +21,18 @@ import {
 } from '../useOfflineQueue';
 
 const QUEUE_KEY = 'erg_pending_sessions';
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function makeWrapper(client) {
+  return function Wrapper({ children }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
 
 beforeEach(async () => {
   // drainQueue holds a module-level in-flight guard; let any drain started by
@@ -40,7 +54,9 @@ describe('useOfflineQueue drainQueue user_id backfill', () => {
     getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
     enqueueSession({ date: '2026-06-25', type: 'erg', label: 'Test' });
 
-    renderHook(() => useOfflineQueue());
+    renderHook(() => useOfflineQueue(), {
+      wrapper: makeWrapper(makeClient()),
+    });
 
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     const row = insertMock.mock.calls[0][0];
@@ -59,7 +75,9 @@ describe('useOfflineQueue drainQueue user_id backfill', () => {
       user_id: 'original-owner',
     });
 
-    renderHook(() => useOfflineQueue());
+    renderHook(() => useOfflineQueue(), {
+      wrapper: makeWrapper(makeClient()),
+    });
 
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     expect(insertMock.mock.calls[0][0].user_id).toBe('original-owner');
@@ -69,7 +87,9 @@ describe('useOfflineQueue drainQueue user_id backfill', () => {
     getUserMock.mockResolvedValue({ data: { user: null } });
     enqueueSession({ date: '2026-06-25', type: 'erg' });
 
-    renderHook(() => useOfflineQueue());
+    renderHook(() => useOfflineQueue(), {
+      wrapper: makeWrapper(makeClient()),
+    });
 
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     expect(insertMock.mock.calls[0][0].user_id).toBeUndefined();
@@ -82,7 +102,9 @@ describe('useOfflineQueue drainQueue user_id backfill', () => {
     });
     enqueueSession({ date: '2026-06-25', type: 'erg' });
 
-    renderHook(() => useOfflineQueue());
+    renderHook(() => useOfflineQueue(), {
+      wrapper: makeWrapper(makeClient()),
+    });
 
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     const remaining = JSON.parse(localStorage.getItem(QUEUE_KEY));
@@ -159,7 +181,9 @@ describe('useOfflineQueue legacy-row migration', () => {
       distance: 5000,
     });
 
-    renderHook(() => useOfflineQueue());
+    renderHook(() => useOfflineQueue(), {
+      wrapper: makeWrapper(makeClient()),
+    });
 
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     const row = insertMock.mock.calls[0][0];
@@ -182,7 +206,9 @@ describe('useOfflineQueue legacy-row migration', () => {
       distance: 5000,
     });
 
-    renderHook(() => useOfflineQueue());
+    renderHook(() => useOfflineQueue(), {
+      wrapper: makeWrapper(makeClient()),
+    });
 
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     const [remaining] = JSON.parse(localStorage.getItem(QUEUE_KEY));
@@ -204,7 +230,9 @@ describe('useOfflineQueue legacy-row migration', () => {
       label: 'Erg Session 07:15',
     });
 
-    const { result } = renderHook(() => useOfflineQueue());
+    const { result } = renderHook(() => useOfflineQueue(), {
+      wrapper: makeWrapper(makeClient()),
+    });
 
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(result.current.pending).toBe(0));
@@ -223,7 +251,9 @@ describe('useOfflineQueue legacy-row migration', () => {
       label: 'Erg Session 07:15',
     });
 
-    renderHook(() => useOfflineQueue());
+    renderHook(() => useOfflineQueue(), {
+      wrapper: makeWrapper(makeClient()),
+    });
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
 
     // A second trigger while the first drain is still awaiting the insert.
@@ -233,5 +263,87 @@ describe('useOfflineQueue legacy-row migration', () => {
 
     await waitFor(() => expect(localStorage.getItem(QUEUE_KEY)).toBe('[]'));
     expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useOfflineQueue drain invalidation', () => {
+  it('invalidates every session-reading query once after a successful drain', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    enqueueSession({ date: '6/25/26', type: 'erg', label: 'Erg Session' });
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    renderHook(() => useOfflineQueue(), { wrapper: makeWrapper(client) });
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalledTimes(3));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['erg-sessions'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tss-history'] });
+  });
+
+  it('invalidates nothing when the queue is empty', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    renderHook(() => useOfflineQueue(), { wrapper: makeWrapper(client) });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('invalidates nothing when every queued row fails to insert', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    insertMock.mockResolvedValue({
+      error: { code: '08006', message: 'network' },
+    });
+    enqueueSession({ date: '6/25/26', type: 'erg', label: 'A' });
+    enqueueSession({ date: '6/25/26', type: 'erg', label: 'B' });
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    renderHook(() => useOfflineQueue(), { wrapper: makeWrapper(client) });
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(2));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(JSON.parse(localStorage.getItem(QUEUE_KEY))).toHaveLength(2);
+  });
+
+  it('invalidates once after the loop, not once per drained row', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    enqueueSession({ date: '6/25/26', type: 'erg', label: 'A' });
+    enqueueSession({ date: '6/25/26', type: 'erg', label: 'B' });
+    enqueueSession({ date: '6/25/26', type: 'erg', label: 'C' });
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    renderHook(() => useOfflineQueue(), { wrapper: makeWrapper(client) });
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalledTimes(3));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(invalidateSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('still invalidates on a partial drain and retains the failed row', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+    insertMock
+      .mockResolvedValueOnce({ error: null })
+      .mockResolvedValueOnce({ error: { code: '08006', message: 'network' } });
+    enqueueSession({ date: '6/25/26', type: 'erg', label: 'lands' });
+    enqueueSession({ date: '6/25/26', type: 'erg', label: 'fails' });
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    renderHook(() => useOfflineQueue(), { wrapper: makeWrapper(client) });
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalledTimes(3));
+    const remaining = JSON.parse(localStorage.getItem(QUEUE_KEY));
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].label).toBe('fails');
   });
 });

--- a/web/src/hooks/useOfflineQueue.js
+++ b/web/src/hooks/useOfflineQueue.js
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Capacitor } from '@capacitor/core';
 import { Network } from '@capacitor/network';
 import { supabase } from '../supabaseClient';
 import { toLogDate } from '../utils/dateFormat.js';
+import { invalidateSessionQueries } from '../utils/invalidateSessionQueries.js';
 
 const QUEUE_KEY = 'erg_pending_sessions';
 
@@ -82,12 +84,18 @@ async function drainQueue() {
 
 export function useOfflineQueue() {
   const [pending, setPending] = useState(readQueue().length);
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     const sync = async (connected) => {
       if (connected) {
         const synced = await drainQueue();
-        if (synced > 0) setPending(readQueue().length);
+        if (synced > 0) {
+          setPending(readQueue().length);
+          // Once after the loop, not per row: N×3 refetch triggers would race
+          // the inserts still in flight.
+          invalidateSessionQueries(queryClient);
+        }
       }
     };
 
@@ -108,7 +116,7 @@ export function useOfflineQueue() {
       webSync();
       return () => window.removeEventListener('online', webSync);
     }
-  }, []);
+  }, [queryClient]);
 
   function addToQueue(session) {
     enqueueSession(session);

--- a/web/src/utils/__tests__/invalidateSessionQueries.test.js
+++ b/web/src/utils/__tests__/invalidateSessionQueries.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { invalidateSessionQueries } from '../invalidateSessionQueries.js';
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+describe('invalidateSessionQueries', () => {
+  it('invalidates exactly the three session-reading query keys', () => {
+    const client = makeClient();
+    const spy = vi.spyOn(client, 'invalidateQueries');
+
+    invalidateSessionQueries(client);
+
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['erg-sessions'] });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['tss-history'] });
+  });
+
+  it('does not name the benchmark keys — the sessions prefix covers them', () => {
+    const client = makeClient();
+    const spy = vi.spyOn(client, 'invalidateQueries');
+
+    invalidateSessionQueries(client);
+
+    expect(spy).not.toHaveBeenCalledWith({
+      queryKey: ['sessions', 'benchmark-window'],
+    });
+    expect(spy).not.toHaveBeenCalledWith({
+      queryKey: ['benchmark-sessions'],
+    });
+  });
+
+  it('marks a cached benchmark-window query stale via the sessions prefix', async () => {
+    const client = makeClient();
+    const key = ['sessions', 'benchmark-window'];
+    await client.fetchQuery({ queryKey: key, queryFn: async () => ['row'] });
+    expect(client.getQueryState(key).isInvalidated).toBe(false);
+
+    invalidateSessionQueries(client);
+
+    expect(client.getQueryState(key).isInvalidated).toBe(true);
+  });
+});

--- a/web/src/utils/invalidateSessionQueries.js
+++ b/web/src/utils/invalidateSessionQueries.js
@@ -1,7 +1,9 @@
-// Every query that reads `sessions`. A session insert must invalidate all of
-// them; the three write paths each used to pick their own subset and disagreed
-// (#195). ['sessions'] is a prefix, so it also reaches
+// Every react-query query that reads `sessions`. A session insert must
+// invalidate all of them; the three write paths each used to pick their own
+// subset and disagreed (#195). ['sessions'] is a prefix, so it also reaches
 // ['sessions','benchmark-window'] — do NOT list that key separately.
+// useSessionLog.js also reads sessions but through a raw useState/useEffect
+// fetch, so no invalidation can reach it (#194).
 export function invalidateSessionQueries(queryClient) {
   queryClient.invalidateQueries({ queryKey: ['sessions'] });
   queryClient.invalidateQueries({ queryKey: ['erg-sessions'] });

--- a/web/src/utils/invalidateSessionQueries.js
+++ b/web/src/utils/invalidateSessionQueries.js
@@ -1,0 +1,9 @@
+// Every query that reads `sessions`. A session insert must invalidate all of
+// them; the three write paths each used to pick their own subset and disagreed
+// (#195). ['sessions'] is a prefix, so it also reaches
+// ['sessions','benchmark-window'] — do NOT list that key separately.
+export function invalidateSessionQueries(queryClient) {
+  queryClient.invalidateQueries({ queryKey: ['sessions'] });
+  queryClient.invalidateQueries({ queryKey: ['erg-sessions'] });
+  queryClient.invalidateQueries({ queryKey: ['tss-history'] });
+}

--- a/web/src/views/ErgLiveView.jsx
+++ b/web/src/views/ErgLiveView.jsx
@@ -8,6 +8,7 @@ import WorkoutTarget from '../components/WorkoutTarget';
 import { parsePace, formatElapsed } from '../services/pm5Bluetooth';
 import { THEME } from '../constants/theme.js';
 import { toISODate, toLogDate } from '../utils/dateFormat.js';
+import { invalidateSessionQueries } from '../utils/invalidateSessionQueries.js';
 
 const C = {
   bg: THEME.bg,
@@ -644,8 +645,7 @@ export default function ErgLiveView({ plannedSessions = [], onSessionSaved }) {
     }
 
     if (!dbError || isDuplicate(dbError)) {
-      queryClient.invalidateQueries({ queryKey: ['sessions'] });
-      queryClient.invalidateQueries({ queryKey: ['erg-sessions'] });
+      invalidateSessionQueries(queryClient);
       setSaveState('saved');
     } else {
       queue();

--- a/web/src/views/__tests__/ErgLiveView.test.jsx
+++ b/web/src/views/__tests__/ErgLiveView.test.jsx
@@ -276,6 +276,7 @@ describe('ErgLiveView save outcomes', () => {
     );
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['erg-sessions'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tss-history'] });
     expect(addToQueueMock).not.toHaveBeenCalled();
   });
 

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -126,6 +126,11 @@ export default defineConfig({
           branches: 70,
         },
         'src/utils/dateFormat.js': { lines: 80, functions: 80, branches: 70 },
+        'src/utils/invalidateSessionQueries.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
         'src/hooks/useSessions.js': { lines: 80, functions: 80, branches: 70 },
         'src/hooks/useTSSHistory.js': {
           lines: 80,


### PR DESCRIPTION
Closes #195

## What changed and why

The offline queue drained on reconnect and invalidated nothing, so a session saved offline stayed invisible to every view until a `staleTime` lapsed or the app remounted. Auditing the other write paths showed the real problem is that all three disagreed — and none invalidated `['tss-history']`, which nothing in the codebase has ever invalidated, so CTL/ATL/TSB could be stale for up to five minutes after a save.

| Path | Before | After |
|---|---|---|
| `LogSessionForm.jsx` | `['sessions']` | all three |
| `ErgLiveView.jsx` | `['sessions']`, `['erg-sessions']` | all three |
| `useOfflineQueue.js` drain | **nothing** | all three |

`utils/invalidateSessionQueries.js` is now the single definition of what a session insert must refresh. A helper rather than three aligned copies because this drift has already happened twice — once for `['erg-sessions']`, once for `['tss-history']`.

**Correction to the issue body:** it proposed invalidating `['benchmark-sessions']`. No such key exists. The benchmark window lives at `['sessions','benchmark-window']`, a prefix-child of `['sessions']`, so it was already being reached. One test pins that the helper does not list it separately; another proves the cascade behaviourally by seeding a query and asserting it goes stale.

The drain needed no plumbing. `drainQueue` is module-private with one caller — the `sync()` closure, which already runs under `QueryClientProvider` and already guards on `synced > 0`. Invalidating once inside that guard gives correct partial-drain behaviour for free: some rows landed, refresh with what did; nothing landed, invalidate nothing, matching `LogSessionForm`'s existing failure contract. No signature change, no singleton (that would create an import cycle through `main.jsx`).

## How to test manually

Covered by CI. For a live check: go offline, save a session from the PM5 live view, reconnect — the session list, erg list and training-load numbers should all refresh without a reload.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

603 tests (+8). Eight existing `renderHook` sites in `useOfflineQueue.test.js` gained a `QueryClientProvider`, which the hook now requires.

**Merge order:** this one first — it is clean against both other open PRs.

Out of scope: `useSessionLog.js` (#194), the NULL-`status` bug in `LogSessionForm` (#205).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGRNSgkij9fa148Kmw8Eno)_