### PR TITLE
docs: record the four follow-ups from #194 as drafted issues

### DIFF
--- a/coach/followups-194.md
+++ b/coach/followups-194.md
@@ -1,0 +1,249 @@
+# Follow-ups from #194 / PR #211
+
+Four issues, ready to file. Verified against `main` at `9560364` and the live DB on
+2026-08-22. Tracking still lives in GitHub Issues per `WORKFLOW.md` — this file is
+the drafting notes, not the tracker. Delete it once the four are filed.
+
+Ranked by consequence. **A** is the only one currently producing wrong output;
+**B** and **C** are correctness-of-record; **D** is a small paired cleanup.
+
+> **Already resolved — do not file.** The original top follow-up was
+> "`LogSessionForm` writes no `status`, so hand-logged sessions are invisible to
+> CTL/ATL/TSB". **#221 fixed it** (`LogSessionForm.jsx:81` now writes
+> `status: 'completed'`), and the live table has **zero** NULL-status rows, so no
+> backfill is needed either. Superseded before it was filed.
+
+---
+
+## A. `useErgSessions` filters on `status = 'logged'`, which matches zero rows
+
+**Labels:** `bug` · **Priority:** High
+
+### Problem
+
+`web/src/hooks/useErgSessions.js:39`:
+
+```js
+.eq('status', 'logged')
+```
+
+The live `sessions` table contains **no `logged` rows at all**. Current distribution:
+
+| status | rows |
+|---|---:|
+| `actual` | 35 |
+| `cancelled` | 32 |
+| `completed` | 23 |
+| `planned` | 2 |
+| `(null)` | 0 |
+
+So this hook returns an empty set on every call, and whatever it feeds renders empty.
+
+`'logged'` is a real status value — `constants/sessionStatus.js` lists it in
+`COMPLETED_STATUSES`, and per `CLAUDE.md` it is written by the live PM5 Bluetooth
+save path. It has simply never been written yet. The bug is that this hook gates on
+that *one* value rather than the full completed set, so it silently excludes the
+58 sessions that genuinely are done.
+
+### Why it matters
+
+Same class as #194 — a bespoke definition of "done" that drifted from the shared
+one — but failing in the opposite direction. #194 counted too much; this counts
+nothing.
+
+### Fix
+
+Use the shared primitive, consistent with `useTSSHistory.js:17`:
+
+```js
+.in('status', COMPLETED_STATUSES)
+```
+
+Or `isCompletedStatus` (`utils/sessionStatus.js`, added in #211) if filtering
+client-side.
+
+### Before doing it
+
+**Establish what this hook currently feeds and whether that surface is visibly
+empty today.** If a view has been rendering blank since this landed, that is worth
+knowing — and it changes the fix from "correctness tidy-up" to "restore a broken
+screen". Confirm the before/after row count the way #211 did: write the assertion
+first, watch it fail at 0.
+
+### Acceptance criteria
+
+1. The hook returns sessions whose status is any of `COMPLETED_STATUSES`.
+2. A test asserts a `logged`, an `actual` and a `completed` row all come back, and
+   that `cancelled` and `planned` do not.
+3. The before/after count is stated in the PR, measured rather than asserted.
+
+---
+
+## B. No CHECK constraint on `sessions.status`
+
+**Labels:** `enhancement`, `database` · **Priority:** Medium
+
+### Problem
+
+`sessions.status` is plain `text`, nullable, no default, and **no CHECK constraint**
+(the only CHECK on the table is `sessions_date_parseable`). Nothing prevents a
+sixth status value — a typo from a Coach MCP write, a hand edit in the Supabase
+dashboard, a future write path inventing `'skipped'` or `'missed'`.
+
+Every consumer today treats an unknown value differently by accident rather than
+by design. #211 made `useSessionLog` fail closed deliberately — an unknown status
+is excluded from the counted set, so the session goes visibly missing rather than
+counting as phantom training. That is the right default, but it is a mitigation,
+not a fix. The hazard is that the column accepts the bad value at all.
+
+### Fix
+
+Additive, reversible migration via `apply_migration` (never raw `execute_sql`):
+
+```sql
+alter table sessions
+  add constraint sessions_status_known
+  check (status in ('actual','completed','logged','planned','cancelled'))
+  not valid;
+```
+
+`not valid` skips revalidating existing rows — all 92 already conform, so validate
+it immediately after if you want the guarantee enforced retroactively.
+
+**Needs Scott's approval before applying** — it is DDL on the live table.
+
+### Consider pairing with `not null`
+
+Now that #221 makes `LogSessionForm` write a real status and the table holds zero
+NULL rows, `status` could also become `not null` with a default. If that lands,
+the `status == null` branch in `utils/sessionStatus.js:18` stops being load-bearing
+and can be removed — see **D**. Decide the two together; doing B without D leaves a
+comment claiming the branch is load-bearing when it no longer is.
+
+### Acceptance criteria
+
+1. Migration is additive and reversible, applied via `apply_migration`.
+2. An insert with an unknown status is rejected.
+3. All 92 existing rows still satisfy the constraint (verify before validating).
+4. Supabase security/perf advisors run clean after the DDL.
+
+---
+
+## C. Calendar days that are both done and cancelled render as plain "done"
+
+**Labels:** `enhancement`, `ui` · **Priority:** Medium
+
+### Problem
+
+After #211, a day whose only session was cancelled correctly stops reading
+`✓ DONE`. But a day with **both** a cancelled session and a completed one reads as
+an ordinary done day — the cancellation vanishes from the calendar entirely.
+
+**Seven such dates exist today:**
+
+| date | cancelled | done |
+|---|---:|---:|
+| 6/23/26 | 1 | 1 |
+| 6/25/26 | 1 | 2 |
+| 6/27/26 | 1 | 1 |
+| 7/3/26 | 2 | 1 |
+| 7/13/26 | 1 | 1 |
+| 7/14/26 | 1 | 1 |
+| 7/20/26 | 2 | 1 |
+
+That is precisely the scenario that set #211's direction: a prescription skipped,
+something else done instead. The Log now records both; the calendar shows only the
+half that happened.
+
+### Why this was deliberately deferred from #211
+
+Two reasons, both still true:
+
+1. **It is not a styling tweak.** `dayStatus` (`utils/schedule.js`) would need a
+   fourth state, which means `logEntriesForDate` / `dayStatus` / `getUpcomingSessions`
+   become status-aware. #211 established the opposite contract — those helpers are
+   **status-blind by design**, callers pass an already-filtered list, and a
+   characterization test pins it. Breaking that in the very next PR re-creates the
+   drift that caused #194. If the calendar needs cancelled data, pass it as a
+   *separate* prop rather than teaching the date helpers about status.
+2. **The day is genuinely two states at once.** How one cell renders both is a
+   design question — combined badge, count suffix, precedence — with knock-ons
+   through `statusColor` / `statusLabel` and the `logged.length` count in
+   `CalendarView.jsx`.
+
+### Not visible today
+
+`CalendarView.jsx:42-43` windows the strip to today−3 → today+14. Every cancelled
+row is dated 23 Jun – 20 Jul, so none currently render. **This cannot be verified by
+looking at the calendar** — it must be proven with a clocked test. Do not let a
+"looks fine to me" pass conclude there is nothing to fix.
+
+### Acceptance criteria
+
+1. A day with both a cancelled and a completed session is visually distinguishable
+   from a day with only completed sessions.
+2. `utils/schedule.js` stays status-blind — its characterization test still passes
+   unmodified.
+3. A clocked test covers one of the seven real dates above.
+
+---
+
+## D. `useSessionLog` orders by `created_at`, not `date_iso`
+
+**Labels:** `bug` · **Priority:** Medium
+
+### Problem
+
+`web/src/hooks/useSessionLog.js:22`:
+
+```js
+.order('created_at', { ascending: false })
+```
+
+That is **insertion order, not training order**. `App.jsx:213` even comments
+`// dbSessions are newest-first`, which is true only in the `created_at` sense.
+
+Consumers that assume training-date order:
+
+- `App.jsx:213` — `latestErg = ergSessions[0]`, shown as the latest-erg tile
+- `OverviewView.jsx` — `loggedSessions.slice(0, 4)` "recent sessions"
+- `OverviewView.jsx` — first non-null `srpe` scan for "last sRPE"
+
+A session imported or edited late sorts as "most recent" regardless of when it was
+actually done. Bulk-imported history is the obvious way to trigger it.
+
+Same class as #187 and #213 (which fixed the ordering in `useErgSessions` and
+`useBenchmarkSessions`); `useSessionLog` is the remaining hook on the old pattern.
+
+### Fix
+
+Per the standing rule in `CLAUDE.md` — order by the generated `date_iso` column,
+never the text `date`, with `nullsFirst: false` on descending.
+`useErgSessions.js:48-49` is the reference implementation, including the `id`
+tiebreak:
+
+```js
+.order('date_iso', { ascending: false, nullsFirst: false })
+.order('id', { ascending: false })
+```
+
+### Watch for
+
+Changing the order changes what `latestErg` and "recent 4" display. That is the
+point, but it should be **stated as a before/after in the PR** rather than shipped
+silently — if the latest-erg tile changes which session it names, that should come
+from the PR, not from noticing later.
+
+### Optional pairing
+
+If **B** lands `not null` on `status`, remove the now-dead `status == null` branch
+in `utils/sessionStatus.js:18` and its comment in the same PR. Do **not** remove it
+before B — as of today it is still the correct behaviour for any NULL that reaches
+the predicate, and the tests assert it.
+
+### Acceptance criteria
+
+1. Ordering is by `date_iso` desc with `nullsFirst: false`, plus an `id` tiebreak.
+2. A test proves a row created late but dated early does not sort first.
+3. The `App.jsx:213` "newest-first" comment is corrected to say training-date order.
+4. Before/after for `latestErg` and the recent-4 list stated in the PR.


