### PR TITLE
fix: give form-logged sessions a status so they count for something (#205)

### DIFF
--- a/web/src/components/LogSessionForm.jsx
+++ b/web/src/components/LogSessionForm.jsx
@@ -73,6 +73,12 @@ export default function LogSessionForm({ onSaved }) {
       const { error } = await supabase.from('sessions').insert({
         date,
         type: 'Strength',
+        // sessions.status is nullable with no default, and NULL is not in
+        // COMPLETED_STATUSES — an omitted status meant the row rendered in the
+        // log but counted for nothing: no TSS/CTL/ATL/TSB, and it could never
+        // clear a benchmark. 'completed' rather than 'logged': that one is the
+        // PM5 live-save path's marker.
+        status: 'completed',
         label: label.trim(),
         duration: duration.trim() || null,
         srpe,

--- a/web/src/components/__tests__/LogSessionForm.test.jsx
+++ b/web/src/components/__tests__/LogSessionForm.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { COMPLETED_STATUSES } from '../../constants/sessionStatus.js';
 
 // Mock the supabase client before importing the component under test.
 const insertMock = vi.fn();
@@ -92,6 +93,30 @@ describe('LogSessionForm', () => {
     expect(row.label).toBe('Lower 2');
     expect(row.user_id).toBe('user-123');
     expect(row.exercises).toEqual([expect.objectContaining({ name: 'Squat' })]);
+  });
+
+  // The column is nullable with no default, so omitting status wrote NULL —
+  // which is not in COMPLETED_STATUSES. The row showed up in the log and was
+  // invisible to CTL/ATL/TSB and to the benchmark matcher. Assert membership of
+  // the list the consumers actually gate on, not just the literal: a future
+  // edit to either side has to keep them agreeing.
+  it('saves a status the load and benchmark consumers count as completed', async () => {
+    const client = makeClient();
+    renderWithClient(<LogSessionForm />, client);
+
+    fireEvent.click(screen.getByText(/LOG A STRENGTH SESSION/i));
+    fireEvent.change(screen.getByPlaceholderText('Lower 2'), {
+      target: { value: 'Lower 2' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Exercise name'), {
+      target: { value: 'Squat' },
+    });
+    fireEvent.click(screen.getByText('SUBMIT SESSION'));
+
+    await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
+    const row = insertMock.mock.calls[0][0];
+    expect(row.status).toBe('completed');
+    expect(COMPLETED_STATUSES).toContain(row.status);
   });
 
   it('surfaces an error message and does not invalidate when the insert fails', async () => {


### PR DESCRIPTION
Closes #205

## What changed and why

`sessions.status` is nullable with **no column default**, and `LogSessionForm` inserted without naming it. `NULL` is not in `COMPLETED_STATUSES`, so a session logged through the form rendered in the log while being invisible to everything derived from it:

- `useTSSHistory` filters `.in('status', COMPLETED_STATUSES)` → the session contributed **nothing to CTL/ATL/TSB**
- `findMatch` in `benchmarkStatus.js` gates on the same list → it could **never clear a benchmark badge**

One line: `status: 'completed'` on the insert.

**Why `'completed'` and not `'logged'`:** `CLAUDE.md` reserves `'logged'` for the PM5 live-save path, and `ErgLiveView.jsx:618` is the only other place app code writes this column. A manually-logged session shouldn't claim to have come off the erg.

## How to test manually

Log a strength session through the form, then check the row carries `status = 'completed'` and that the training-load numbers move.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

656 tests (+7 file total). The new test asserts `COMPLETED_STATUSES` **membership**, not just the literal string — the bug was the value falling outside the list the consumers gate on, so that's the invariant worth pinning. Mutation-checked: removing the field again fails exactly that test.

## Notes

**Latent until now.** All 92 live `sessions` rows carry a non-null status, so the form has never actually been the source of a saved row — the defect was sitting in the write path waiting for first use.

**Not fixed here:** the column has no `NOT NULL` constraint and no default, so nothing at the database level would reject this class of omission. That's a migration and a separate decision — worth doing, since a backfill check shows zero null rows today, but it belongs in its own backend PR rather than riding along with a one-line frontend fix.

**Also noticed, not touched:** this insert writes `type: 'Strength'` (capital S), which does not match any `type` value currently in the table (`strength`, `Upper Strength`, `Lower Strength`, …). Possibly harmless, possibly a second consistency bug — out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGRNSgkij9fa148Kmw8Eno)_