### PR TITLE
feat: show rescheduled benchmarks instead of warning forever (#192)

### DIFF
--- a/web/src/components/BenchmarkBadge.jsx
+++ b/web/src/components/BenchmarkBadge.jsx
@@ -1,11 +1,18 @@
+import { toLogDate } from '../utils/dateFormat.js';
+
 // Presentational only — props in, no hooks, no data access.
-const COLOURS = { overdue: '#ff2d55', upcoming: '#ffd700' };
+const COLOURS = {
+  overdue: '#ff2d55',
+  upcoming: '#ffd700',
+  scheduled: '#a78bfa',
+};
 
 export default function BenchmarkBadge({
   status,
   fuzzy = false,
   daysOverdue = null,
   daysUntilStart = null,
+  rescheduledTo = null,
 }) {
   const colour = COLOURS[status];
   if (!colour) return null;
@@ -15,6 +22,14 @@ export default function BenchmarkBadge({
     parts.push('OVERDUE');
     if (typeof daysOverdue === 'number' && daysOverdue > 0) {
       parts.push(`${daysOverdue}d`);
+    }
+  } else if (status === 'scheduled') {
+    // Explicitly branched, never folded into the trailing else: a scheduled
+    // benchmark falling through to the upcoming branch would read 'DUE'.
+    parts.push('↻ RESCHEDULED');
+    if (rescheduledTo) parts.push(toLogDate(rescheduledTo));
+    if (typeof daysOverdue === 'number' && daysOverdue > 0) {
+      parts.push(`${daysOverdue}d OVERDUE`);
     }
   } else {
     parts.push('DUE');

--- a/web/src/components/__tests__/BenchmarkBadge.test.jsx
+++ b/web/src/components/__tests__/BenchmarkBadge.test.jsx
@@ -53,4 +53,54 @@ describe('BenchmarkBadge', () => {
     rerender(<BenchmarkBadge status="upcoming" daysUntilStart={3} />);
     expect(container.firstChild).toHaveStyle({ color: '#ffd700' });
   });
+
+  // AC4 — the rescheduled state has to be legible as its own thing: it is not
+  // an alarm (the date is booked) and it is not routine (it is still late).
+  it('AC4 renders the reschedule date and how late the benchmark still is', () => {
+    render(
+      <BenchmarkBadge
+        status="scheduled"
+        rescheduledTo="2026-09-12"
+        daysOverdue={31}
+      />
+    );
+    expect(
+      screen.getByText('↻ RESCHEDULED · 9/12/26 · 31d OVERDUE')
+    ).toBeInTheDocument();
+  });
+
+  it('AC4 colours scheduled violet, distinct from overdue and upcoming', () => {
+    const { container } = render(
+      <BenchmarkBadge status="scheduled" rescheduledTo="2026-09-12" />
+    );
+    expect(container.firstChild).toHaveStyle({ color: '#a78bfa' });
+    expect(container.firstChild).not.toHaveStyle({ color: '#ff2d55' });
+    expect(container.firstChild).not.toHaveStyle({ color: '#ffd700' });
+  });
+
+  // THE regression. Adding 'scheduled' to COLOURS without splitting the trailing
+  // else renders a booked benchmark as 'DUE' — a colour it has never been due in,
+  // saying the opposite of what happened.
+  it('AC4 never renders DUE for a scheduled benchmark', () => {
+    const { container, rerender } = render(
+      <BenchmarkBadge status="scheduled" rescheduledTo="2026-09-12" />
+    );
+    expect(screen.queryByText(/DUE/)).not.toBeInTheDocument();
+    expect(container.firstChild.textContent).toBe('↻ RESCHEDULED · 9/12/26');
+    rerender(
+      <BenchmarkBadge
+        status="scheduled"
+        rescheduledTo="2026-09-12"
+        daysOverdue={31}
+        fuzzy
+      />
+    );
+    expect(screen.queryByText(/^DUE/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/exact date TBD/)).not.toBeInTheDocument();
+  });
+
+  it('omits the date when there is no reschedule date to show', () => {
+    render(<BenchmarkBadge status="scheduled" daysOverdue={31} />);
+    expect(screen.getByText('↻ RESCHEDULED · 31d OVERDUE')).toBeInTheDocument();
+  });
 });

--- a/web/src/constants/sessionStatus.js
+++ b/web/src/constants/sessionStatus.js
@@ -4,3 +4,8 @@
 // writes 'logged'. All three must count as "done" for TSS/CTL/ATL/TSB, or
 // newly-logged sessions silently vanish from training-load calculations.
 export const COMPLETED_STATUSES = ['actual', 'completed', 'logged'];
+
+// A forward-looking prescription — a session Scott intends to do, not one that
+// happened. Deliberately NOT in COMPLETED_STATUSES: it must never clear a
+// benchmark, only reschedule one.
+export const PLANNED_STATUS = 'planned';

--- a/web/src/utils/__tests__/benchmarkStatus.test.js
+++ b/web/src/utils/__tests__/benchmarkStatus.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { resolveLadderStatuses, selectUpcoming } from '../benchmarkStatus.js';
+import {
+  compareBenchmarkSeverity,
+  resolveLadderStatuses,
+  selectUpcoming,
+} from '../benchmarkStatus.js';
 import { COMPLETED_STATUSES } from '../../constants/sessionStatus.js';
 import { EVENT_LADDER } from '../../constants/schedule.js';
 
@@ -516,5 +520,182 @@ describe('resolveLadderStatuses — loading (L1) and selectUpcoming', () => {
     const states = resolve([CP2, entry], []);
     expect(selectUpcoming(states).map((s) => s.entry)).toEqual([entry]);
     expect(selectUpcoming(null)).toEqual([]);
+  });
+});
+
+// A benchmark that never happened stays overdue for ever — CP Test #1 would
+// read OVERDUE · 197d by the time its replacement window opens, and a permanent
+// warning is wallpaper. Putting a `planned` row on the calendar is the reschedule
+// gesture; these prove the badge reads it WITHOUT ever treating it as evidence.
+describe('resolveLadderStatuses — rescheduled via a planned session', () => {
+  const planned = (id, date, label) => ({ id, date, label, status: 'planned' });
+  const CP_RETEST = 'CP RETEST — 1min + 4min max';
+
+  it('AC1 never lets a planned session count as done, however good the label', () => {
+    const [s] = resolve([CP2], [planned(300, '9/12/26', CP_RETEST)]);
+    expect(s.done).toBe(false);
+    expect(s.matchedSessionId).toBeNull();
+    expect(s.status).toBe('scheduled');
+  });
+
+  it('AC2 resolves an overdue benchmark with a future planned session to scheduled', () => {
+    const [s] = resolve([CP2], [planned(300, '9/12/26', CP_RETEST)]);
+    expect(s.status).toBe('scheduled');
+    expect(s.rescheduledTo).toBe('2026-09-12');
+    expect(s.plannedSessionId).toBe(300);
+    // The elapsed count survives the second pass: rescheduled is not forgiven.
+    expect(s.daysOverdue).toBe(31);
+  });
+
+  it('AC2 counts a session dated exactly today as a live commitment', () => {
+    const [s] = resolve([CP2], [planned(301, '8/20/26', CP_RETEST)]);
+    expect(s.status).toBe('scheduled');
+    expect(s.rescheduledTo).toBe('2026-08-20');
+  });
+
+  it('AC3 leaves a benchmark overdue when the planned session is in the past', () => {
+    const [s] = resolve([CP2], [planned(302, '8/19/26', CP_RETEST)]);
+    expect(s.status).toBe('overdue');
+    expect(s.rescheduledTo).toBeNull();
+    expect(s.plannedSessionId).toBeNull();
+  });
+
+  // The two `planned` rows that actually sit in the table today. Both are past
+  // AND label-inert, so they fail the date gate and the label gate — the live
+  // verdict is byte-for-byte what it was before this pass existed.
+  it('AC3 leaves the live ladder unchanged against the real planned rows', () => {
+    const REAL_PLANNED = [
+      planned(43, '6/23/26', 'Upper Strength A'),
+      planned(56, '7/1/26', 'Upper B'),
+    ];
+    const states = resolve(EVENT_LADDER, [
+      SESSION_45,
+      ...MID_JUL_DONE,
+      CANCELLED_RETEST,
+      ...EARLY_AUG_DONE,
+      ...REAL_PLANNED,
+    ]);
+    const loud = states.filter((s) => s.status !== 'quiet');
+    expect(loud.map((s) => [s.entry.name, s.status])).toEqual([
+      ['CP Test #2 (2nd duration)', 'overdue'],
+      ['5k Time Trial', 'overdue'],
+    ]);
+  });
+
+  // Same rows, moved into the future: the label gate alone still rejects them,
+  // which proves the live result above is not carried by the date gate only.
+  it('AC3 leaves a benchmark overdue when a future planned label does not match', () => {
+    const [s] = resolve([CP2], [planned(43, '9/1/26', 'Upper Strength A')]);
+    expect(s.status).toBe('overdue');
+  });
+
+  it('does not let a planned ride reschedule a distance benchmark', () => {
+    const K1000 = EVENT_LADDER.find((e) => e.name.startsWith('1000m'));
+    const [s] = resolveLadderStatuses(
+      [K1000],
+      [planned(500, '3/1/27', 'Zwift Alpe du Zwift — 1:12:30, 22.4km, 1,000m')],
+      { today: '2027-02-05', sessionsReady: true }
+    );
+    expect(s.status).toBe('overdue');
+    expect(s.plannedSessionId).toBeNull();
+  });
+
+  it('leaves an upcoming benchmark upcoming, planned session or not', () => {
+    const entry = { date: '25 Aug 26', name: '2k Test', kind: 'benchmark' };
+    const [s] = resolve([entry], [planned(303, '9/1/26', '2k test')]);
+    expect(s.status).toBe('upcoming');
+    expect(s.rescheduledTo).toBeNull();
+  });
+
+  it('leaves a done benchmark quiet, planned session or not', () => {
+    const [s] = resolve(
+      [CP2],
+      [
+        {
+          id: 1,
+          date: '7/15/26',
+          label: 'CP retest 4min max',
+          status: 'completed',
+        },
+        planned(304, '9/12/26', CP_RETEST),
+      ]
+    );
+    expect(s.status).toBe('quiet');
+    expect(s.done).toBe(true);
+    expect(s.rescheduledTo).toBeNull();
+  });
+
+  // One retest on the calendar is one benchmark rescheduled. Sharing it would
+  // silence two badges off a single commitment — the original slip, reinvented.
+  it('does not let one planned session clear two overdue benchmarks', () => {
+    const [first, second] = resolve(
+      [CP1, CP2],
+      [planned(305, '9/1/26', 'CP retest 4min')]
+    );
+    expect(first.status).toBe('scheduled');
+    expect(first.plannedSessionId).toBe(305);
+    expect(second.status).toBe('overdue');
+    expect(second.plannedSessionId).toBeNull();
+  });
+
+  it('picks the earliest future planned session', () => {
+    const [s] = resolve(
+      [CP2],
+      [planned(310, '10/1/26', CP_RETEST), planned(311, '9/1/26', CP_RETEST)]
+    );
+    expect(s.plannedSessionId).toBe(311);
+    expect(s.rescheduledTo).toBe('2026-09-01');
+  });
+
+  it('breaks a same-date planned tie on the lower session id', () => {
+    const rows = [
+      planned(320, '9/1/26', CP_RETEST),
+      planned(315, '9/1/26', CP_RETEST),
+    ];
+    expect(resolve([CP2], rows)[0].plannedSessionId).toBe(315);
+    expect(resolve([CP2], [...rows].reverse())[0].plannedSessionId).toBe(315);
+  });
+
+  it('ignores a planned session with an unreadable date', () => {
+    const [s] = resolve([CP2], [planned(330, 'someday', CP_RETEST)]);
+    expect(s.status).toBe('overdue');
+  });
+
+  it('never reschedules a benchmark whose name yields no keywords', () => {
+    const entry = {
+      date: '~Mid Jul 26',
+      name: 'Critical Power retest',
+      kind: 'benchmark',
+    };
+    const [s] = resolve(
+      [entry],
+      [planned(340, '9/1/26', 'Critical Power retest')]
+    );
+    expect(s.keywords).toEqual([]);
+    expect(s.status).toBe('overdue');
+  });
+});
+
+describe('compareBenchmarkSeverity (AC5)', () => {
+  const st = (status, index) => ({ status, index });
+
+  it('ranks overdue above upcoming above scheduled above the silent states', () => {
+    const rows = [
+      st('unknown', 4),
+      st('scheduled', 2),
+      st('quiet', 3),
+      st('overdue', 0),
+      st('upcoming', 1),
+    ];
+    expect(
+      [...rows].sort(compareBenchmarkSeverity).map((r) => r.status)
+    ).toEqual(['overdue', 'upcoming', 'scheduled', 'quiet', 'unknown']);
+  });
+
+  it('breaks a same-status tie on ladder index', () => {
+    const rows = [st('overdue', 7), st('overdue', 2), st('overdue', 5)];
+    expect(
+      [...rows].sort(compareBenchmarkSeverity).map((r) => r.index)
+    ).toEqual([2, 5, 7]);
   });
 });

