### PR TITLE
chore: order useErgSessions and useBenchmarkSessions by date_iso (#200)

### DIFF
--- a/web/src/hooks/__tests__/useBenchmarkSessions.test.js
+++ b/web/src/hooks/__tests__/useBenchmarkSessions.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const fromMock = vi.fn();
+const orderMock = vi.fn();
+const limitMock = vi.fn();
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: (...args) => fromMock(...args),
+  },
+}));
+
+import { useBenchmarkSessions } from '../useBenchmarkSessions.js';
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function makeWrapper(client) {
+  function Wrapper({ children }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  }
+  return Wrapper;
+}
+
+// order() spies on its arguments and keeps returning the chain; limit()
+// terminates it. The query contract is what this hook is — there is no derived
+// state to assert on.
+function mockQuery(data, error = null) {
+  const chain = {
+    select: () => chain,
+    order: (...args) => {
+      orderMock(...args);
+      return chain;
+    },
+    limit: (...args) => {
+      limitMock(...args);
+      return Promise.resolve({ data, error });
+    },
+  };
+  fromMock.mockReturnValue(chain);
+}
+
+async function renderBenchmarkSessions(client = makeClient()) {
+  const { result } = renderHook(() => useBenchmarkSessions(), {
+    wrapper: makeWrapper(client),
+  });
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  return result;
+}
+
+beforeEach(() => {
+  fromMock.mockReset();
+  orderMock.mockReset();
+  limitMock.mockReset();
+});
+
+describe('useBenchmarkSessions', () => {
+  it('orders on the derived date_iso column with NULLS LAST', async () => {
+    mockQuery([]);
+    await renderBenchmarkSessions();
+    expect(orderMock).toHaveBeenCalledWith('date_iso', {
+      ascending: false,
+      nullsFirst: false,
+    });
+  });
+
+  it('never orders on the lexically-sorting text date column (#187)', async () => {
+    mockQuery([]);
+    await renderBenchmarkSessions();
+    expect(orderMock).not.toHaveBeenCalledWith('date', expect.anything());
+  });
+
+  it('requests the full 500-row benchmark history', async () => {
+    mockQuery([]);
+    await renderBenchmarkSessions();
+    expect(limitMock).toHaveBeenCalledWith(500);
+  });
+
+  // Deliberate asymmetry with useErgSessions: the ladder resolver picks by date,
+  // not by position, so it needs no id tiebreaker. Pinned so a future reader does
+  // not "fix" the difference.
+  it('does not add an id tiebreaker', async () => {
+    mockQuery([]);
+    await renderBenchmarkSessions();
+    expect(orderMock).not.toHaveBeenCalledWith('id', expect.anything());
+  });
+
+  it('keeps the cache key under the ["sessions"] prefix so invalidation reaches it', async () => {
+    mockQuery([]);
+    const client = makeClient();
+    await renderBenchmarkSessions(client);
+    expect(
+      client
+        .getQueryCache()
+        .findAll({ queryKey: ['sessions'] })
+        .map((q) => q.queryKey)
+    ).toContainEqual(['sessions', 'benchmark-window']);
+  });
+
+  it('returns an empty array when there are no sessions', async () => {
+    mockQuery(null);
+    const result = await renderBenchmarkSessions();
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('sets isError on supabase error', async () => {
+    mockQuery(null, { message: 'boom' });
+    const { result } = renderHook(() => useBenchmarkSessions(), {
+      wrapper: makeWrapper(makeClient()),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/web/src/hooks/__tests__/useErgSessions.test.js
+++ b/web/src/hooks/__tests__/useErgSessions.test.js
@@ -4,6 +4,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
 const fromMock = vi.fn();
+const orderMock = vi.fn();
+const limitMock = vi.fn();
 
 vi.mock('../../supabaseClient.js', () => ({
   supabase: {
@@ -51,8 +53,14 @@ function mockQuery(data, error = null, cp = 205) {
     const chain = {
       select: () => chain,
       eq: () => chain,
-      order: () => chain,
-      limit: () => Promise.resolve({ data, error }),
+      order: (...args) => {
+        orderMock(...args);
+        return chain;
+      },
+      limit: (...args) => {
+        limitMock(...args);
+        return Promise.resolve({ data, error });
+      },
     };
     return chain;
   });
@@ -60,6 +68,8 @@ function mockQuery(data, error = null, cp = 205) {
 
 beforeEach(() => {
   fromMock.mockReset();
+  orderMock.mockReset();
+  limitMock.mockReset();
 });
 
 describe('useErgSessions', () => {
@@ -194,8 +204,9 @@ describe('useErgSessions', () => {
     expect(result.current.data[0].date_display).toBe('not-a-date');
   });
 
-  // Postgres sorts the TEXT date lexically, so it hands back "12/31/25" above
-  // "1/1/26". The hook must re-sort newest-first on the normalized key.
+  // The DB returns date_iso order; these fixtures are deliberately scrambled to
+  // pin the client-side guard that survives a rollback or a stale PostgREST
+  // schema cache. They are NOT evidence the server order is wrong.
   it('re-sorts newest-first across a year boundary', async () => {
     mockQuery([
       { id: 12, date: '12/31/25', type: 'erg', avg_watts: 150 },
@@ -223,6 +234,62 @@ describe('useErgSessions', () => {
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data.map((s) => s.id)).toEqual([16, 15]);
+  });
+
+  it('orders on the derived date_iso column with NULLS LAST', async () => {
+    mockQuery([]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(orderMock).toHaveBeenCalledWith('date_iso', {
+      ascending: false,
+      nullsFirst: false,
+    });
+  });
+
+  it('never orders on the lexically-sorting text date column (#187)', async () => {
+    mockQuery([]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(orderMock).not.toHaveBeenCalledWith('date', expect.anything());
+  });
+
+  it('breaks ties on id so the limit boundary is deterministic', async () => {
+    mockQuery([]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(orderMock).toHaveBeenCalledWith('id', { ascending: false });
+  });
+
+  it('requests a 50-row recency window', async () => {
+    mockQuery([]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(limitMock).toHaveBeenCalledWith(50);
+  });
+
+  it('sorts an unparseable date last, mirroring NULLS LAST', async () => {
+    mockQuery([
+      { id: 17, date: 'garbage', type: 'erg', avg_watts: 150 },
+      { id: 18, date: '8/7/26', type: 'erg', avg_watts: 150 },
+      { id: 19, date: '5/22/26', type: 'erg', avg_watts: 150 },
+    ]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data.map((s) => s.date)).toEqual([
+      '8/7/26',
+      '5/22/26',
+      'garbage',
+    ]);
   });
 
   it('sets isError on supabase error', async () => {

--- a/web/src/hooks/useBenchmarkSessions.js
+++ b/web/src/hooks/useBenchmarkSessions.js
@@ -6,10 +6,12 @@ import { supabase } from '../supabaseClient.js';
 // LogSessionForm and ErgLiveView (neither passes `exact`) refetch it too and a
 // freshly-logged test clears its badge without any edit to those files.
 //
-// limit 500 rather than useSessions()' 50: sessions.date is TEXT, so the
-// server-side order is not chronological and a small limit truncates the wrong
-// rows. At ~92 rows today, 500 returns the whole table and set membership stops
-// depending on the broken sort. The resolver filters by date itself.
+// limit 500 rather than useSessions()' 50 because the ladder resolver wants the
+// whole benchmark history, not a recency window: it searches back from each
+// event's own date, so a 50-row cut would hide older attempts. At 92 rows today
+// the limit never binds; ordering by date_iso makes the cut "the most recent
+// 500" if it ever does. The resolver filters by date itself and is
+// order-independent, so no id tiebreaker is needed here.
 export function useBenchmarkSessions() {
   return useQuery({
     queryKey: ['sessions', 'benchmark-window'],
@@ -17,7 +19,7 @@ export function useBenchmarkSessions() {
       const { data, error } = await supabase
         .from('sessions')
         .select('id, date, label, status')
-        .order('date', { ascending: false })
+        .order('date_iso', { ascending: false, nullsFirst: false })
         .limit(500);
       if (error) throw error;
       return data ?? [];

--- a/web/src/hooks/useErgSessions.js
+++ b/web/src/hooks/useErgSessions.js
@@ -55,10 +55,10 @@ export function useErgSessions() {
   });
 
   // enrich() derives pace/zone/date_display; the sort is defence, not
-  // correctness — the query above already returns date_iso order, and
-  // toISODate() accepts exactly the shapes session_date_to_iso() does. Keep it:
-  // the map is here anyway, and it holds ordering through a rollback or the
-  // window where PostgREST has not reloaded its schema cache.
+  // correctness — the query above already returns date_iso order. What it still
+  // guards is a date the generated column could not parse: those arrive as
+  // date_iso NULL, land last under NULLS LAST, and would otherwise keep that
+  // position here. The map is here anyway, so the sort is close to free.
   const data = useMemo(
     () =>
       (query.data ?? [])

--- a/web/src/hooks/useErgSessions.js
+++ b/web/src/hooks/useErgSessions.js
@@ -37,7 +37,16 @@ export function useErgSessions() {
         )
         .eq('type', 'erg')
         .eq('status', 'logged')
-        .order('date', { ascending: false })
+        // date_iso, not date: sessions.date is TEXT "M/D/YY" and sorts lexically, so
+        // a LIMIT over it returns the wrong SET of rows (#187). nullsFirst is
+        // mandatory — postgrest-js omits the clause entirely when it is undefined,
+        // and Postgres defaults descending to NULLS FIRST, which would float an
+        // unparseable date to the top as "most recent".
+        // id breaks ties: the PM5 save path suffixes the label with hh:mm so two
+        // sessions can share a date, and without it the 50-row cut is arbitrary and
+        // moves between refetches.
+        .order('date_iso', { ascending: false, nullsFirst: false })
+        .order('id', { ascending: false })
         .limit(50);
       if (error) throw error;
       return data ?? [];
@@ -45,10 +54,11 @@ export function useErgSessions() {
     staleTime: 60_000,
   });
 
-  // sessions.date is TEXT "M/D/YY", so the server-side .order() above sorts it
-  // lexically ("12/31/25" lands above "1/1/26"). Re-sort on the normalized ISO
-  // key. The .limit(50) is still applied to that lexical order server-side, so
-  // past 50 rows this fetches the wrong 50 — see #184.
+  // enrich() derives pace/zone/date_display; the sort is defence, not
+  // correctness — the query above already returns date_iso order, and
+  // toISODate() accepts exactly the shapes session_date_to_iso() does. Keep it:
+  // the map is here anyway, and it holds ordering through a rollback or the
+  // window where PostgREST has not reloaded its schema cache.
   const data = useMemo(
     () =>
       (query.data ?? [])

--- a/web/src/utils/benchmarkStatus.js
+++ b/web/src/utils/benchmarkStatus.js
@@ -50,11 +50,11 @@ function betterFit(a, b) {
   return a.session.id < b.session.id;
 }
 
-// Deterministic best fit, NOT the first row in payload order. The payload is
-// ordered by the TEXT date column, so '7/5/26' sorts above '6/23/26'; combined
-// with a search range that runs forward to today, first-in-order let CP Test #1
-// consume the session that belongs to CP Test #2 and the later badge could
-// never clear. Choosing by date instead of position also makes the result
+// Deterministic best fit, NOT the first row in payload order. The payload used
+// to be ordered by the TEXT date column, so '7/5/26' sorted above '6/23/26';
+// combined with a search range that runs forward to today, first-in-order let
+// CP Test #1 consume the session that belongs to CP Test #2 and the later badge
+// could never clear. Choosing by date instead of position also makes the result
 // independent of how the server happened to sort the rows.
 function findMatch(sessions, keywords, searchStart, searchEnd, consumed, win) {
   if (keywords.length === 0) return null;

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -137,6 +137,16 @@ export default defineConfig({
           functions: 80,
           branches: 70,
         },
+        'src/hooks/useErgSessions.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/hooks/useBenchmarkSessions.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
         'src/components/ErrorFallback.jsx': {
           lines: 80,
           functions: 80,


### PR DESCRIPTION
Closes #200

## What changed and why

#187/#198 added the generated `date_iso` column and moved `useSessions` and `useTSSHistory` onto it. These two hooks were left on the lexical TEXT ordering. Both now order by `date_iso` with `nullsFirst: false` — not optional, since postgrest-js omits the clause entirely when the option is undefined and Postgres defaults descending to NULLS FIRST, which would float an unparseable date to the top as the most recent row.

| | `useErgSessions` | `useBenchmarkSessions` |
|---|---|---|
| `date_iso` + `nullsFirst: false` | ✅ | ✅ |
| `id` tiebreaker | ✅ — `limit(50)` is a real cut and the PM5 path suffixes labels with `hh:mm`, so two sessions can share a date | ❌ deliberate — `limit(500)` against 92 rows never binds, and the resolver already tiebreaks by id itself |
| client-side re-sort | kept | none, and none added |

The asymmetry is pinned by a test asserting `useBenchmarkSessions` does *not* order by `id`, so a future "consistency" cleanup fails loudly.

**Comment corrections.** The stale comment cited #184, not #187 as the issue body claimed; both rewritten comments now cite #187, the issue that explains why `date_iso` exists. A third stale comment in `benchmarkStatus.js` asserted "the payload is ordered by the TEXT date column" — the premise this PR falsifies — and is now past tense. A fourth was corrected in review: the re-sort's rationale claimed it survives a rollback or a stale PostgREST schema cache, which it cannot (a 400 leaves no payload to re-sort). What it actually guards is an unparseable date arriving NULL, which is what the new test covers.

## How to test manually

No user-visible change. `useBenchmarkSessions` returns the whole table either way at 92 rows; `useErgSessions` returns an empty set in production because no row carries `status='logged'` yet (see #206). This is correctness insurance for data the table hasn't reached.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

607 tests (+12), including a new `useBenchmarkSessions.test.js` — it was the only one of the four session hooks with no direct test, and this PR changes its query contract.

**Merge order:** second, after #195. Conflicts with the #192 PR on one comment block in `benchmarkStatus.js`; #192 rebases onto this.

Out of scope: widening `useErgSessions`' `status='logged'` filter (#206), any limit, select list, query key or `staleTime`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGRNSgkij9fa148Kmw8Eno)_