### PR DESCRIPTION
## What changed and why

Adds `coach/followups-194.md` — the four follow-ups surfaced while working #194, written as ready-to-file issue bodies so they survive the session that found them.

Notes only. **GitHub Issues remains the tracker** per `WORKFLOW.md`; the file says so at the top and tells you to delete it once the four are filed. It is not a revival of `coach/work-orders/`.

### What's in it

| | Follow-up | Priority |
|---|---|---|
| **A** | `useErgSessions` filters `.eq('status','logged')` — matches **zero** live rows, so the hook returns nothing on every call | High |
| **B** | No CHECK constraint on `sessions.status` — nothing prevents a sixth value | Medium |
| **C** | Calendar days that are both done and cancelled render as plain "done" — 7 such dates exist | Medium |
| **D** | `useSessionLog` orders by `created_at`, not `date_iso` — insertion order, not training order | Medium |

**A is the one to look at first.** It is #194's bug inverted: another bespoke definition of "done" that drifted from the shared `COMPLETED_STATUSES`, except it counts nothing rather than too much.

A fifth item — `LogSessionForm` writing no `status` — was resolved by #221 while this sat unwritten. It is recorded as **do-not-file with the reason**, rather than deleted, so the next reader doesn't rediscover it and re-file it.

### Accuracy

Every `path:line` reference was re-checked against `main` at `9560364` immediately before committing (`App.jsx` latestErg had shifted 214 → 213), and every row count was queried from the live table rather than carried over from the #194 issue text.

Each entry carries the reasoning, the fix, acceptance criteria, and where relevant the trap:

- **C cannot be verified by looking at the calendar** — it windows today−3 → today+14 and every cancelled row is from June/July, so it needs a clocked test.
- **B and D are coupled** — if B adds `not null`, the `status == null` branch in `isCompletedStatus` stops being load-bearing and should go in the same PR.

## How to test manually

Documentation only — no code, no tests, no behaviour change.

## Checklist

- [x] CI is green — with the caveat that **Lint & Format, Test & Coverage, Build, Playwright and Lighthouse all report `skipped`, not `success`**: `Detect web changes` correctly finds no `web/` changes in a docs-only PR, so those jobs never run. Nothing regressed and nothing was bypassed, but they are not evidence of anything here. The checks that did run and pass are PR-title validation, path labelling, dependency review and the Vercel preview deploy.
- [x] Tests cover the change, or I've noted why they don't — docs-only, nothing to test
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no runtime surface changed