--- a/web/src/utils/benchmarkStatus.js
+++ b/web/src/utils/benchmarkStatus.js
@@ -1,4 +1,7 @@
-import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+import {
+  COMPLETED_STATUSES,
+  PLANNED_STATUS,
+} from '../constants/sessionStatus.js';
 import { toISODate } from './dateFormat.js';
 import {
   BENCHMARK_GRACE_DAYS,
@@ -26,6 +29,8 @@ function baseState(entry, index) {
     matchedSessionId: null,
     daysUntilStart: null,
     daysOverdue: null,
+    rescheduledTo: null,
+    plannedSessionId: null,
     keywords: [],
   };
 }
@@ -50,6 +55,15 @@ function betterFit(a, b) {
   return a.session.id < b.session.id;
 }
 
+// Whole-token membership plus the ride-elevation exclusion — the label half of
+// eligibility, shared by the completed-session and planned-session passes. The
+// STATUS half is deliberately not shared: each pass keeps its own gate.
+function labelMatches(label, keywords) {
+  const tokens = tokenize(label);
+  if (!tokens.some((t) => keywords.includes(t))) return false;
+  return !hasRideDistance(tokens);
+}
+
 // Deterministic best fit, NOT the first row in payload order. The payload used
 // to be ordered by the TEXT date column, so '7/5/26' sorted above '6/23/26';
 // combined with a search range that runs forward to today, first-in-order let
