### PR TITLE
feat: give EVENT_LADDER benchmarks a real link to their session (#188)

### DIFF
--- a/supabase/migrations/009_sessions_benchmark_key.sql
+++ b/supabase/migrations/009_sessions_benchmark_key.sql
@@ -1,0 +1,34 @@
+-- 009_sessions_benchmark_key.sql
+-- Additive + reversible. Gives sessions an explicit link to a season-ladder
+-- benchmark (#188), replacing the keyword-guessing resolver: a benchmark is
+-- "done" only when a completed session carries its slug here, never because of
+-- what words happen to appear in a session label.
+--
+-- Nullable, no default, no FK (the ladder is a git-committed JS constant, not a
+-- table) and deliberately NO CHECK on the value set: a CHECK would force a
+-- migration on every ladder rename, and an unrecognised key is already inert -
+-- it matches no ladder entry, so the benchmark simply stays due.
+--
+-- RLS is untouched. The four owner policies on public.sessions
+-- (001_enable_rls.sql:29-46) are column-agnostic, so the new column is covered
+-- from day one with zero policy edits.
+
+ALTER TABLE public.sessions
+  ADD COLUMN IF NOT EXISTS benchmark_key text;
+
+COMMENT ON COLUMN public.sessions.benchmark_key IS
+  'Explicit link to a season-ladder benchmark (#188). The canonical slug list is '
+  'EVENT_LADDER in web/src/constants/schedule.js - the `key` field on the '
+  'kind=benchmark entries: cp-test-1, cp-test-2, 5k-tt, 2k-test, tune-ups. A '
+  'value outside that list is inert: it matches no ladder entry, so the '
+  'benchmark stays due and nothing breaks. At most one non-null row per user may '
+  'hold each value - enforced by sessions_one_session_per_benchmark.';
+
+-- AC4, the half that survives a Coach-over-MCP write: a duplicate link raises
+-- 23505 at the database rather than silently producing an ambiguous badge.
+-- Partial, mirroring anchors_one_live_per_key (006_context_store.sql:56-57), so
+-- every currently-unlinked row sits outside the predicate and the index cannot
+-- fail on existing data.
+CREATE UNIQUE INDEX IF NOT EXISTS sessions_one_session_per_benchmark
+  ON public.sessions (user_id, benchmark_key)
+  WHERE benchmark_key IS NOT NULL;

--- a/supabase/migrations/009_sessions_benchmark_key_rollback.sql
+++ b/supabase/migrations/009_sessions_benchmark_key_rollback.sql
@@ -1,0 +1,10 @@
+-- Rollback for 009_sessions_benchmark_key.sql. NOT auto-applied.
+--
+-- Revert the Vercel deploy FIRST. A client whose .select() names benchmark_key
+-- against a schema without the column gets a PostgREST 400 on every sessions
+-- read - which is not just a lost link, it blanks every benchmark badge.
+--
+-- Order matters: the index is built on the column, so it goes first.
+
+DROP INDEX IF EXISTS public.sessions_one_session_per_benchmark;
+ALTER TABLE public.sessions DROP COLUMN IF EXISTS benchmark_key;

--- a/web/src/components/BenchmarkLinkControl.jsx
+++ b/web/src/components/BenchmarkLinkControl.jsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+import { THEME } from '../constants/theme.js';
+import { toISODate } from '../utils/dateFormat.js';
+
+// props:
+//   benchmarkKey    — string, required. The ladder entry's slug.
+//   benchmarkName   — string, required. For the aria-labels.
+//   linkedSessionId — number | null. Pass bench.matchedSessionId.
+//   sessions        — array of { id, date, label, status, benchmark_key }.
+//   onLink          — (sessionId | null) => void.
+//   busy            — bool. Disables the control while the write is in flight.
+//   error           — string | null. Rendered inline; keeps the select open.
+//
+// Presentational: no hooks beyond its own open/closed state, no data access.
+// The parent owns the mutation, so a failure comes back as `error` text rather
+// than being swallowed here — a 23505 means another session already claims this
+// benchmark, and the reader has to be told that.
+export default function BenchmarkLinkControl({
+  benchmarkKey,
+  benchmarkName,
+  linkedSessionId = null,
+  sessions = [],
+  onLink,
+  busy = false,
+  error = null,
+}) {
+  const [open, setOpen] = useState(false);
+  // An error keeps the select on screen, so the retry is one click away rather
+  // than behind a re-expand.
+  const expanded = open || Boolean(error);
+  const linked = linkedSessionId != null;
+
+  // The server orders sessions.date as TEXT, so the payload is not
+  // chronological. Sort here rather than trust it; the resolver no longer sorts
+  // at all. Ties on date break on the higher id — the later row of that day.
+  const candidates = sessions
+    .filter((s) => s && COMPLETED_STATUSES.includes(s.status))
+    .slice()
+    .sort((a, b) => {
+      const ai = toISODate(a.date);
+      const bi = toISODate(b.date);
+      if (ai !== bi) return ai < bi ? 1 : -1;
+      return b.id - a.id;
+    });
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={busy}
+        aria-expanded={expanded}
+        aria-label={`Link a session to ${benchmarkName}`}
+        style={{
+          border: 'none',
+          background: 'none',
+          padding: 0,
+          cursor: busy ? 'default' : 'pointer',
+          fontFamily: 'inherit',
+          fontSize: 9,
+          letterSpacing: 1,
+          fontWeight: 700,
+          marginLeft: 6,
+          color: linked ? THEME.green : THEME.textFaint,
+        }}
+      >
+        {linked ? 'LINKED ✓' : 'LINK'}
+      </button>
+      {expanded && (
+        <select
+          aria-label={`Session for ${benchmarkName}`}
+          value={linked ? String(linkedSessionId) : ''}
+          disabled={busy}
+          onChange={(ev) => onLink(Number(ev.target.value) || null)}
+          style={{
+            display: 'block',
+            background: THEME.field,
+            border: `1px solid ${THEME.border}`,
+            color: THEME.text,
+            borderRadius: 4,
+            fontSize: 10,
+            padding: '4px 6px',
+            fontFamily: 'inherit',
+            marginTop: 4,
+          }}
+        >
+          <option value="">— not done —</option>
+          {candidates.map((s) => {
+            // A row already claimed by ANOTHER benchmark stays visible but
+            // unselectable, so the state is legible instead of the session
+            // simply vanishing. The partial unique index is the half that holds.
+            const otherKey =
+              s.benchmark_key && s.benchmark_key !== benchmarkKey
+                ? s.benchmark_key
+                : null;
+            return (
+              <option
+                key={s.id}
+                value={String(s.id)}
+                disabled={Boolean(otherKey)}
+              >
+                {`${s.date} — ${s.label}${otherKey ? ` (linked: ${otherKey})` : ''}`}
+              </option>
+            );
+          })}
+        </select>
+      )}
+      {error && (
+        <div style={{ fontSize: 9, color: THEME.red, marginTop: 3 }}>
+          {error}
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/__tests__/BenchmarkLinkControl.test.jsx
+++ b/web/src/components/__tests__/BenchmarkLinkControl.test.jsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BenchmarkLinkControl from '../BenchmarkLinkControl.jsx';
+
+// Deliberately NOT in date order: the server sorts sessions.date as TEXT, so
+// this is the shape of payload the control actually receives.
+const SESSIONS = [
+  {
+    id: 61,
+    date: '7/5/26',
+    label: 'CP RETEST — 1min + 4min max',
+    status: 'completed',
+    benchmark_key: null,
+  },
+  {
+    id: 45,
+    date: '6/23/26',
+    label: 'CP Test - 4min MAX (GATED)',
+    status: 'completed',
+    benchmark_key: 'cp-test-1',
+  },
+  {
+    id: 70,
+    date: '8/3/26',
+    label: 'PM — 5,000m',
+    status: 'logged',
+    benchmark_key: null,
+  },
+  {
+    id: 80,
+    date: '8/20/26',
+    label: 'Planned 5k',
+    status: 'planned',
+    benchmark_key: null,
+  },
+  {
+    id: 81,
+    date: '8/19/26',
+    label: 'Abandoned 5k',
+    status: 'cancelled',
+    benchmark_key: null,
+  },
+];
+
+function renderControl(props = {}) {
+  return render(
+    <BenchmarkLinkControl
+      benchmarkKey="5k-tt"
+      benchmarkName="5k Time Trial"
+      linkedSessionId={null}
+      sessions={SESSIONS}
+      onLink={() => {}}
+      {...props}
+    />
+  );
+}
+
+describe('BenchmarkLinkControl', () => {
+  it('reads LINK when nothing is linked and LINKED ✓ when a session holds it', () => {
+    const { unmount } = renderControl();
+    expect(screen.getByRole('button')).toHaveTextContent('LINK');
+    expect(screen.getByRole('button')).not.toHaveTextContent('LINKED');
+    unmount();
+
+    renderControl({ linkedSessionId: 70 });
+    expect(screen.getByRole('button')).toHaveTextContent('LINKED ✓');
+  });
+
+  // The candidate list is the only place a planned or cancelled row could leak
+  // back in as an offerable "completion", so the filter is asserted directly.
+  it('offers only completed sessions, newest first', async () => {
+    const user = userEvent.setup();
+    renderControl();
+    await user.click(screen.getByRole('button'));
+
+    const labels = screen
+      .getAllByRole('option')
+      .map((o) => o.textContent.trim());
+    expect(labels).toEqual([
+      '— not done —',
+      '8/3/26 — PM — 5,000m',
+      '7/5/26 — CP RETEST — 1min + 4min max',
+      '6/23/26 — CP Test - 4min MAX (GATED) (linked: cp-test-1)',
+    ]);
+    expect(labels.join('|')).not.toContain('Planned 5k');
+    expect(labels.join('|')).not.toContain('Abandoned 5k');
+  });
+
+  // sessions.date is TEXT and unpadded, so two pieces on one day are
+  // indistinguishable by date alone. The later row of that day is the one more
+  // likely to be the test, so the higher id sorts first.
+  it('breaks a same-date tie on the higher id', async () => {
+    const user = userEvent.setup();
+    renderControl({
+      sessions: [
+        { id: 90, date: '8/3/26', label: 'AM shakeout', status: 'completed' },
+        { id: 91, date: '8/3/26', label: 'PM 5,000m', status: 'completed' },
+      ],
+    });
+    await user.click(screen.getByRole('button'));
+
+    expect(
+      screen.getAllByRole('option').map((o) => o.textContent.trim())
+    ).toEqual(['— not done —', '8/3/26 — PM 5,000m', '8/3/26 — AM shakeout']);
+  });
+
+  // Client-side half of AC4. It stays visible rather than being filtered out so
+  // "where did session 45 go?" is never a question.
+  it('renders a session claimed by another benchmark as disabled and says which', async () => {
+    const user = userEvent.setup();
+    renderControl();
+    await user.click(screen.getByRole('button'));
+
+    const claimed = screen.getByRole('option', { name: /cp-test-1/ });
+    expect(claimed).toBeDisabled();
+    expect(claimed.textContent).toContain('(linked: cp-test-1)');
+    expect(
+      screen.getByRole('option', { name: /PM — 5,000m/ })
+    ).not.toBeDisabled();
+  });
+
+  it('calls onLink with the session id on select and with null on "— not done —"', async () => {
+    const user = userEvent.setup();
+    const onLink = vi.fn();
+    renderControl({ onLink, linkedSessionId: 70 });
+    await user.click(screen.getByRole('button'));
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, '61');
+    expect(onLink).toHaveBeenCalledWith(61);
+
+    await user.selectOptions(select, '');
+    expect(onLink).toHaveBeenLastCalledWith(null);
+  });
+
+  // A 23505 is "another session already claims this benchmark". It must reach
+  // the reader, and the select must still be there to retry against.
+  it('renders the error inline and leaves the select open', () => {
+    renderControl({ error: 'Another session already claims this benchmark' });
+    expect(
+      screen.getByText('Another session already claims this benchmark')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('disables the button and the select while busy', async () => {
+    const user = userEvent.setup();
+    renderControl({ busy: true, error: 'nope' });
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('combobox')).toBeDisabled();
+
+    // A disabled toggle cannot be clicked open or shut.
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+});

--- a/web/src/constants/schedule.js
+++ b/web/src/constants/schedule.js
@@ -315,6 +315,7 @@ export const EVENT_LADDER = [
     date: 'Wed 1 Jul 26',
     name: 'CP Test #1 (4-min)',
     kind: 'benchmark',
+    key: 'cp-test-1',
     phase: 'Base',
     serves:
       'Keystone pt 1 — first clean rowing-test anchor on fresh legs (post-FIFO taper). 4-min all-out (C2 protocol, pace-able, on the ranking). Sets a trustworthy threshold anchor; CP+W′ model completed by test #2 next home week. Unlocks %CP pacing + Power Guide.',
@@ -323,6 +324,7 @@ export const EVENT_LADDER = [
     date: '~Mid Jul 26',
     name: 'CP Test #2 (2nd duration)',
     kind: 'benchmark',
+    key: 'cp-test-2',
     phase: 'Base',
     serves:
       'Keystone pt 2 — second maximal effort at a different duration (e.g. 1-min + the 4-min, or a longer 7-10min piece) to complete the 2-point power-duration model. More reliable than any single all-out test. Builds CP + W′ properly.',
@@ -331,6 +333,7 @@ export const EVENT_LADDER = [
     date: '~Early Aug 26',
     name: '5k Time Trial',
     kind: 'benchmark',
+    key: '5k-tt',
     phase: 'Base end',
     serves:
       'First real read on the 5000m format + what base built. Do fresh, low-stakes.',
@@ -355,6 +358,7 @@ export const EVENT_LADDER = [
     date: '~Mid Jan 27',
     name: '2k Test',
     kind: 'benchmark',
+    key: '2k-test',
     phase: 'Peak lead-in',
     serves:
       'Universal rowing benchmark — best single fitness measure, predicts across all distances. Pre-peak data.',
@@ -363,6 +367,7 @@ export const EVENT_LADDER = [
     date: 'Late Jan 27',
     name: '1000m + 1-min tune-ups',
     kind: 'benchmark',
+    key: 'tune-ups',
     phase: 'Peak',
     serves:
       'Race-specific rehearsals at Worlds distances, ~3-4wk out. Dial pacing, not compete.',

--- a/web/src/hooks/__tests__/useBenchmarkStatuses.test.js
+++ b/web/src/hooks/__tests__/useBenchmarkStatuses.test.js
@@ -11,13 +11,16 @@ vi.mock('../../supabaseClient.js', () => ({
   },
 }));
 
-import { useBenchmarkStatuses } from '../useBenchmarkStatuses.js';
+import {
+  useBenchmarkDataUnavailable,
+  useBenchmarkStatuses,
+} from '../useBenchmarkStatuses.js';
 import { EVENT_LADDER } from '../../constants/schedule.js';
 
 const TODAY = '2026-08-20';
-// The full ladder, not just entry 1. AC5 is the criterion the shipped defect
-// violated, and a one-entry ladder removes the entry that does the stealing —
-// this test was blind to its own bug. IDX is CP Test #2's position.
+// The full ladder, not just entry 1: a one-entry ladder cannot show that a link
+// lands on the benchmark it names and on no other. IDX is CP Test #2's
+// position, whose key is 'cp-test-2'.
 const LADDER = EVENT_LADDER;
 const IDX = 1;
 
@@ -25,16 +28,17 @@ const RETEST = {
   id: 61,
   date: '7/5/26',
   label: 'CP RETEST — 1min + 4min max (rested, fed)',
+  benchmark_key: 'cp-test-2',
 };
 
-// CP Test #1, genuinely completed eight days early. Present in the live table,
-// so the full-ladder tests below must carry it: without it CP Test #1 has no
-// candidate of its own and legitimately competes for the retest.
+// CP Test #1, completed eight days early and explicitly linked. Present in the
+// live table, so the full-ladder tests below carry it.
 const CP1_DONE = {
   id: 45,
   date: '6/23/26',
   label: 'CP Test - 4min MAX (GATED)',
   status: 'completed',
+  benchmark_key: 'cp-test-1',
 };
 
 let payload = { data: [], error: null };
@@ -93,20 +97,22 @@ describe('useBenchmarkStatuses', () => {
     await waitFor(() => expect(fromMock).toHaveBeenCalledWith('sessions'));
   });
 
-  // AC5 — the badge clears once the session is logged, with no edit to the
-  // existing invalidateQueries({ queryKey: ['sessions'] }) call sites: the
-  // benchmark key is a prefix match of theirs.
-  it('AC5 flips from overdue to quiet when the cancelled retest is completed', async () => {
+  // AC5 — the badge clears once the link lands, with no edit to the existing
+  // invalidateQueries({ queryKey: ['sessions'] }) call sites: the benchmark
+  // query key is a prefix match of theirs. The row itself never changes label
+  // or date here; only benchmark_key moves, which is the whole feature.
+  it('AC5 flips from overdue to quiet when the link lands', async () => {
     payload = {
-      data: [{ ...RETEST, status: 'cancelled' }, CP1_DONE],
+      data: [{ ...RETEST, status: 'completed', benchmark_key: null }, CP1_DONE],
       error: null,
     };
     mockSessions();
     const { result, client } = setup();
     await waitFor(() => expect(result.current[IDX].status).toBe('overdue'));
+    expect(result.current[IDX].matchedSessionId).toBeNull();
 
     payload = {
-      data: [{ ...RETEST, status: 'logged' }, CP1_DONE],
+      data: [{ ...RETEST, status: 'completed' }, CP1_DONE],
       error: null,
     };
     await client.invalidateQueries({ queryKey: ['sessions'] });
@@ -116,13 +122,14 @@ describe('useBenchmarkStatuses', () => {
     expect(result.current[0].matchedSessionId).toBe(45);
   });
 
-  // D1 — the clearing row must survive the payload size, not just the first page.
-  it('D1 resolves a clearing session sitting deep in the payload', async () => {
+  // D1 — the linked row must survive the payload size, not just the first page.
+  it('D1 resolves a linked session sitting deep in the payload', async () => {
     const filler = Array.from({ length: 300 }, (_, i) => ({
       id: 1000 + i,
       date: '7/15/26',
       label: 'UT2 40min recovery @ 130-142W',
       status: 'completed',
+      benchmark_key: null,
     }));
     payload = {
       data: [...filler, { ...RETEST, status: 'completed' }, CP1_DONE],
@@ -148,5 +155,39 @@ describe('useBenchmarkStatuses', () => {
     await waitFor(() =>
       expect(result.current).toHaveLength(EVENT_LADDER.length)
     );
+  });
+});
+
+// AC9's companion: the ladder resolving to all-`unknown` is indistinguishable
+// from "nothing due", so callers need a separate way to say the read failed.
+describe('useBenchmarkDataUnavailable', () => {
+  function setupFlag() {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    function Wrapper({ children }) {
+      return React.createElement(QueryClientProvider, { client }, children);
+    }
+    return renderHook(() => useBenchmarkDataUnavailable(), {
+      wrapper: Wrapper,
+    });
+  }
+
+  it('reports unavailable once the sessions read fails', async () => {
+    payload = { data: null, error: { message: 'boom' } };
+    mockSessions();
+    const { result } = setupFlag();
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  // Pending is deliberately NOT unavailable: a slow first read must not flash
+  // an outage line and then replace it with badges.
+  it('stays false while the read is pending and after it succeeds', async () => {
+    payload = { data: [], error: null };
+    mockSessions();
+    const { result } = setupFlag();
+    expect(result.current).toBe(false);
+    await waitFor(() => expect(fromMock).toHaveBeenCalled());
+    expect(result.current).toBe(false);
   });
 });

--- a/web/src/hooks/__tests__/useLinkBenchmarkSession.test.js
+++ b/web/src/hooks/__tests__/useLinkBenchmarkSession.test.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const fromMock = vi.fn();
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: (...args) => fromMock(...args),
+  },
+}));
+
+import { useLinkBenchmarkSession } from '../useLinkBenchmarkSession.js';
+
+// Every .update().eq() lands in `calls` in the order it was issued, so the
+// clear-then-set ORDER is directly assertable rather than merely implied.
+let calls;
+let results;
+
+function mockSessions() {
+  calls = [];
+  fromMock.mockImplementation((table) => ({
+    update: (values) => ({
+      eq: (column, value) => {
+        calls.push({ table, values, column, value });
+        const next = results.shift();
+        return Promise.resolve(next ?? { data: null, error: null });
+      },
+    }),
+  }));
+}
+
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+  function Wrapper({ children }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  }
+  const view = renderHook(() => useLinkBenchmarkSession(), {
+    wrapper: Wrapper,
+  });
+  return { ...view, client, invalidateSpy };
+}
+
+beforeEach(() => {
+  fromMock.mockReset();
+  results = [];
+  mockSessions();
+});
+
+describe('useLinkBenchmarkSession', () => {
+  // Risk 5. sessions_one_session_per_benchmark is a partial unique index on
+  // (user_id, benchmark_key), so setting the new holder while the incumbent
+  // still carries the key is a guaranteed 23505. Order is the fix, so order is
+  // the assertion — not just "both statements ran".
+  it('clears the incumbent before setting the new holder', async () => {
+    const { result } = setup();
+    await result.current.mutateAsync({
+      benchmarkKey: 'cp-test-2',
+      sessionId: 61,
+    });
+
+    expect(calls).toEqual([
+      {
+        table: 'sessions',
+        values: { benchmark_key: null },
+        column: 'benchmark_key',
+        value: 'cp-test-2',
+      },
+      {
+        table: 'sessions',
+        values: { benchmark_key: 'cp-test-2' },
+        column: 'id',
+        value: 61,
+      },
+    ]);
+  });
+
+  // AC4's database half. A duplicate arrives as a 23505 from Postgres; the hook
+  // must let it out so the control can say "another session already claims this
+  // benchmark" rather than silently reporting success.
+  it('surfaces a unique violation when another session already claims the benchmark', async () => {
+    results = [
+      { data: null, error: null },
+      {
+        data: null,
+        error: {
+          code: '23505',
+          message:
+            'duplicate key value violates unique constraint "sessions_one_session_per_benchmark"',
+        },
+      },
+    ];
+    const { result } = setup();
+
+    await expect(
+      result.current.mutateAsync({ benchmarkKey: 'cp-test-2', sessionId: 61 })
+    ).rejects.toMatchObject({ code: '23505' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error.code).toBe('23505');
+  });
+
+  it('throws when the clear fails and never attempts the set', async () => {
+    results = [{ data: null, error: { code: '42501', message: 'denied' } }];
+    const { result } = setup();
+
+    await expect(
+      result.current.mutateAsync({ benchmarkKey: 'cp-test-2', sessionId: 61 })
+    ).rejects.toMatchObject({ code: '42501' });
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('unlinks with the clear alone when sessionId is null', async () => {
+    const { result } = setup();
+    await result.current.mutateAsync({
+      benchmarkKey: '5k-tt',
+      sessionId: null,
+    });
+
+    expect(calls).toEqual([
+      {
+        table: 'sessions',
+        values: { benchmark_key: null },
+        column: 'benchmark_key',
+        value: '5k-tt',
+      },
+    ]);
+  });
+
+  it('treats an undefined sessionId as an unlink', async () => {
+    const { result } = setup();
+    await result.current.mutateAsync({ benchmarkKey: '5k-tt' });
+    expect(calls).toHaveLength(1);
+  });
+
+  // Prefix match, no `exact`: ['sessions','benchmark-window'] is a child of
+  // ['sessions'], so the badge refetches without touching any other call site.
+  it('invalidates the sessions query tree on success', async () => {
+    const { result, invalidateSpy } = setup();
+    await result.current.mutateAsync({
+      benchmarkKey: 'cp-test-1',
+      sessionId: 45,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
+  });
+
+  // The clear can land and the set fail, which nulls the key in the database
+  // while the cache still names the old holder. Invalidating only on success
+  // would leave the badge reading done against an unlinked row — a false-done,
+  // the one direction this design promises it cannot produce.
+  it('invalidates when the set fails after the clear landed', async () => {
+    results = [
+      { data: null, error: null },
+      { data: null, error: { code: '23505', message: 'duplicate key' } },
+    ];
+    const { result, invalidateSpy } = setup();
+
+    await expect(
+      result.current.mutateAsync({ benchmarkKey: 'cp-test-1', sessionId: 45 })
+    ).rejects.toMatchObject({ code: '23505' });
+
+    expect(calls).toHaveLength(2);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
+  });
+
+  it('invalidates when the clear itself fails', async () => {
+    results = [{ data: null, error: { code: '42501', message: 'denied' } }];
+    const { result, invalidateSpy } = setup();
+
+    await expect(
+      result.current.mutateAsync({ benchmarkKey: 'cp-test-1', sessionId: 45 })
+    ).rejects.toMatchObject({ code: '42501' });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sessions'] });
+  });
+});

--- a/web/src/hooks/useBenchmarkSessions.js
+++ b/web/src/hooks/useBenchmarkSessions.js
@@ -4,21 +4,22 @@ import { supabase } from '../supabaseClient.js';
 // Scoped read for the benchmark badges. The key is a CHILD of ['sessions'], so
 // the existing invalidateQueries({ queryKey: ['sessions'] }) calls in
 // LogSessionForm and ErgLiveView (neither passes `exact`) refetch it too and a
-// freshly-logged test clears its badge without any edit to those files.
+// freshly-linked test clears its badge without any edit to those files.
 //
 // limit 500 rather than useSessions()' 50 because the ladder resolver wants the
-// whole benchmark history, not a recency window: it searches back from each
-// event's own date, so a 50-row cut would hide older attempts. At 92 rows today
-// the limit never binds; ordering by date_iso makes the cut "the most recent
-// 500" if it ever does. The resolver filters by date itself and is
-// order-independent, so no id tiebreaker is needed here.
+// whole benchmark history, not a recency window: the planned pass searches
+// forward from today and a 50-row cut would hide older attempts. At 92 rows
+// today the limit never binds; ordering by date_iso makes the cut "the most
+// recent 500" if it ever does. Both passes are order-independent — the link
+// pass keys on benchmark_key with a lowest-id tie-break, the planned pass picks
+// the earliest ISO date — so no id tiebreaker is needed here.
 export function useBenchmarkSessions() {
   return useQuery({
     queryKey: ['sessions', 'benchmark-window'],
     queryFn: async () => {
       const { data, error } = await supabase
         .from('sessions')
-        .select('id, date, label, status')
+        .select('id, date, label, status, benchmark_key')
         .order('date_iso', { ascending: false, nullsFirst: false })
         .limit(500);
       if (error) throw error;

--- a/web/src/hooks/useLinkBenchmarkSession.js
+++ b/web/src/hooks/useLinkBenchmarkSession.js
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '../supabaseClient.js';
+import { invalidateSessionQueries } from '../utils/invalidateSessionQueries.js';
+
+// Moves a benchmark's link onto a session, or clears it. CLEAR THEN SET, never
+// the reverse: sessions_one_session_per_benchmark is a partial unique index on
+// (user_id, benchmark_key), so writing the new holder while the incumbent still
+// carries the key is a guaranteed 23505.
+//
+// Call with sessionId == null to unlink: step 1 alone is the whole operation.
+//
+// The two statements are NOT atomic. A failure between them leaves the
+// benchmark unlinked and its badge back to overdue — the safe direction, since
+// it can never produce a false-done, and re-running the link fixes it. A
+// single-user app does not need an RPC for this.
+//
+// Neither statement names user_id: sessions_update_own carries both USING and
+// WITH CHECK on auth.uid() = user_id, so RLS narrows both .eq() filters and a
+// cross-user write is impossible.
+export function useLinkBenchmarkSession() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ benchmarkKey, sessionId }) => {
+      const cleared = await supabase
+        .from('sessions')
+        .update({ benchmark_key: null })
+        .eq('benchmark_key', benchmarkKey);
+      if (cleared.error) throw cleared.error;
+      if (sessionId == null) return;
+
+      const claimed = await supabase
+        .from('sessions')
+        .update({ benchmark_key: benchmarkKey })
+        .eq('id', sessionId);
+      if (claimed.error) throw claimed.error;
+    },
+    // onSettled, not onSuccess: step 1 can succeed and step 2 fail, which nulls
+    // the key in the database while the cached payload still names the old
+    // holder. Invalidating only on success would leave the badge reading done
+    // against a row that no longer carries the key — the one direction this
+    // design promises it can never produce.
+    onSettled: () => {
+      invalidateSessionQueries(queryClient);
+    },
+  });
+}

--- a/web/src/utils/__tests__/benchmarkStatus.test.js
+++ b/web/src/utils/__tests__/benchmarkStatus.test.js
@@ -9,76 +9,91 @@ import { EVENT_LADDER } from '../../constants/schedule.js';
 
 const TODAY = '2026-08-20';
 
-const CP1 = EVENT_LADDER[0]; // 'Wed 1 Jul 26'   · CP Test #1 (4-min)
-const CP2 = EVENT_LADDER[1]; // '~Mid Jul 26'    · CP Test #2 (2nd duration)
-const TT5K = EVENT_LADDER[2]; // '~Early Aug 26' · 5k Time Trial
-const TEST2K = EVENT_LADDER[5]; // '~Mid Jan 27' · 2k Test
+const CP1 = EVENT_LADDER[0]; // 'Wed 1 Jul 26'   · CP Test #1 (4-min)  · cp-test-1
+const CP2 = EVENT_LADDER[1]; // '~Mid Jul 26'    · CP Test #2          · cp-test-2
+const TT5K = EVENT_LADDER[2]; // '~Early Aug 26' · 5k Time Trial       · 5k-tt
+const TEST2K = EVENT_LADDER[5]; // '~Mid Jan 27' · 2k Test             · 2k-test
 
-// Real rows, real labels, verified field-by-field against the live DB — the five
-// completed sessions that actually sit inside the ~Mid Jul window. None of them is a CP test, which is exactly why
-// window-only matching (any session in the window ⇒ done) is disqualified.
+// Real rows, real labels, verified field-by-field against the live DB — the
+// completed sessions that actually sit inside the ~Mid Jul window. None of them
+// is a CP test, and none of them carries a link, so none of them clears
+// anything. Before #188 the resolver guessed from these labels; now it cannot.
 const MID_JUL_DONE = [
   {
     id: 72,
     date: '7/11/26',
     label: 'UT1 55min steady @ 150-160W',
     status: 'completed',
+    benchmark_key: null,
   },
   {
     id: 74,
     date: '7/13/26',
     label: 'UT1 50min steady @ 148-158W',
     status: 'completed',
-  },
-  {
-    id: 91,
-    date: '7/14/26',
-    label: 'UT1 Steady 50min @ 158W + 10min WU',
-    status: 'completed',
+    benchmark_key: null,
   },
   {
     id: 79,
     date: '7/16/26',
     label: 'UT2 40min recovery @ 130-142W',
     status: 'completed',
+    benchmark_key: null,
   },
-  { id: 86, date: '7/20/26', label: 'Lower 1 (RDL-led)', status: 'completed' },
+  {
+    id: 86,
+    date: '7/20/26',
+    label: 'Lower 1 (RDL-led)',
+    status: 'completed',
+    benchmark_key: null,
+  },
 ];
 
-// The only session that names the CP retest — and it was cancelled.
-const CANCELLED_RETEST = {
-  id: 61,
-  date: '7/5/26',
-  label: 'CP RETEST — 1min + 4min max (rested, fed)',
-  status: 'cancelled',
-};
-
-// CP Test #1, genuinely done eight days early.
+// CP Test #1, genuinely done eight days early — and explicitly linked. The date
+// sits OUTSIDE the one-day 'Wed 1 Jul 26' window on purpose: a link ignores the
+// window entirely (spec C).
 const SESSION_45 = {
   id: 45,
   date: '6/23/26',
   label: 'CP Test - 4min MAX (GATED)',
   status: 'completed',
+  benchmark_key: 'cp-test-1',
 };
 
+// The only session that names the CP retest — and it was cancelled. Under the
+// link rule its label is irrelevant anyway; it stays as the fixture the live
+// ladder assertion below is built from.
+const CANCELLED_RETEST = {
+  id: 61,
+  date: '7/5/26',
+  label: 'CP RETEST — 1min + 4min max (rested, fed)',
+  status: 'cancelled',
+  benchmark_key: null,
+};
+
+// The completed rows inside the ~Early Aug window. None is a 5k, and none
+// carries a link, so none of them clears the 5k Time Trial.
 const EARLY_AUG_DONE = [
   {
     id: 97,
     date: '8/2/26',
     label: 'UT1 45min Ramp SR — peaks 250W',
     status: 'completed',
+    benchmark_key: null,
   },
   {
     id: 98,
     date: '8/4/26',
     label: '40min progressive build — final 10min @ 220W',
     status: 'completed',
+    benchmark_key: null,
   },
   {
     id: 90,
     date: '8/7/26',
     label: 'UT1 Steady 50min @ 164W (2:08.8/500) + 10min WU',
     status: 'completed',
+    benchmark_key: null,
   },
 ];
 
@@ -89,8 +104,79 @@ function resolve(ladder, sessions, today = TODAY) {
   });
 }
 
-describe('resolveLadderStatuses — due and overdue (AC1, AC2)', () => {
-  it('AC1 marks an elapsed benchmark with no matching session overdue', () => {
+describe('resolveLadderStatuses — the link decides done (AC1, AC3)', () => {
+  it('AC1 clears a benchmark from a linked session whose label says nothing about it', () => {
+    const row = {
+      id: 79,
+      date: '7/16/26',
+      label: 'UT2 40min recovery @ 130-142W',
+      status: 'completed',
+      benchmark_key: 'cp-test-1',
+    };
+    const [s] = resolve([CP1], [row]);
+    expect(s.status).toBe('quiet');
+    expect(s.done).toBe(true);
+    expect(s.matchedSessionId).toBe(79);
+  });
+
+  // The single most important test in this file. Before #188 this exact row
+  // cleared CP Test #1 by keyword; Scott's Gate 1 decision was that only a link
+  // may clear a benchmark, so the loudest possible label must now change
+  // nothing. If this test ever goes green-by-accident the feature is undone.
+  it('AC3 leaves a benchmark overdue when a session names it but carries no link', () => {
+    const namesItButUnlinked = {
+      id: 45,
+      date: '7/1/26', // squarely inside CP Test #1's window
+      label: 'CP Test - 4min MAX (GATED)',
+      status: 'completed',
+      benchmark_key: null,
+    };
+    const [s] = resolve([CP1], [namesItButUnlinked]);
+    expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
+    expect(s.matchedSessionId).toBeNull();
+  });
+
+  it('AC3b clears a benchmark whose linked session label names a different benchmark', () => {
+    const row = {
+      id: 61,
+      date: '7/5/26',
+      label: 'CP RETEST — 1min + 4min max',
+      status: 'completed',
+      benchmark_key: '5k-tt',
+    };
+    const [cp1, tt5k] = resolve([CP1, TT5K], [row]);
+    expect(tt5k.status).toBe('quiet');
+    expect(tt5k.done).toBe(true);
+    expect(tt5k.matchedSessionId).toBe(61);
+    expect(cp1.status).toBe('overdue');
+    expect(cp1.done).toBe(false);
+    expect(cp1.matchedSessionId).toBeNull();
+  });
+
+  // Spec C: a link ignores the window in BOTH directions. The badge clears
+  // because the link exists, never because the date looked plausible.
+  it.each([['2027-03-15'], ['2026-01-01']])(
+    'clears a linked benchmark logged well outside its window (%s)',
+    (date) => {
+      const [s] = resolve([CP1], [{ ...SESSION_45, date }]);
+      expect(s.status).toBe('quiet');
+      expect(s.done).toBe(true);
+      expect(s.matchedSessionId).toBe(45);
+    }
+  );
+
+  // Every remaining ~Mid Jul row is completed and none is linked, so CP Test #2
+  // stays overdue no matter how full the window is.
+  it('leaves a benchmark overdue when its whole window is full of unlinked completed rows', () => {
+    const [s] = resolve([CP2], MID_JUL_DONE);
+    expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
+  });
+});
+
+describe('resolveLadderStatuses — due and overdue (AC2)', () => {
+  it('AC2a marks an unlinked elapsed benchmark overdue', () => {
     const [s] = resolve([CP2], []);
     expect(s.status).toBe('overdue');
     expect(s.daysOverdue).toBe(31);
@@ -98,7 +184,7 @@ describe('resolveLadderStatuses — due and overdue (AC1, AC2)', () => {
     expect(s.matchedSessionId).toBeNull();
   });
 
-  it('AC2a marks a benchmark starting in 5 days upcoming', () => {
+  it('AC2b marks an unlinked benchmark starting in 5 days upcoming', () => {
     const entry = { date: '25 Aug 26', name: '2k Test', kind: 'benchmark' };
     const [s] = resolve([entry], []);
     expect(s.status).toBe('upcoming');
@@ -106,7 +192,7 @@ describe('resolveLadderStatuses — due and overdue (AC1, AC2)', () => {
     expect(s.daysOverdue).toBeNull();
   });
 
-  it('AC2b keeps a started-but-not-ended window upcoming', () => {
+  it('keeps a started-but-not-ended window upcoming', () => {
     const entry = { date: 'Mid Aug 26', name: '2k Test', kind: 'benchmark' };
     const [s] = resolve([entry], []);
     expect(s.status).toBe('upcoming');
@@ -119,176 +205,177 @@ describe('resolveLadderStatuses — due and overdue (AC1, AC2)', () => {
     expect(s.daysUntilStart).toBeNull();
   });
 
-  it('carries the window, fuzzy flag, keywords, entry and index through', () => {
+  it('AC2c carries the fuzzy flag on a fuzzy window', () => {
     const [s] = resolve([CP2], []);
     expect(s.window).toEqual({ start: '2026-07-11', end: '2026-07-20' });
     expect(s.fuzzy).toBe(true);
-    expect(s.keywords).toEqual(['cp']);
     expect(s.entry).toBe(CP2);
     expect(s.index).toBe(0);
   });
-});
 
-describe('resolveLadderStatuses — the real ladder today (AC3)', () => {
-  it('AC3a reports CP Test #2 overdue: the window is full of routine rows and the only CP session was cancelled', () => {
-    const [s] = resolve([CP2], [...MID_JUL_DONE, CANCELLED_RETEST]);
-    expect(s.status).toBe('overdue');
-    expect(s.done).toBe(false);
-  });
-
-  it('AC3b reports the 5k Time Trial overdue although every session in its window is completed', () => {
-    const [s] = resolve([TT5K], EARLY_AUG_DONE);
-    expect(s.status).toBe('overdue');
-    expect(s.done).toBe(false);
-  });
-
-  it('AC3c clears CP Test #1 from a session logged eight days before the window', () => {
-    const [s] = resolve([CP1], [SESSION_45]);
-    expect(s.status).toBe('quiet');
-    expect(s.done).toBe(true);
-    expect(s.matchedSessionId).toBe(45);
-  });
-
-  it('yields exactly two badges across the live ladder today', () => {
-    const states = resolve(EVENT_LADDER, [
-      SESSION_45,
-      ...MID_JUL_DONE,
-      CANCELLED_RETEST,
-      ...EARLY_AUG_DONE,
-    ]);
-    const loud = states.filter((s) => s.status !== 'quiet');
-    expect(loud.map((s) => [s.entry.name, s.status])).toEqual([
-      ['CP Test #2 (2nd duration)', 'overdue'],
-      ['5k Time Trial', 'overdue'],
-    ]);
+  // The one field the #188 contract removes. Asserting its absence is what
+  // stops a well-meaning revert quietly reinstating label inference.
+  // #188 removed keywords from the DONE decision, not from the module: the
+  // reschedule pass (#192) still derives them to spot a PLANNED session that
+  // names a benchmark. What must stay true is the narrower claim — keywords
+  // never clear anything — which the no-fallback test below enshrines.
+  it('derives keywords only for benchmark entries, never for competitions', () => {
+    const states = resolve(EVENT_LADDER, [SESSION_45]);
+    const benchmarks = states.filter((s) => s.entry.kind === 'benchmark');
+    const others = states.filter((s) => s.entry.kind !== 'benchmark');
+    expect(benchmarks.every((s) => s.keywords.length > 0)).toBe(true);
+    expect(others.every((s) => s.keywords.length === 0)).toBe(true);
   });
 });
 
-// The defect that shipped: every test above resolves a ONE-ENTRY ladder, which
-// removes the entry that does the stealing. These resolve the WHOLE ladder, in
-// the payload order the server actually returns.
-describe('resolveLadderStatuses — the whole ladder, real payload order', () => {
-  // sessions.date is TEXT, so .order('date', {ascending:false}) puts '7/5/26'
-  // above '6/23/26'. Selecting the first eligible row in payload order let CP
-  // Test #1 — whose search range runs forward to today, fifty days past its own
-  // one-day window — consume session 61 and leave CP Test #2 permanently
-  // overdue. Best-fit selection assigns each session to the benchmark it
-  // belongs to regardless of how the rows arrive.
-  const TEXT_DESC_PAYLOAD = [
-    {
-      id: 61,
-      date: '7/5/26',
-      label: 'CP RETEST — 1min + 4min max (rested, fed)',
-      status: 'completed',
-    },
-    {
-      id: 45,
-      date: '6/23/26',
-      label: 'CP Test - 4min MAX (GATED)',
-      status: 'completed',
-    },
-  ];
-
-  it('does not let CP Test #1 steal the session belonging to CP Test #2', () => {
-    const [first, second] = resolve(EVENT_LADDER, TEXT_DESC_PAYLOAD);
-    expect([first.matchedSessionId, second.matchedSessionId]).toEqual([45, 61]);
-    expect([first.status, second.status]).toEqual(['quiet', 'quiet']);
+describe('resolveLadderStatuses — the link index (AC4)', () => {
+  const sameKey = (id) => ({
+    id,
+    date: '6/29/26',
+    label: 'CP test 4min max',
+    status: 'completed',
+    benchmark_key: 'cp-test-1',
   });
 
-  it('assigns the same way when the payload arrives in ascending date order', () => {
-    const [first, second] = resolve(
-      EVENT_LADDER,
-      [...TEXT_DESC_PAYLOAD].reverse()
-    );
-    expect([first.matchedSessionId, second.matchedSessionId]).toEqual([45, 61]);
+  // The partial unique index makes this impossible at the database, but a stale
+  // cache or a client ahead of the migration can still hand the resolver two.
+  // Lowest id, not earliest date — the resolver never parses sessions.date.
+  it('AC4a takes the lowest id when two rows carry the same benchmark_key', () => {
+    const rows = [sameKey(86), sameKey(84)];
+    expect(resolve([CP1], rows)[0].matchedSessionId).toBe(84);
+    expect(resolve([CP1], [...rows].reverse())[0].matchedSessionId).toBe(84);
   });
 
-  it('AC3c leaves CP Test #2 overdue when only session 45 exists', () => {
-    const [first, second] = resolve(EVENT_LADDER, [
-      SESSION_45,
-      CANCELLED_RETEST,
-    ]);
+  it('AC4b a session with one key satisfies only that benchmark', () => {
+    const row = {
+      id: 200,
+      date: '6/29/26',
+      label: 'CP test 4min max',
+      status: 'completed',
+      benchmark_key: 'cp-test-1',
+    };
+    const [first, second] = resolve([CP1, CP2], [row]);
     expect(first.status).toBe('quiet');
-    expect(first.matchedSessionId).toBe(45);
+    expect(first.matchedSessionId).toBe(200);
     expect(second.status).toBe('overdue');
     expect(second.matchedSessionId).toBeNull();
   });
 
-  // AC4, as the story actually reads it: Scott does the missed retest today and
-  // the badge clears — with CP Test #1 already accounted for by session 45.
-  it('AC4 clears CP Test #2 when the retest is logged today', () => {
-    const loggedToday = {
-      id: 210,
-      date: '8/20/26',
-      label: 'CP RETEST — 1min + 4min max',
-      status: 'logged',
-    };
-    const states = resolve(EVENT_LADDER, [
-      loggedToday,
+  it('ignores a session row with a null benchmark_key', () => {
+    const [s] = resolve(
+      [CP2],
+      [
+        { id: 9, date: '7/15/26', label: 'CP retest', status: 'completed' },
+        {
+          id: 10,
+          date: '7/16/26',
+          label: 'CP retest',
+          status: 'completed',
+          benchmark_key: null,
+        },
+        {
+          id: 11,
+          date: '7/17/26',
+          label: 'CP retest',
+          status: 'completed',
+          benchmark_key: '',
+        },
+        null,
+      ]
+    );
+    expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
+    expect(s.matchedSessionId).toBeNull();
+  });
+
+  // Risk 3: Coach writes a slug that is not on the ladder. Benign by
+  // construction — it matches no entry, the benchmark stays due, nothing throws.
+  it('treats an unrecognised benchmark_key as inert', () => {
+    const [s] = resolve(
+      [CP2],
+      [
+        {
+          id: 12,
+          date: '7/15/26',
+          label: 'CP retest 4min max',
+          status: 'completed',
+          benchmark_key: 'cp-test-99',
+        },
+      ]
+    );
+    expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
+  });
+
+  it('resolves identically whichever order the payload arrives in', () => {
+    const rows = [
       SESSION_45,
       ...MID_JUL_DONE,
-      CANCELLED_RETEST,
-      ...EARLY_AUG_DONE,
-    ]);
-    expect(states[0].matchedSessionId).toBe(45);
-    expect(states[1].status).toBe('quiet');
-    expect(states[1].matchedSessionId).toBe(210);
-    const loud = states.filter((st) => st.status !== 'quiet');
-    expect(loud.map((st) => st.entry.name)).toEqual(['5k Time Trial']);
+      {
+        id: 61,
+        date: '7/5/26',
+        label: 'CP RETEST — 1min + 4min max',
+        status: 'completed',
+        benchmark_key: 'cp-test-2',
+      },
+    ];
+    const forward = resolve(EVENT_LADDER, rows);
+    const backward = resolve(EVENT_LADDER, [...rows].reverse());
+    expect(forward.map((s) => s.matchedSessionId)).toEqual(
+      backward.map((s) => s.matchedSessionId)
+    );
+    expect(forward.map((s) => s.status)).toEqual(backward.map((s) => s.status));
   });
 });
 
-describe('resolveLadderStatuses — 5k naming (FIX 2)', () => {
-  const in5kWindow = (id, label) => [
-    { id, date: '8/3/26', label, status: 'completed' },
+describe('resolveLadderStatuses — what counts as a completion (AC5)', () => {
+  const linked = (status) => [
+    {
+      id: 1,
+      date: '7/15/26',
+      label: 'CP retest 4min max',
+      status,
+      benchmark_key: 'cp-test-2',
+    },
   ];
 
-  it.each([['5,000m'], ['PM — 5,000m'], ['5000m Time Trial'], ['5k TT']])(
-    'clears the 5k benchmark from a session labelled %s',
-    (label) => {
-      const [st] = resolve([TT5K], in5kWindow(30, label));
-      expect(st.status).toBe('quiet');
-      expect(st.matchedSessionId).toBe(30);
-    }
-  );
-
-  // One character from a false clear: the comma fold must not turn '18.5km'
-  // into a '5k' token. A bike ride is not a 5k time trial.
-  it.each([['Zwift Loopin Lava — 35:45, 18.5km, 212m'], ['Erg Session 14:32']])(
-    'does not clear the 5k benchmark from %s',
-    (label) => {
-      const [st] = resolve([TT5K], in5kWindow(31, label));
-      expect(st.status).toBe('overdue');
-      expect(st.done).toBe(false);
-    }
-  );
-});
-
-describe('resolveLadderStatuses — what counts as done (AC4)', () => {
-  const labelled = (status) => [
-    { id: 1, date: '7/15/26', label: 'CP retest 4min max', status },
-  ];
-
-  it('AC4a does not count a cancelled session', () => {
-    expect(resolve([CP2], labelled('cancelled'))[0].status).toBe('overdue');
+  it('AC5a reverts to overdue when the linked session is cancelled', () => {
+    const [s] = resolve([CP2], linked('cancelled'));
+    expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
+    expect(s.matchedSessionId).toBeNull();
   });
 
-  it('AC4b does not count a planned session', () => {
-    expect(resolve([CP2], labelled('planned'))[0].status).toBe('overdue');
+  it('ignores a planned session even when it carries the benchmark_key', () => {
+    expect(resolve([CP2], linked('planned'))[0].status).toBe('overdue');
   });
 
-  it('AC4c reports overdue when there are no sessions at all', () => {
+  it('AC5b reverts when the linked session disappears from the payload', () => {
+    const before = resolve([CP2], linked('completed'));
+    expect(before[0].status).toBe('quiet');
+    expect(before[0].done).toBe(true);
+
+    const after = resolve([CP2], []);
+    expect(after[0].status).toBe('overdue');
+    expect(after[0].done).toBe(false);
+    expect(after[0].matchedSessionId).toBeNull();
+  });
+
+  it('reports overdue when there are no sessions at all', () => {
     expect(resolve([CP2], [])[0].status).toBe('overdue');
     expect(resolve([CP2], null)[0].status).toBe('overdue');
     expect(resolve([CP2], undefined)[0].status).toBe('overdue');
   });
 
-  it.each(COMPLETED_STATUSES)('AC4d counts a %s session as done', (status) => {
-    const [s] = resolve([CP2], labelled(status));
-    expect(s.status).toBe('quiet');
-    expect(s.done).toBe(true);
-    expect(s.matchedSessionId).toBe(1);
-  });
+  it.each(COMPLETED_STATUSES)(
+    'counts a %s session carrying the key as done',
+    (status) => {
+      const [s] = resolve([CP2], linked(status));
+      expect(s.status).toBe('quiet');
+      expect(s.done).toBe(true);
+      expect(s.matchedSessionId).toBe(1);
+    }
+  );
 });
 
 describe('resolveLadderStatuses — non-benchmark and unparseable entries (AC6, P2, L3)', () => {
@@ -305,6 +392,23 @@ describe('resolveLadderStatuses — non-benchmark and unparseable entries (AC6, 
     expect(states.every((s) => s.window === null)).toBe(true);
   });
 
+  it('AC6b ignores a benchmark_key naming a non-benchmark entry', () => {
+    const comp = EVENT_LADDER.find((e) => e.kind === 'competition');
+    const strayLink = [
+      {
+        id: 300,
+        date: '9/20/26',
+        label: 'Erg Power Series heat 1',
+        status: 'completed',
+        benchmark_key: comp.name,
+      },
+    ];
+    const [s] = resolve([comp], strayLink, '2027-12-31');
+    expect(s.status).toBe('quiet');
+    expect(s.done).toBe(false);
+    expect(s.matchedSessionId).toBeNull();
+  });
+
   it('P2 leaves a benchmark with an unreadable date quiet rather than throwing', () => {
     const entry = { date: 'someday', name: 'CP Test #3', kind: 'benchmark' };
     const [s] = resolve([entry], [SESSION_45]);
@@ -313,153 +417,48 @@ describe('resolveLadderStatuses — non-benchmark and unparseable entries (AC6, 
     expect(s.done).toBe(false);
   });
 
-  it('never auto-clears a benchmark whose name yields no keywords', () => {
+  it('leaves a benchmark entry carrying no key alone', () => {
     const entry = {
       date: '~Mid Jul 26',
-      name: 'Critical Power retest',
+      name: 'CP Test #3',
       kind: 'benchmark',
     };
-    const [s] = resolve(
-      [entry],
-      [
-        {
-          id: 5,
-          date: '7/15/26',
-          label: 'Critical Power retest',
-          status: 'completed',
-        },
-      ]
-    );
-    expect(s.keywords).toEqual([]);
+    const [s] = resolve([entry], [SESSION_45]);
     expect(s.status).toBe('overdue');
+    expect(s.done).toBe(false);
   });
 
   it('L3 returns an empty array for an empty ladder', () => {
     expect(resolve([], [])).toEqual([]);
     expect(resolve(null, [])).toEqual([]);
   });
+
+  it('leaves a null ladder entry quiet rather than throwing', () => {
+    const [s] = resolve([null], [SESSION_45]);
+    expect(s.status).toBe('quiet');
+    expect(s.done).toBe(false);
+  });
 });
 
-describe('resolveLadderStatuses — matching precision (P4, P5, AC7)', () => {
-  // A ride row ends "<time>, 22.4km, 1,000m" and that last field is ELEVATION.
-  // Once commas stopped splitting digit groups it tokenises to '1000m', which
-  // is a keyword of the 1000m benchmark — so the comma rule that made '5,000m'
-  // work also opened this. The km token is what separates a ride from a row.
-  it("P6 does not let a ride's elevation satisfy a distance benchmark", () => {
-    const K1000 = EVENT_LADDER.find((e) => e.name.startsWith('1000m'));
-    const [s] = resolveLadderStatuses(
-      [K1000],
-      [
-        {
-          id: 500,
-          date: '1/20/27',
-          label: 'Zwift Alpe du Zwift — 1:12:30, 22.4km, 1,000m',
-          status: 'completed',
-        },
-      ],
-      { today: '2027-02-05', sessionsReady: true }
-    );
-    expect(s.status).toBe('overdue');
-    expect(s.matchedSessionId).toBeNull();
+// Risk 4: a builder who slugifies `name` instead of reading the literal `key`
+// orphans every link the moment an entry is renamed. These are the five
+// hand-written literals the migration's column COMMENT points at.
+describe('EVENT_LADDER benchmark keys', () => {
+  it('carries the five literal slugs on the benchmark entries only', () => {
+    const benchmarks = EVENT_LADDER.filter((e) => e.kind === 'benchmark');
+    expect(benchmarks.map((e) => e.key)).toEqual([
+      'cp-test-1',
+      'cp-test-2',
+      '5k-tt',
+      '2k-test',
+      'tune-ups',
+    ]);
+    const others = EVENT_LADDER.filter((e) => e.kind !== 'benchmark');
+    expect(others.every((e) => !('key' in e))).toBe(true);
   });
+});
 
-  it('P6b still clears a rowed 5,000m, which carries no km token', () => {
-    const [s] = resolve(
-      [TT5K],
-      [{ id: 25, date: '8/5/26', label: 'PM — 5,000m', status: 'completed' }]
-    );
-    expect(s.status).toBe('quiet');
-    expect(s.matchedSessionId).toBe(25);
-  });
-
-  // Same-date rows are common here (7/20/26 -> 84/85/86), so the id tie-break
-  // is a live path, not a defensive one.
-  it('P7 breaks a same-date tie on the lower session id', () => {
-    const rows = [
-      {
-        id: 86,
-        date: '6/29/26',
-        label: 'CP test 4min max',
-        status: 'completed',
-      },
-      {
-        id: 84,
-        date: '6/29/26',
-        label: 'CP test 4min max',
-        status: 'completed',
-      },
-    ];
-    expect(resolve([CP1], rows)[0].matchedSessionId).toBe(84);
-    expect(resolve([CP1], [...rows].reverse())[0].matchedSessionId).toBe(84);
-  });
-
-  it('P4 does not let a 40min recovery row satisfy a 4min CP test', () => {
-    const [s] = resolve(
-      [CP1],
-      [
-        {
-          id: 79,
-          date: '7/1/26',
-          label: 'UT2 40min recovery @ 130-142W',
-          status: 'completed',
-        },
-      ]
-    );
-    expect(s.status).toBe('overdue');
-    expect(s.done).toBe(false);
-  });
-
-  // The discriminating case. '40min' above does not contain '4min' at all, so a
-  // naive label.includes(keyword) rejects it too and the test cannot tell the
-  // two implementations apart. '24min' does contain '4min', so substring
-  // matching would wrongly clear CP Test #1 here and whole-token must not.
-  it('P4 does not let a 24min row substring-match the 4min CP test', () => {
-    const label = 'UT2 24min recovery @ 130-142W';
-    expect(label.toLowerCase().includes('4min')).toBe(true);
-
-    const [s] = resolve(
-      [CP1],
-      [{ id: 80, date: '7/1/26', label, status: 'completed' }]
-    );
-    expect(s.status).toBe('overdue');
-    expect(s.done).toBe(false);
-    expect(s.matchedSessionId).toBeNull();
-  });
-
-  it('P5 lets only the earlier benchmark claim a shared CP session', () => {
-    const shared = {
-      id: 200,
-      date: '6/29/26',
-      label: 'CP test 4min max',
-      status: 'completed',
-    };
-    const [first, second] = resolve([CP1, CP2], [shared]);
-    expect(first.status).toBe('quiet');
-    expect(first.matchedSessionId).toBe(200);
-    expect(second.status).toBe('overdue');
-    expect(second.matchedSessionId).toBeNull();
-  });
-
-  // Claim order falls back to ladder position when two benchmarks open on the
-  // same day; without the tie-break the winner would depend on sort stability.
-  it('P5b breaks a claim-order tie on ladder position', () => {
-    const shape = { kind: 'benchmark', phase: 'Base', serves: 'calibration' };
-    const a = { ...shape, date: '~Mid Jul 26', name: 'CP Test A (4-min)' };
-    const b = { ...shape, date: '~Mid Jul 26', name: 'CP Test B (4-min)' };
-    const shared = {
-      id: 201,
-      date: '7/12/26',
-      label: 'CP test 4min max',
-      status: 'completed',
-    };
-
-    const [first, second] = resolve([a, b], [shared]);
-    expect(first.window.start).toBe(second.window.start);
-    expect(first.matchedSessionId).toBe(201);
-    expect(second.matchedSessionId).toBeNull();
-    expect(second.status).toBe('overdue');
-  });
-
+describe('resolveLadderStatuses — ordering and windows', () => {
   it('AC7 keeps same-month benchmarks in different years independent', () => {
     const lastYear = {
       date: '~Mid Jan 26',
@@ -477,23 +476,6 @@ describe('resolveLadderStatuses — matching precision (P4, P5, AC7)', () => {
     const states = resolve([CP2, CP1], []);
     expect(states.map((s) => s.entry)).toEqual([CP2, CP1]);
     expect(states.map((s) => s.index)).toEqual([0, 1]);
-  });
-
-  it('honours a graceDays override', () => {
-    const tight = resolveLadderStatuses([CP1], [SESSION_45], {
-      today: TODAY,
-      sessionsReady: true,
-      graceDays: 3,
-    });
-    expect(tight[0].status).toBe('overdue');
-  });
-
-  it('ignores sessions with an unreadable date', () => {
-    const [s] = resolve(
-      [CP2],
-      [{ id: 9, date: 'sometime', label: 'CP retest', status: 'completed' }]
-    );
-    expect(s.status).toBe('overdue');
   });
 });
 
@@ -513,6 +495,11 @@ describe('resolveLadderStatuses — loading (L1) and selectUpcoming', () => {
   it('reports unknown when today is missing', () => {
     const states = resolveLadderStatuses([CP2], [], { sessionsReady: true });
     expect(states[0].status).toBe('unknown');
+  });
+
+  it('reports unknown when the options bag is absent or null', () => {
+    expect(resolveLadderStatuses([CP2], [])[0].status).toBe('unknown');
+    expect(resolveLadderStatuses([CP2], [], null)[0].status).toBe('unknown');
   });
 
   it('selectUpcoming returns only the upcoming states', () => {
@@ -616,6 +603,7 @@ describe('resolveLadderStatuses — rescheduled via a planned session', () => {
           date: '7/15/26',
           label: 'CP retest 4min max',
           status: 'completed',
+          benchmark_key: 'cp-test-2',
         },
         planned(304, '9/12/26', CP_RETEST),
       ]

--- a/web/src/utils/__tests__/eventWindow.test.js
+++ b/web/src/utils/__tests__/eventWindow.test.js
@@ -1,7 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { EVENT_LADDER } from '../../constants/schedule.js';
 import {
-  BENCHMARK_GRACE_DAYS,
   addCalendarDays,
   benchmarkKeywords,
   diffCalendarDays,
@@ -181,9 +180,7 @@ describe('calendar arithmetic', () => {
   });
 
   it('adds and subtracts days across month boundaries', () => {
-    expect(addCalendarDays('2026-07-11', -BENCHMARK_GRACE_DAYS)).toBe(
-      '2026-06-27'
-    );
+    expect(addCalendarDays('2026-07-11', -14)).toBe('2026-06-27');
     expect(addCalendarDays('2026-02-28', 1)).toBe('2026-03-01');
     expect(addCalendarDays('2028-02-28', 1)).toBe('2028-02-29');
   });

--- a/web/src/utils/benchmarkStatus.js
+++ b/web/src/utils/benchmarkStatus.js
@@ -4,8 +4,6 @@ import {
 } from '../constants/sessionStatus.js';
 import { toISODate } from './dateFormat.js';
 import {
-  BENCHMARK_GRACE_DAYS,
-  addCalendarDays,
   benchmarkKeywords,
   diffCalendarDays,
   parseEventWindow,
@@ -13,8 +11,32 @@ import {
 } from './eventWindow.js';
 
 // Pure resolver: given the event ladder and the session rows, decide which
-// benchmarks are overdue, due soon, or quiet. `today` is INJECTED — nothing
-// below the hook layer reads the clock, so every case is reproducible.
+// benchmarks are overdue, due soon, rescheduled, or quiet. `today` is
+// INJECTED — nothing below the hook layer reads the clock, so every case is
+// reproducible.
+//
+// Two passes over disjoint row sets, and the split is the whole design:
+//
+//   Pass 1 — DONE, from COMPLETED rows, by EXPLICIT LINK only (#188). A
+//   completed session carries the ladder entry's slug in
+//   sessions.benchmark_key. Label text is never read to CLEAR a benchmark, so
+//   no wording can clear one and no wording can stop one clearing. The link
+//   also ignores the window: a test logged weeks late still counts, because a
+//   date gate would be a second implicit input in a different costume.
+//
+//   Pass 2 — RESCHEDULED, from PLANNED rows, by label keywords (#192). A
+//   planned row is a commitment, never evidence: it can only move a badge from
+//   'overdue' to 'scheduled', never to 'done'. Keyword matching is safe here
+//   precisely because the worst case is a badge that says "moved" instead of
+//   "late" — it can never fabricate a completed benchmark.
+//
+// So the invariant is not "label text is never read", it is: label text is
+// never read to clear a benchmark, only to reschedule one. The status gates of
+// the two passes are disjoint and must never be merged.
+//
+// Neither pass lets payload order change an outcome: pass 1 keys on
+// benchmark_key with a lowest-id tie-break, pass 2 picks the earliest ISO date
+// with a lowest-id tie-break.
 
 const UPCOMING_WITHIN_DAYS = 7;
 
@@ -44,55 +66,38 @@ function hasRideDistance(tokens) {
   return tokens.some((t) => /^\d+(?:\.\d+)?km$/.test(t));
 }
 
-// Ranks two eligible candidates: a session dated inside the entry's own window
-// beats one only in the grace/forward slack, then the earlier date wins, then
-// the lower id. Never "nearest to the window" — session 61 (7/5, four days off
-// the 7/1 window) is nearer than session 45 (6/23, eight days), so nearest-first
-// leaves the steal in place.
-function betterFit(a, b) {
-  if (a.inWindow !== b.inWindow) return a.inWindow;
-  if (a.iso !== b.iso) return a.iso < b.iso;
-  return a.session.id < b.session.id;
-}
-
-// Whole-token membership plus the ride-elevation exclusion — the label half of
-// eligibility, shared by the completed-session and planned-session passes. The
-// STATUS half is deliberately not shared: each pass keeps its own gate.
+// Whole-token membership plus the ride-elevation exclusion. Used by the PLANNED
+// pass only — the completed pass reads benchmark_key and never a label.
 function labelMatches(label, keywords) {
   const tokens = tokenize(label);
   if (!tokens.some((t) => keywords.includes(t))) return false;
   return !hasRideDistance(tokens);
 }
 
-// Deterministic best fit, NOT the first row in payload order. The payload used
-// to be ordered by the TEXT date column, so '7/5/26' sorted above '6/23/26';
-// combined with a search range that runs forward to today, first-in-order let
-// CP Test #1 consume the session that belongs to CP Test #2 and the later badge
-// could never clear. Choosing by date instead of position also makes the result
-// independent of how the server happened to sort the rows.
-function findMatch(sessions, keywords, searchStart, searchEnd, consumed, win) {
-  if (keywords.length === 0) return null;
-  let best = null;
-  for (const s of sessions) {
-    if (!s || !COMPLETED_STATUSES.includes(s.status)) continue;
-    if (consumed.has(s.id)) continue;
-    const iso = toISODate(s.date);
-    if (!iso || iso < searchStart || iso > searchEnd) continue;
-    if (!labelMatches(s.label, keywords)) continue;
-    const cand = {
-      session: s,
-      iso,
-      inWindow: iso >= win.start && iso <= win.end,
-    };
-    if (best === null || betterFit(cand, best)) best = cand;
+// At most one completed session per key, lowest id wins a collision. `id` is a
+// bigint identity column — always present, always comparable, independent of
+// payload order. NOT earliest date: sessions.date is TEXT and needs a parse
+// that can fail. The partial unique index sessions_one_session_per_benchmark
+// makes a collision impossible at the database; this keeps the resolver
+// deterministic anyway, against a stale cache or a client ahead of the
+// migration.
+function buildLinkIndex(rows) {
+  const byKey = new Map();
+  for (const row of rows) {
+    if (!row) continue;
+    const key = row.benchmark_key;
+    if (typeof key !== 'string' || key === '') continue;
+    if (!COMPLETED_STATUSES.includes(row.status)) continue;
+    const held = byKey.get(key);
+    if (held === undefined || row.id < held.id) byKey.set(key, row);
   }
-  return best === null ? null : best.session;
+  return byKey;
 }
 
 // The rescheduling counterpart: the soonest FUTURE planned session that names
 // the benchmark. A planned row is a commitment, never evidence — it can only
 // move a badge from 'overdue' to 'scheduled', never to 'done', so the status
-// gate here is PLANNED_STATUS and must never be merged with findMatch's.
+// gate here is PLANNED_STATUS and must never be merged with the link pass's.
 // `today` is inclusive: a session dated today is still a live commitment.
 function findPlannedMatch(sessions, keywords, today, claimed) {
   if (keywords.length === 0) return null;
@@ -113,11 +118,7 @@ function findPlannedMatch(sessions, keywords, today, claimed) {
 
 export function resolveLadderStatuses(ladder, sessions, options = {}) {
   const entries = Array.isArray(ladder) ? ladder : [];
-  const {
-    today,
-    sessionsReady,
-    graceDays = BENCHMARK_GRACE_DAYS,
-  } = options ?? {};
+  const { today, sessionsReady } = options ?? {};
   const states = entries.map(baseState);
 
   // Loading or errored data is never overdue and never done — the badge stays
@@ -125,7 +126,9 @@ export function resolveLadderStatuses(ladder, sessions, options = {}) {
   if (!sessionsReady || !today) return states;
 
   const rows = Array.isArray(sessions) ? sessions : [];
+  const links = buildLinkIndex(rows);
   const pending = [];
+
   for (const st of states) {
     if (!st.entry || st.entry.kind !== 'benchmark') {
       st.status = 'quiet';
@@ -142,8 +145,8 @@ export function resolveLadderStatuses(ladder, sessions, options = {}) {
     pending.push(st);
   }
 
-  // Claim order is chronological: an earlier benchmark takes the session first,
-  // so one CP effort cannot silently clear two CP tests.
+  // Chronological, so that when two overdue benchmarks could both claim the
+  // same planned session in pass 2, the earlier one takes it.
   pending.sort((a, b) =>
     a.window.start === b.window.start
       ? a.index - b.index
@@ -152,30 +155,16 @@ export function resolveLadderStatuses(ladder, sessions, options = {}) {
         : 1
   );
 
-  const consumed = new Set();
   for (const st of pending) {
-    const searchStart = addCalendarDays(st.window.start, -graceDays);
-    const searchEnd = st.window.end > today ? st.window.end : today;
-    const match =
-      searchStart === null
-        ? null
-        : findMatch(
-            rows,
-            st.keywords,
-            searchStart,
-            searchEnd,
-            consumed,
-            st.window
-          );
-    if (match) {
-      consumed.add(match.id);
+    const linked = st.entry.key ? links.get(st.entry.key) : undefined;
+    if (linked) {
       st.done = true;
-      st.matchedSessionId = match.id;
+      st.matchedSessionId = linked.id;
+      st.status = 'quiet';
+      continue;
     }
 
-    if (st.done) {
-      st.status = 'quiet';
-    } else if (today > st.window.end) {
+    if (today > st.window.end) {
       st.status = 'overdue';
       st.daysOverdue = diffCalendarDays(st.window.end, today);
     } else {

--- a/web/src/utils/eventWindow.js
+++ b/web/src/utils/eventWindow.js
@@ -1,17 +1,18 @@
 // Interprets the human prose in EVENT_LADDER[].date ("~Mid Jul 26",
 // "12 Sep-9 Oct 26", "Wed 1 Jul 26") into a concrete calendar interval, plus
-// the keyword/token helpers that decide whether a logged session represents a
-// given benchmark. This is a PARSER, not a formatter — it never produces a
-// display string, so it introduces no second formatDate variant.
+// the keyword/token helpers used to spot a PLANNED session that names a
+// benchmark. This is a PARSER, not a formatter — it never produces a display
+// string, so it introduces no second formatDate variant.
+//
+// The keyword helpers no longer say anything about which session SATISFIES a
+// benchmark: being done is an explicit link (sessions.benchmark_key, #188) read
+// by benchmarkStatus.js, never an inference from label text. They survive for
+// the reschedule pass only (#192), where the worst case is a badge reading
+// "moved" instead of "late" — never a fabricated completion.
 //
 // Every date crosses a function boundary as an ISO 'YYYY-MM-DD' STRING, never a
 // Date object, so comparisons are zero-padded lexical compares and timezone
 // never enters them. todayISO() is the ONLY function here that reads the clock.
-
-// Days of slack allowed BEFORE a benchmark window opens when searching for the
-// session that satisfies it. Tests done early (or a slipped date logged against
-// the original plan) still clear the signal.
-export const BENCHMARK_GRACE_DAYS = 14;
 
 // Hand-seeded benchmark vocabulary. 'cp' is the sole benchmark identifier that
 // carries no digit, so the digit-bearing token rule below cannot derive it.

--- a/web/src/views/CalendarView.jsx
+++ b/web/src/views/CalendarView.jsx
@@ -1,9 +1,13 @@
+import { useState } from 'react';
 import WorkoutItem from '../components/WorkoutItem.jsx';
 import BenchmarkBadge from '../components/BenchmarkBadge.jsx';
+import BenchmarkLinkControl from '../components/BenchmarkLinkControl.jsx';
 import {
   useBenchmarkStatuses,
   useBenchmarkDataUnavailable,
 } from '../hooks/useBenchmarkStatuses.js';
+import { useBenchmarkSessions } from '../hooks/useBenchmarkSessions.js';
+import { useLinkBenchmarkSession } from '../hooks/useLinkBenchmarkSession.js';
 import {
   getRosterMode,
   resolveDay,
@@ -20,6 +24,18 @@ export default function CalendarView({ loggedSessions, isWide }) {
   // the wrong row once the rows are re-ordered by severity.
   const benchmarkStatuses = useBenchmarkStatuses();
   const benchmarksUnavailable = useBenchmarkDataUnavailable();
+  // Same query key useBenchmarkStatuses already reads, so react-query serves it
+  // from cache — this is not a second request.
+  const { data: benchmarkSessions } = useBenchmarkSessions();
+  const link = useLinkBenchmarkSession();
+  // One mutation serves every row, so remember which benchmark issued the write
+  // and show its busy/error state against that row only.
+  const [linkingKey, setLinkingKey] = useState(null);
+  const linkError = link.isError
+    ? link.error?.code === '23505'
+      ? 'Another session already claims this benchmark'
+      : link.error?.message || 'Could not save the link'
+    : null;
   const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   const monthNames = [
     'Jan',
@@ -270,6 +286,23 @@ export default function CalendarView({ loggedSessions, isWide }) {
                   daysUntilStart={bench.daysUntilStart}
                   rescheduledTo={bench.rescheduledTo}
                 />
+                {/* status 'unknown' means the sessions read is pending or failed
+                    (#188). Rendering then would flash LINK before flipping to
+                    LINKED, and offer a picker over an empty candidate list. */}
+                {e.kind === 'benchmark' && bench.status !== 'unknown' && (
+                  <BenchmarkLinkControl
+                    benchmarkKey={e.key}
+                    benchmarkName={e.name}
+                    linkedSessionId={bench.matchedSessionId}
+                    sessions={benchmarkSessions ?? []}
+                    onLink={(sessionId) => {
+                      setLinkingKey(e.key);
+                      link.mutate({ benchmarkKey: e.key, sessionId });
+                    }}
+                    busy={link.isPending && linkingKey === e.key}
+                    error={linkingKey === e.key ? linkError : null}
+                  />
+                )}
               </div>
             </div>
           );

--- a/web/src/views/__tests__/CalendarView.benchmark.test.jsx
+++ b/web/src/views/__tests__/CalendarView.benchmark.test.jsx
@@ -15,21 +15,25 @@ vi.mock('../../supabaseClient.js', () => ({
 
 import CalendarView from '../CalendarView.jsx';
 
-// Live ids and labels; session 61's status is the counterfactual under test
-// (it is cancelled in the table). Its date sorts ABOVE 45's under the text
-// ordering the server applies, so this is the payload order the app receives.
+// Live ids and labels, now carrying explicit links (#188). Session 61's status
+// is the counterfactual under test (it is cancelled in the table). Its date
+// sorts ABOVE 45's under the text ordering the server applies, so this is the
+// payload order the app receives — and the outcome no longer depends on it,
+// because the resolver keys on benchmark_key and never reads sessions.date.
 const PAYLOAD = [
   {
     id: 61,
     date: '7/5/26',
     label: 'CP RETEST — 1min + 4min max (rested, fed)',
     status: 'completed',
+    benchmark_key: 'cp-test-2',
   },
   {
     id: 45,
     date: '6/23/26',
     label: 'CP Test - 4min MAX (GATED)',
     status: 'completed',
+    benchmark_key: 'cp-test-1',
   },
 ];
 
@@ -72,7 +76,7 @@ describe('CalendarView + useBenchmarkStatuses (integration, unmocked hook)', () 
   // Every ladder window below is in the past for any real "today" from
   // 2026-08-20 on, so the outcome does not drift with the wall clock. The day
   // count inside the badge does, hence the prefix match.
-  it('badges only the 5k Time Trial row once both CP tests are accounted for', async () => {
+  it('badges only the 5k Time Trial row once both CP tests are linked', async () => {
     mockSessions(PAYLOAD);
     renderView();
 
@@ -81,7 +85,7 @@ describe('CalendarView + useBenchmarkStatuses (integration, unmocked hook)', () 
     expect(screen.getAllByText(/^OVERDUE/)).toHaveLength(1);
   });
 
-  it('badges CP Test #2 as well when its retest was cancelled', async () => {
+  it('badges CP Test #2 as well when its linked retest was cancelled', async () => {
     mockSessions([{ ...PAYLOAD[0], status: 'cancelled' }, PAYLOAD[1]]);
     renderView();
 
@@ -147,13 +151,19 @@ describe('CalendarView + useBenchmarkStatuses (integration, unmocked hook)', () 
   // absence assertion on its own satisfies on the first tick while the query is
   // still pending — it passes against an empty payload and against the pre-fix
   // code, which is the toothless shape this file exists to prevent. Leaving CP
-  // Test #2 overdue gives the wait something real to settle on: pre-fix, the 5k
-  // is still overdue too and the count is 2.
-  it('clears only the 5k badge when the trial is logged as 5,000m', async () => {
+  // Test #2 overdue gives the wait something real to settle on: without the
+  // link, the 5k is still overdue too and the count is 2.
+  it('clears only the 5k badge when a session carries benchmark_key 5k-tt', async () => {
     mockSessions([
       { ...PAYLOAD[0], status: 'cancelled' },
       PAYLOAD[1],
-      { id: 25, date: '8/3/26', label: 'PM — 5,000m', status: 'completed' },
+      {
+        id: 25,
+        date: '8/3/26',
+        label: 'PM — steady 5,000m',
+        status: 'completed',
+        benchmark_key: '5k-tt',
+      },
     ]);
     renderView();
 
@@ -163,6 +173,27 @@ describe('CalendarView + useBenchmarkStatuses (integration, unmocked hook)', () 
 
     const badged = badges.map((b) => b.parentElement.textContent).join('|');
     expect(badged).not.toContain('5k Time Trial');
+  });
+
+  // AC3, at the view. The label is the strongest possible keyword match for the
+  // 5k, and it clears nothing, because nothing links it.
+  it('leaves the 5k overdue when a session names it but carries no link', async () => {
+    mockSessions([
+      PAYLOAD[0],
+      PAYLOAD[1],
+      {
+        id: 26,
+        date: '8/3/26',
+        label: '5k Time Trial — 5,000m',
+        status: 'completed',
+        benchmark_key: null,
+      },
+    ]);
+    renderView();
+
+    const badges = await screen.findAllByText(/^OVERDUE/);
+    expect(badges).toHaveLength(1);
+    expect(badges[0].parentElement.textContent).toContain('5k Time Trial');
   });
 });
 

--- a/web/src/views/__tests__/CalendarView.test.jsx
+++ b/web/src/views/__tests__/CalendarView.test.jsx
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EVENT_LADDER } from '../../constants/schedule.js';
 
 const statusesMock = vi.fn();
+const sessionsMock = vi.fn();
+const mutateMock = vi.fn();
+let mutationState;
 
 // Mocked at the module boundary so the view test stays free of Supabase and of
 // the wall clock; the resolver itself is covered in benchmarkStatus.test.js.
@@ -12,7 +16,32 @@ vi.mock('../../hooks/useBenchmarkStatuses.js', () => ({
   useBenchmarkDataUnavailable: () => false,
 }));
 
+vi.mock('../../hooks/useBenchmarkSessions.js', () => ({
+  useBenchmarkSessions: (...args) => sessionsMock(...args),
+}));
+
+vi.mock('../../hooks/useLinkBenchmarkSession.js', () => ({
+  useLinkBenchmarkSession: () => ({ mutate: mutateMock, ...mutationState }),
+}));
+
 import CalendarView from '../CalendarView.jsx';
+
+const CANDIDATES = [
+  {
+    id: 45,
+    date: '6/23/26',
+    label: 'CP Test - 4min MAX (GATED)',
+    status: 'completed',
+    benchmark_key: null,
+  },
+  {
+    id: 70,
+    date: '8/3/26',
+    label: 'PM — 5,000m',
+    status: 'completed',
+    benchmark_key: null,
+  },
+];
 
 function quietStates() {
   return EVENT_LADDER.map((entry, index) => ({
@@ -56,6 +85,10 @@ function ladderRowTexts() {
 beforeEach(() => {
   statusesMock.mockReset();
   statusesMock.mockReturnValue(quietStates());
+  sessionsMock.mockReset();
+  sessionsMock.mockReturnValue({ data: CANDIDATES });
+  mutateMock.mockReset();
+  mutationState = { isPending: false, isError: false, error: null };
 });
 
 describe('CalendarView', () => {
@@ -179,5 +212,143 @@ describe('CalendarView', () => {
     renderView();
     expect(statusesMock).toHaveBeenCalledTimes(1);
     expect(statusesMock).toHaveBeenCalledWith();
+  });
+});
+
+// The rendered slice is EVENT_LADDER.slice(0, 5) — indices 0-2 are benchmarks,
+// 3-4 are competitions. A competition has no `key`, so a control on one of
+// those rows could only ever write a null slug.
+describe('CalendarView benchmark link control', () => {
+  it('renders the control on the three visible benchmark rows and on neither competition', () => {
+    renderView();
+    const controls = screen.getAllByRole('button', { name: /^Link a session/ });
+    expect(controls.map((b) => b.getAttribute('aria-label'))).toEqual([
+      'Link a session to CP Test #1 (4-min)',
+      'Link a session to CP Test #2 (2nd duration)',
+      'Link a session to 5k Time Trial',
+    ]);
+    expect(
+      screen.queryByRole('button', { name: /Erg Power Series/ })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /C2 Monthly/ })
+    ).not.toBeInTheDocument();
+  });
+
+  // Every state is 'unknown' while the sessions read is pending or failed.
+  // Rendering the control then would flash LINK before flipping to LINKED, and
+  // hand over a picker with nothing in it.
+  it('renders no control at all while the benchmark statuses are unknown', () => {
+    statusesMock.mockReturnValue(
+      quietStates().map((s) => ({ ...s, status: 'unknown' }))
+    );
+    renderView();
+    expect(
+      screen.queryAllByRole('button', { name: /^Link a session/ })
+    ).toHaveLength(0);
+  });
+
+  it('reads LINKED ✓ on a benchmark the resolver matched to a session', () => {
+    const states = quietStates();
+    states[0] = { ...states[0], done: true, matchedSessionId: 45 };
+    statusesMock.mockReturnValue(states);
+    renderView();
+
+    const controls = screen.getAllByRole('button', { name: /^Link a session/ });
+    expect(controls[0]).toHaveTextContent('LINKED ✓');
+    expect(controls[1]).toHaveTextContent('LINK');
+    expect(controls[1]).not.toHaveTextContent('LINKED');
+  });
+
+  it('sends the ladder slug and the chosen session id to the mutation', async () => {
+    const user = userEvent.setup();
+    renderView();
+    await user.click(
+      screen.getByRole('button', { name: 'Link a session to 5k Time Trial' })
+    );
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: 'Session for 5k Time Trial' }),
+      '70'
+    );
+
+    expect(mutateMock).toHaveBeenCalledWith({
+      benchmarkKey: '5k-tt',
+      sessionId: 70,
+    });
+  });
+
+  // A 23505 means another session already holds this slug. Saying "failed"
+  // would hide the only fact that tells Scott what to do next.
+  it('names the unique violation instead of a generic failure, on that row only', async () => {
+    const user = userEvent.setup();
+    mutationState = {
+      isPending: false,
+      isError: true,
+      error: { code: '23505', message: 'duplicate key value violates …' },
+    };
+    renderView();
+
+    // Nothing shows until this row is the one that issued the write.
+    expect(screen.queryByText(/already claims/)).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Link a session to 5k Time Trial' })
+    );
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: 'Session for 5k Time Trial' }),
+      '70'
+    );
+
+    expect(
+      screen.getByText('Another session already claims this benchmark')
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/already claims/)).toHaveLength(1);
+  });
+
+  it('falls back to the driver message for any other write failure', async () => {
+    const user = userEvent.setup();
+    mutationState = {
+      isPending: false,
+      isError: true,
+      error: { code: '42501', message: 'permission denied for table sessions' },
+    };
+    renderView();
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Link a session to CP Test #1 (4-min)',
+      })
+    );
+    await user.selectOptions(
+      screen.getByRole('combobox', {
+        name: 'Session for CP Test #1 (4-min)',
+      }),
+      '45'
+    );
+
+    expect(
+      screen.getByText('permission denied for table sessions')
+    ).toBeInTheDocument();
+  });
+
+  it('disables the row that issued an in-flight write', async () => {
+    const user = userEvent.setup();
+    mutationState = { isPending: true, isError: false, error: null };
+    renderView();
+
+    const target = screen.getByRole('button', {
+      name: 'Link a session to 5k Time Trial',
+    });
+    await user.click(target);
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: 'Session for 5k Time Trial' }),
+      '70'
+    );
+
+    expect(target).toBeDisabled();
+    expect(
+      screen.getByRole('button', {
+        name: 'Link a session to CP Test #1 (4-min)',
+      })
+    ).not.toBeDisabled();
   });
 });

--- a/web/src/views/program/__tests__/ProgramYear.test.jsx
+++ b/web/src/views/program/__tests__/ProgramYear.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import ProgramYear from '../ProgramYear.jsx';
+import { EVENT_LADDER } from '../../../constants/schedule.js';
 
 describe('ProgramYear', () => {
   it('renders the season target and annual arc', () => {
@@ -15,5 +16,26 @@ describe('ProgramYear', () => {
       screen.getByText(/EVENT PATHWAY · HOME ERG → INTERNATIONAL/i)
     ).toBeInTheDocument();
     expect(screen.getByText(/ORGANISATIONS TO FOLLOW/i)).toBeInTheDocument();
+  });
+
+  // AC8. The season timeline is static reference content: it renders the whole
+  // ladder, including the four entries the Calendar panel never shows, and it
+  // reads only date/name/kind/serves. Adding `key` to five entries and a link
+  // control to the Calendar must not leak a badge or an affordance in here.
+  it('renders all nine ladder entries with no badge and no link control', () => {
+    render(<ProgramYear />);
+
+    expect(EVENT_LADDER).toHaveLength(9);
+    // getAllBy: a couple of ladder names also appear in the pathway section
+    // above, which is exactly the static-reference duplication AC8 protects.
+    for (const e of EVENT_LADDER) {
+      expect(screen.getAllByText(e.name).length).toBeGreaterThan(0);
+    }
+
+    expect(screen.queryByText(/OVERDUE/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^DUE/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^LINK/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
   });
 });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -126,6 +126,16 @@ export default defineConfig({
           functions: 80,
           branches: 70,
         },
+        'src/components/BenchmarkLinkControl.jsx': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/hooks/useLinkBenchmarkSession.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
         'src/utils/dateFormat.js': { lines: 80, functions: 80, branches: 70 },
         'src/utils/invalidateSessionQueries.js': {
           lines: 80,


### PR DESCRIPTION
> ## 🔄 Rebased onto `main` (`9560364`) — read this first
>
> This branch was cut at `c0acf7d`. Two commits landed on `main` afterwards that touch the same resolver, and reconciling them **narrows one claim made below**.
>
> **`#192`/`#214` — rescheduled benchmarks.** `main` added a *second* pass that reads **PLANNED** rows by label keyword and can move a badge `overdue → scheduled`. It is preserved intact, so `benchmarkKeywords`, `BENCHMARK_TERMS`, `tokenize` and `labelMatches` **survive in `eventWindow.js`** rather than being deleted as this PR originally had them.
>
> The two features are genuinely independent, and the split is now the design:
>
> | | reads | can set | fires when |
> |---|---|---|---|
> | Pass 1 — **done** | **completed** rows, by `benchmark_key` | `done`, `quiet` | always |
> | Pass 2 — **reschedule** | **planned** rows, by keyword | `scheduled` | only if already `overdue` |
>
> Disjoint row sets, separate claim sets, and pass 2 never touches a `done` benchmark. A planned row still cannot fabricate a completion — `main`'s own comment puts it best: *"A planned row is a commitment, never evidence."*
>
> **So the honest invariant is narrower than "Label text is never read" below:** label text is never read to **clear** a benchmark, only to **reschedule** one. Keyword matching is safe in pass 2 precisely because its worst case is a badge reading "moved" instead of "late".
>
> **`#200`/`#213` — `date_iso` ordering.** Kept, alongside `benchmark_key` in the select. The "Deliberately left alone" note about `.order('date', …)` below is **resolved**, not outstanding.
>
> **Two tests changed meaning.** `exposes no keywords field on any state` became `derives keywords only for benchmark entries` (the field is needed again); and the fixture in `leaves a done benchmark quiet, planned session or not` now establishes done-ness **by link** rather than by label — which is the whole point of this change. The `CANCELLED_RETEST` and `EARLY_AUG_DONE` fixtures are restored for the live-ladder assertion.
>
> **Why this PR had no web CI until now:** `ci-web.yml` never triggered on the original push — only `ci-android` and the PR-title lint ran, so Lint, Test, Build, Playwright and CodeQL had **never** executed against these 18 files. The rebase-push fixed that; the results below are the first real verdict.

---

## What this changes

`EVENT_LADDER` benchmarks had no link of any kind to a `sessions` row, so
"was this benchmark actually done?" was answered heuristically: derive keywords
from the benchmark's name (`CP Test #1 (4-min)` → `['cp','4min']`), match them as
whole tokens against `sessions.label` inside a date window with 14 days of
backward grace, and add a claim-once rule so one session could not clear two
benchmarks.

That matched prose against prose, and failed in both directions — a routine
session whose label happened to contain a keyword cleared the benchmark, and a
benchmark genuinely done but logged with different words (`Critical Power
retest`) nagged forever.

**A benchmark is now done only when a completed session carries its slug in the
new `sessions.benchmark_key` column. Label text is never read to clear one.**

## Design decisions worth reviewing

- **A slug on both sides, not a `session_id` on the ladder.** `EVENT_LADDER` is a
  git-committed constant shipped in the Vercel bundle, so a session id there would
  make every link a code change → PR → CI → deploy. Worse, Coach-over-MCP could
  not create a link at all, since Coach holds DB access, not write access to a
  deployed bundle.
- **The 5 slugs are hand-written literals, never derived from `name`.** Deriving a
  slug means a ladder rename silently orphans the link. A test asserts the five
  literal values, and that non-benchmark entries have no `key` field at all.
- **Dates no longer gate "done".** A date check would be a second implicit input to
  the done decision — the same bug class this PR removes, in a different costume. A
  test logged three weeks after a slipped `~Mid Jul` window still counts. The window
  stays fully live for timing **unlinked** benchmarks (overdue / upcoming / fuzzy).
- **Uniqueness is held at the database**, by a partial unique index
  `(user_id, benchmark_key) WHERE benchmark_key IS NOT NULL`, mirroring
  `anchors_one_live_per_key`. That is the half that survives a Coach-over-MCP write
  with no app validation in the way — a duplicate raises `23505` rather than
  silently producing an ambiguous badge. The resolver *also* keeps a deterministic
  lowest-`id` rule, so it stays correct against a stale cache or a client running
  ahead of the migration.
- **The link control is a pure `UPDATE` on the Calendar ladder panel**, so **no
  session insert path changed**. `LogSessionForm` was rejected as a home (it
  hard-codes `type: 'Strength'`; every ladder benchmark is an erg test) and
  `ErgLiveView` too (it could never link a historical or non-Bluetooth session, and
  `useOfflineQueue` replays queued rows verbatim, so a queued row carrying a key
  could hit the unique index on drain with no UI to report it).
- **Clear-then-set, never the reverse.** Writing the new holder while the incumbent
  still carries the key is a guaranteed `23505`. The two statements are not atomic;
  a failure between them leaves the benchmark *unlinked*, which is the safe
  direction — it can never produce a false-done, and a retry fixes it.

## What was deleted

`findMatch`, `betterFit`, the ride-elevation guard's use in the completed pass, the
grace search, and the completed-pass claim-once set are gone. The **done** matcher
collapses to a lookup.

`benchmarkKeywords`, `BENCHMARK_TERMS`, `tokenize` and `labelMatches` are **kept**
— see the rebase note above; they now serve the reschedule pass only.

`addCalendarDays` is **deliberately kept** though no production code calls it now —
it is a generic side-effect-free calendar primitive sitting beside
`diffCalendarDays`, with its tests intact. Flagging it so it reads as a decision,
not an oversight.

The two cross-entry collision tests (`P5`, `P5b`) were deleted rather than
rewritten. That is safe **only** because the scenario is now structurally
impossible: `benchmark_key` is a scalar on the row, so one session can never be a
candidate for two benchmarks.

## The tripwire, inverted

#175 deliberately shipped tests asserting the known-wrong behaviour as a tripwire
for this issue. The false-overdue one is **inverted, not deleted**:

> `AC3 leaves a benchmark overdue when a session names it but carries no link`

A `completed` session labelled `CP Test - 4min MAX (GATED)` — the real historical
label, which the old keyword resolver *did* match — dated `7/1/26`, sitting exactly
inside CP Test #1's one-day window, with `benchmark_key: null`, must still resolve
`overdue`. That test is the "no keyword fallback" decision made executable, and it
**passes after the rebase** — which is what proves pass 2 did not reintroduce a
keyword path into the done decision.

## Migration

`009_sessions_benchmark_key.sql` (+ rollback companion). Additive and reversible:
a nullable `text` column, a `COMMENT` naming `EVENT_LADDER` as the canonical slug
list, and the partial unique index. **RLS is untouched** — the four owner policies
on `sessions` are column-agnostic, so the new column is covered from day one with
zero policy edits.

**Already applied to the live database** (the spec's required order: migration
first, then Vercel — the reverse gives a PostgREST 400 on every sessions read).
Re-verified today: column and index both exist, **0 rows carry a key**. No schema
change was needed for the rebase.

## ⚠️ Expected first-deploy behaviour

**Every benchmark that currently clears by keyword will flip to OVERDUE** until it
is linked by hand. That is the correct meaning of "no link" under the no-fallback
decision, not a regression. Slightly softened by the reschedule pass: one with a
matching *future planned* session now shows `RESCHEDULED` rather than `OVERDUE`.

There is deliberately **no backfill in this PR** — it is a one-or-two-row `UPDATE`
afterwards:

```sql
update public.sessions set benchmark_key = 'cp-test-1' where id = <id>;
```

Slugs: `cp-test-1`, `cp-test-2`, `5k-tt`, `2k-test`, `tune-ups`. Verify ids against
the live table at the time rather than trusting any id quoted here.

## Deliberately left alone (follow-ups)

- **Porting the reschedule pass to `benchmark_key` too.** Would need a new migration
  — `009`'s unique index has no status predicate, so a planned row claiming a slug
  would `23505` the later completed link — plus extending `BenchmarkLinkControl` to
  offer planned sessions. Worth its own issue.
- `EVENT_LADDER.slice(0, 5)` in `CalendarView` renders indices 0–4 = **3 benchmarks
  + 2 competitions**, so `2k Test` and `1000m + tune-ups` are resolved but never
  rendered — as is the `🎯 TARGET` World Champs entry, whose colour branch is
  unreachable. Tracked in #228; panel length is a product call.
- **`.jsx` files are not linted at all** (#227). `eslint.config.js` has no config
  object whose `files` matches non-test `**/*.jsx`, so ESLint 9 skips them.
  Pre-existing and out of scope.
- No end-to-end test drives click → mutate → `onSuccess` → invalidate → re-render
  through real code (#230); each piece is covered in isolation.

## Verification (after the rebase, on `854f9f2`)

```
npm test          →  713 passed (713), 58 files
npm run lint      →  0 errors (3 pre-existing warnings)
npm run format:check → clean
npm run build     →  exit 0
coverage          →  exit 0, no threshold errors
check:design-sync →  exit 0
```

Behavioural spot-checks confirming the merge, not just the code:

- all 14 rescheduled tests pass, **including the 3 keyword-dependent ones**
  (`…future planned label does not match`, `…planned ride reschedule a distance
  benchmark`, `never reschedules a benchmark whose name yields no keywords`);
- both `compareBenchmarkSeverity` tests pass;
- `ignores a planned session even when it carries the benchmark_key` passes — pass
  1's status gate holds even against a linked planned row;
- both `CalendarView` integration tests exercising the two features **together**
  pass (`AC2 badges CP Test #2 as rescheduled and sorts it below the 5k`,
  `leaves the 5k overdue when a session names it but carries no link`).

`vite.config.js` gained two 80/80/70 per-file entries and **lowered nothing**.

Closes #188