@@ -64,9 +78,7 @@ function findMatch(sessions, keywords, searchStart, searchEnd, consumed, win) {
     if (consumed.has(s.id)) continue;
     const iso = toISODate(s.date);
     if (!iso || iso < searchStart || iso > searchEnd) continue;
-    const tokens = tokenize(s.label);
-    if (!tokens.some((t) => keywords.includes(t))) continue;
-    if (hasRideDistance(tokens)) continue;
+    if (!labelMatches(s.label, keywords)) continue;
     const cand = {
       session: s,
       iso,
@@ -75,6 +87,28 @@ function findMatch(sessions, keywords, searchStart, searchEnd, consumed, win) {
     if (best === null || betterFit(cand, best)) best = cand;
   }
   return best === null ? null : best.session;
+}
+
+// The rescheduling counterpart: the soonest FUTURE planned session that names
+// the benchmark. A planned row is a commitment, never evidence — it can only
+// move a badge from 'overdue' to 'scheduled', never to 'done', so the status
+// gate here is PLANNED_STATUS and must never be merged with findMatch's.
+// `today` is inclusive: a session dated today is still a live commitment.
+function findPlannedMatch(sessions, keywords, today, claimed) {
+  if (keywords.length === 0) return null;
+  let best = null;
+  for (const s of sessions) {
+    if (!s || s.status !== PLANNED_STATUS) continue;
+    if (claimed.has(s.id)) continue;
+    const iso = toISODate(s.date);
+    if (!iso || iso < today) continue;
+    if (!labelMatches(s.label, keywords)) continue;
+    const better =
+      best === null ||
+      (iso === best.iso ? s.id < best.session.id : iso < best.iso);
+    if (better) best = { session: s, iso };
+  }
+  return best;
 }
 
 export function resolveLadderStatuses(ladder, sessions, options = {}) {
@@ -155,7 +189,32 @@ export function resolveLadderStatuses(ladder, sessions, options = {}) {
     }
   }
 
+  // Second pass: an overdue benchmark with a future planned session is not
+  // being ignored, it has been moved. Only 'overdue' is an entry point — a
+  // planned row never touches a done, upcoming or quiet benchmark. A SEPARATE
+  // claim set from pass 1: one planned row must not clear two benchmarks.
+  const claimed = new Set();
+  for (const st of pending) {
+    if (st.status !== 'overdue') continue;
+    const hit = findPlannedMatch(rows, st.keywords, today, claimed);
+    if (!hit) continue;
+    claimed.add(hit.session.id);
+    st.status = 'scheduled';
+    st.rescheduledTo = hit.iso;
+    st.plannedSessionId = hit.session.id;
+  }
+
   return states;
+}
+
+// Loudest first: an overdue benchmark outranks one merely due soon, and both
+// outrank one already rescheduled. Ties keep ladder order.
+const SEVERITY_RANK = { overdue: 0, upcoming: 1, scheduled: 2 };
+
+export function compareBenchmarkSeverity(a, b) {
+  const ra = SEVERITY_RANK[a?.status] ?? 3;
+  const rb = SEVERITY_RANK[b?.status] ?? 3;
+  return ra === rb ? a.index - b.index : ra - rb;
 }
 
 export function selectUpcoming(states) {

--- a/web/src/utils/benchmarkStatus.js
+++ b/web/src/utils/benchmarkStatus.js
@@ -214,7 +214,7 @@ const SEVERITY_RANK = { overdue: 0, upcoming: 1, scheduled: 2 };
 export function compareBenchmarkSeverity(a, b) {
   const ra = SEVERITY_RANK[a?.status] ?? 3;
   const rb = SEVERITY_RANK[b?.status] ?? 3;
-  return ra === rb ? a.index - b.index : ra - rb;
+  return ra === rb ? (a?.index ?? 0) - (b?.index ?? 0) : ra - rb;
 }
 
 export function selectUpcoming(states) {

--- a/web/src/views/CalendarView.jsx
+++ b/web/src/views/CalendarView.jsx
@@ -10,16 +10,14 @@ import {
   dayStatus,
   daySessions,
 } from '../utils/schedule.js';
-import {
-  MICROCYCLE,
-  EVENT_LADDER,
-  PHASE_CONTEXT,
-} from '../constants/schedule.js';
+import { compareBenchmarkSeverity } from '../utils/benchmarkStatus.js';
+import { MICROCYCLE, PHASE_CONTEXT } from '../constants/schedule.js';
 
 // ── CALENDAR VIEW ──
 export default function CalendarView({ loggedSessions, isWide }) {
-  // Resolved once for the FULL ladder; the panel below indexes into it
-  // positionally, so the badges stay aligned if the slice is ever widened.
+  // Resolved once for the FULL ladder. Each state carries its own entry, so the
+  // panel below renders from the states themselves — a badge cannot drift onto
+  // the wrong row once the rows are re-ordered by severity.
   const benchmarkStatuses = useBenchmarkStatuses();
   const benchmarksUnavailable = useBenchmarkDataUnavailable();
   const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -67,6 +65,12 @@ export default function CalendarView({ loggedSessions, isWide }) {
   }
   const todayMode = firstMode;
   const todayCycle = MICROCYCLE[todayMode] || MICROCYCLE.home;
+  // Slice BEFORE sort: which five entries are visible stays a ladder decision,
+  // only their order is a severity one. .slice() copies, so the memoized hook
+  // result is never mutated.
+  const visibleEvents = benchmarkStatuses
+    .slice(0, 5)
+    .sort(compareBenchmarkSeverity);
   return (
     <>
       <div
@@ -218,8 +222,8 @@ export default function CalendarView({ loggedSessions, isWide }) {
             BENCHMARK STATUS UNAVAILABLE
           </div>
         )}
-        {EVENT_LADDER.slice(0, 5).map((e, i) => {
-          const bench = benchmarkStatuses[i];
+        {visibleEvents.map((bench, i) => {
+          const e = bench.entry;
           const col =
             e.kind === 'TARGET'
               ? '#ff2d55'
@@ -230,7 +234,7 @@ export default function CalendarView({ loggedSessions, isWide }) {
                   : '#00d4ff';
           return (
             <div
-              key={i}
+              key={bench.index}
               style={{
                 display: 'flex',
                 gap: 10,
@@ -259,14 +263,13 @@ export default function CalendarView({ loggedSessions, isWide }) {
                 }}
               >
                 {e.name}
-                {bench && (
-                  <BenchmarkBadge
-                    status={bench.status}
-                    fuzzy={bench.fuzzy}
-                    daysOverdue={bench.daysOverdue}
-                    daysUntilStart={bench.daysUntilStart}
-                  />
-                )}
+                <BenchmarkBadge
+                  status={bench.status}
+                  fuzzy={bench.fuzzy}
+                  daysOverdue={bench.daysOverdue}
+                  daysUntilStart={bench.daysUntilStart}
+                  rescheduledTo={bench.rescheduledTo}
+                />
               </div>
             </div>
           );

--- a/web/src/views/__tests__/CalendarView.benchmark.test.jsx
+++ b/web/src/views/__tests__/CalendarView.benchmark.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -53,6 +53,15 @@ function renderView() {
       <CalendarView loggedSessions={[]} isWide={false} />
     </QueryClientProvider>
   );
+}
+
+// The ladder panel's rows in DOM order, so severity ordering can be asserted
+// on the real surface rather than on the resolver's output.
+function ladderRowTexts() {
+  const heading = screen.getByText(/UPCOMING EVENTS · SEASON 1 LADDER/i);
+  return Array.from(heading.parentElement.children)
+    .filter((el) => el !== heading)
+    .map((el) => el.textContent);
 }
 
 beforeEach(() => {
@@ -154,5 +163,63 @@ describe('CalendarView + useBenchmarkStatuses (integration, unmocked hook)', () 
 
     const badged = badges.map((b) => b.parentElement.textContent).join('|');
     expect(badged).not.toContain('5k Time Trial');
+  });
+});
+
+// Rescheduling end-to-end: a `planned` row on the calendar is the whole gesture
+// — no button, no write, no new hook. The chain under test is the same one the
+// sibling cases use, extended by one pass.
+describe('CalendarView + a rescheduled benchmark (integration)', () => {
+  // Session 61 cancelled leaves CP Test #2 overdue, which is the only state a
+  // planned row is allowed to move.
+  const CP2_OVERDUE = [{ ...PAYLOAD[0], status: 'cancelled' }, PAYLOAD[1]];
+  const RETEST_LABEL = 'CP RETEST — 1min + 4min max';
+
+  // The clock is pinned for these two only. Every other case in this file rests
+  // on windows that are past for any real "today", but a FUTURE planned date is
+  // future only relative to the real one — unpinned, this pair would silently
+  // invert on 12 Sep 2026 rather than keep testing what it was written to test.
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 7, 22));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('AC2 badges CP Test #2 as rescheduled and sorts it below the 5k', async () => {
+    mockSessions([
+      ...CP2_OVERDUE,
+      { id: 300, date: '9/12/26', label: RETEST_LABEL, status: 'planned' },
+    ]);
+    renderView();
+
+    const badge = await screen.findByText(/^↻ RESCHEDULED/);
+    expect(badge.textContent).toContain('9/12/26');
+    expect(badge.parentElement.textContent).toContain(
+      'CP Test #2 (2nd duration)'
+    );
+
+    const overdue = screen.getAllByText(/^OVERDUE/);
+    expect(overdue).toHaveLength(1);
+    expect(overdue[0].parentElement.textContent).toContain('5k Time Trial');
+
+    const rows = ladderRowTexts();
+    expect(rows[0]).toContain('5k Time Trial');
+    expect(rows[1]).toContain('CP Test #2 (2nd duration)');
+  });
+
+  it('AC3 leaves both badges overdue when the planned session is in the past', async () => {
+    mockSessions([
+      ...CP2_OVERDUE,
+      { id: 300, date: '7/12/26', label: RETEST_LABEL, status: 'planned' },
+    ]);
+    renderView();
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/^OVERDUE/)).toHaveLength(2)
+    );
+    expect(screen.queryByText(/RESCHEDULED/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/views/__tests__/CalendarView.test.jsx
+++ b/web/src/views/__tests__/CalendarView.test.jsx
@@ -132,6 +132,26 @@ describe('CalendarView', () => {
     ]);
   });
 
+  // Slicing happens BEFORE sorting, so severity reorders the visible five but
+  // never changes which five they are. Without that order a benchmark going
+  // overdue deep in the ladder — the 2k Test, when its Jan 2027 window elapses
+  // — would silently displace a nearer event from the panel.
+  it('AC5 sorts within the visible five without changing which five they are', () => {
+    const states = quietStates();
+    const deep = states.length - 1;
+    expect(deep).toBeGreaterThan(4);
+    states[deep] = { ...states[deep], status: 'overdue', daysOverdue: 400 };
+    statusesMock.mockReturnValue(states);
+    renderView();
+
+    const rows = ladderRowTexts();
+    expect(rows).toHaveLength(5);
+    expect(rows.join(' ')).not.toContain(EVENT_LADDER[deep].name);
+    expect(screen.queryByText(/OVERDUE · 400d/)).toBeNull();
+    // Untouched ladder order behind the cut.
+    expect(rows[0]).toContain(EVENT_LADDER[0].name);
+  });
+
   it('AC4/AC5 renders a rescheduled badge and sorts it below the loud rows', () => {
     const states = quietStates();
     states[4] = { ...states[4], status: 'overdue', daysOverdue: 12 };

--- a/web/src/views/__tests__/CalendarView.test.jsx
+++ b/web/src/views/__tests__/CalendarView.test.jsx
@@ -25,6 +25,8 @@ function quietStates() {
     matchedSessionId: null,
     daysUntilStart: null,
     daysOverdue: null,
+    rescheduledTo: null,
+    plannedSessionId: null,
     keywords: [],
   }));
 }
@@ -40,6 +42,15 @@ function renderView() {
       <CalendarView loggedSessions={[]} isWide={false} />
     </QueryClientProvider>
   );
+}
+
+// The ladder panel's rows, in DOM order — the only way to assert that the loud
+// rows actually float to the top rather than merely rendering somewhere.
+function ladderRowTexts() {
+  const heading = screen.getByText(/UPCOMING EVENTS · SEASON 1 LADDER/i);
+  return Array.from(heading.parentElement.children)
+    .filter((el) => el !== heading)
+    .map((el) => el.textContent);
 }
 
 beforeEach(() => {
@@ -96,6 +107,52 @@ describe('CalendarView', () => {
     expect(badge.parentElement.textContent).toContain(
       'CP Test #2 (2nd duration)'
     );
+  });
+
+  // AC5 — five permanent warnings in ladder order is the same wallpaper the
+  // feature exists to remove. What is actionable has to be at the top.
+  it('AC5 sorts the visible rows overdue → upcoming → the rest', () => {
+    const states = quietStates();
+    states[4] = { ...states[4], status: 'overdue', daysOverdue: 12 };
+    states[1] = { ...states[1], status: 'upcoming', daysUntilStart: 3 };
+    statusesMock.mockReturnValue(states);
+    renderView();
+
+    const rows = ladderRowTexts();
+    expect(rows).toHaveLength(5);
+    expect(rows[0]).toContain(EVENT_LADDER[4].name);
+    expect(rows[0]).toContain('OVERDUE · 12d');
+    expect(rows[1]).toContain(EVENT_LADDER[1].name);
+    expect(rows[1]).toContain('DUE · 3d');
+    // The quiet remainder keeps ladder order behind them.
+    expect(rows.slice(2).map((t) => t.includes(EVENT_LADDER[0].name))).toEqual([
+      true,
+      false,
+      false,
+    ]);
+  });
+
+  it('AC4/AC5 renders a rescheduled badge and sorts it below the loud rows', () => {
+    const states = quietStates();
+    states[4] = { ...states[4], status: 'overdue', daysOverdue: 12 };
+    states[1] = { ...states[1], status: 'upcoming', daysUntilStart: 3 };
+    states[0] = {
+      ...states[0],
+      status: 'scheduled',
+      daysOverdue: 50,
+      rescheduledTo: '2026-09-12',
+      plannedSessionId: 300,
+    };
+    statusesMock.mockReturnValue(states);
+    renderView();
+
+    const badge = screen.getByText('↻ RESCHEDULED · 9/12/26 · 50d OVERDUE');
+    expect(badge.parentElement.textContent).toContain(EVENT_LADDER[0].name);
+
+    const rows = ladderRowTexts();
+    expect(rows[0]).toContain(EVENT_LADDER[4].name);
+    expect(rows[1]).toContain(EVENT_LADDER[1].name);
+    expect(rows[2]).toContain(EVENT_LADDER[0].name);
   });
 
   it('resolves the full ladder once, not per row', () => {

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -182,6 +182,11 @@ export default defineConfig({
           functions: 80,
           branches: 70,
         },
+        'src/views/CalendarView.jsx': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
       },
     },
   },


### PR DESCRIPTION
Closes #192

## What changed and why

CP Test #1, CP Test #2 and the 5k are overdue because they never happened, so they render `OVERDUE` indefinitely — roughly 197 days by the time the Jan 2027 windows open. A banner showing the same three warnings for six months becomes wallpaper, and alarm fatigue is how the original silent-slip bug recurs.

Rescheduling is expressed by putting a `planned` session on the calendar, not by a dismiss button. That capability already existed; the badge just never looked at it. **This is a read change** — no writes, no schema change, no new hook, nothing device-local that Coach cannot see.

An overdue benchmark with a future `planned` session that names it now renders `↻ RESCHEDULED · 9/12/26 · 31d OVERDUE`. Nothing goes silent: the row still renders, still names the benchmark, still carries `daysOverdue`.

**Containment is structural, not trusted.** A second pass runs after the existing matcher, iterates only states already resolved to `overdue`, and keeps its own claim set. So `scheduled` has exactly one inbound edge and a `planned` row has no path to `done` — verifiable by reading eight lines. The two status gates stay in two separate functions and the status list is never parameterised; only the label predicate is shared, so the ride-elevation exclusion cannot regress in one pass alone.

A `planned` row dated before today is a missed plan, not a reschedule, and leaves the warning standing — live sessions 43 and 56 are exactly that case, and there's a test replaying them.

## ⚠️ What you will and won't see on merge

**The reschedule half ships dormant.** No future-dated, label-matching `planned` row exists, so **no badge changes today**. Validation confirmed this by running the resolver against the live 92-row payload.

**The sort half ships live.** The panel reorders on first render:

| | Before | After |
|---|---|---|
| 1 | CP Test #1 *(no badge)* | **CP Test #2** `OVERDUE 33d` |
| 2 | CP Test #2 `OVERDUE 33d` | **5k Time Trial** `OVERDUE 12d` |
| 3 | 5k Time Trial `OVERDUE 12d` | CP Test #1 |
| 4–5 | Erg Power Series / C2 Monthly | *unchanged* |

Please don't file "rescheduling doesn't work" — it works, it's waiting for its first input.

## How to test manually

Insert a `planned` session dated in the future with a label naming a benchmark (e.g. `CP RETEST — 1min + 4min max`) and the CP Test #2 row should flip to the reschedule badge and sort below the remaining overdue row.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

620 tests (+25). Mutation-checked: disabling the second pass fails exactly 7 tests; reversing slice/sort fails exactly 1; folding the `scheduled` branch back into the trailing `else` fails 4.

**Merge order:** last. Rebase onto #213 first — they conflict on one comment block in `benchmarkStatus.js` (keep this branch's `labelMatches` **and** #213's past-tense wording; the code below the marker is byte-identical on both sides).

**Known limitation, filed separately:** the visible five are still chosen by ladder position before severity sorting, so a benchmark at index ≥ 5 going overdue stays invisible. Bites Feb 2027.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGRNSgkij9fa148Kmw8Eno)_