### PR TITLE
fix: lint the .jsx files ESLint was silently skipping (#227)

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -5,6 +5,11 @@ import reactHooksPlugin from 'eslint-plugin-react-hooks';
 export default [
   js.configs.recommended,
   {
+    // Without a `files` glob here, ESLint 9 expands a directory argument
+    // (`eslint src/`) to **/*.js only, so every non-test .jsx was silently
+    // skipped and the lint gate reported green over ~14.5k unvisited lines.
+    // The test/e2e blocks below match .jsx, which is why *those* were linted.
+    files: ['**/*.{js,jsx}'],
     plugins: {
       react: reactPlugin,
       'react-hooks': reactHooksPlugin,
@@ -17,6 +22,8 @@ export default [
         document: 'readonly',
         navigator: 'readonly',
         console: 'readonly',
+        confirm: 'readonly',
+        Image: 'readonly',
         localStorage: 'readonly',
         sessionStorage: 'readonly',
         setTimeout: 'readonly',
@@ -47,6 +54,11 @@ export default [
       'react/prop-types': 'off',
       'react/react-in-jsx-scope': 'off',
       'react-hooks/immutability': 'warn',
+      // Default forbids ' and " too, which fired 27 times purely on prose
+      // ("Scott's", quoted coach notes). React renders those literally and
+      // correctly; escaping them makes the copy unreadable for no safety gain.
+      // > and } stay forbidden — those are the genuinely ambiguous ones.
+      'react/no-unescaped-entities': ['error', { forbid: ['>', '}'] }],
     },
   },
   {

--- a/web/src/StrengthLogger.jsx
+++ b/web/src/StrengthLogger.jsx
@@ -1399,7 +1399,10 @@ function mountStrengthLogger(root) {
             vid.onloadedmetadata = () => {
               try {
                 vid.currentTime = t;
-              } catch (e) {}
+              } catch {
+                // Seeking a not-yet-seekable video throws; the frame we land on
+                // is cosmetic, so play from wherever it is.
+              }
               vid.playbackRate = rate;
               vid.play();
             };
@@ -1621,7 +1624,11 @@ function mountStrengthLogger(root) {
                 .update({ status: 'pending', workout_id: null })
                 .eq('id', draft.assignment.id);
             }
-          } catch (_) {}
+          } catch {
+            // Best-effort release of the assignment. The draft is already gone
+            // locally, and a stuck 'in_progress' row is recoverable by hand —
+            // failing the discard here would strand the user instead.
+          }
           toast('Draft discarded');
         }
       );
@@ -1649,7 +1656,10 @@ export default function StrengthLogger() {
     return () => {
       try {
         cleanup && cleanup();
-      } catch (e) {}
+      } catch {
+        // Unmount teardown: nothing above us can act on a failure here, and
+        // throwing from a cleanup function masks the real unmount error.
+      }
     };
   }, []);
   return (


### PR DESCRIPTION
Closes #227

## What changed and why

`npm run lint` is one of the three required CI gates, and it has been reporting green over **~14,549 lines it never opened**.

`eslint src/` expands a directory argument using the `files` globs in the flat config. The only two globs matching `.jsx` were the **test** and **e2e** blocks — which is why tests *were* linted and nothing else was. The config object carrying all the actual rules has no `files` key, so it is universal but contributes nothing to directory expansion.

Proof before the fix:

```
$ npx eslint --print-config src/views/CalendarView.jsx
undefined

$ npx eslint src/ --format json | ...
files visited: 104  (.js 77, .jsx 27)
non-test .jsx visited: 0
```

**35 files — the bulk of the app's JSX — had zero lint coverage.** Adding `files: ['**/*.{js,jsx}']` to the rules object brings it to 139 files / 35 non-test `.jsx`.

## What that surfaced: 33 errors, all pre-existing

| Rule | Count | Resolution |
|---|---:|---|
| `react/no-unescaped-entities` | 27 | rule narrowed |
| `no-undef` | 3 | globals added |
| `no-empty` | 3 | intent documented |

**`no-undef` (3, all `StrengthLogger.jsx`)** — `confirm` ×2 and `Image` ×1. Real browser globals missing from the allowlist, not broken code; it works fine at runtime. Added to `globals`. These are the smoking gun that the gate was vacuous: `no-undef` is an *error* under `js.configs.recommended`, and CI was green anyway.

**`no-empty` (3, all `StrengthLogger.jsx`)** — deliberate best-effort catches around a video seek, an assignment release, and an unmount teardown. `no-empty` ignores a block that carries a comment, so each now explains *why* it swallows — which fixes the lint and documents the intent, rather than blanket-enabling `allowEmptyCatch`. Dropping the unused binding (`catch (e)` → `catch`) also cleared 3 `no-unused-vars` warnings.

**`react/no-unescaped-entities` (27)** — every single one an apostrophe or quote in prose (`Scott's`, quoted coach notes). React renders those literally and correctly; turning readable copy into `&apos;` soup buys no safety. Rather than switching the rule off, I narrowed its `forbid` list to `>` and `}` — the characters that are genuinely ambiguous in JSX. Real protection kept, noise gone.

## Verified both ways

The point of this PR is that the gate stops being a no-op, so I checked it actually bites:

```
# planted `thisSymbolDoesNotExist()` in CalendarView.jsx
22:3  error  'thisSymbolDoesNotExist' is not defined  no-undef
✖ 13 problems (1 error, 12 warnings)

# removed
✖ 12 problems (0 errors, 12 warnings)
```

**Before this change that same planted line passed lint.**

## Deliberately left alone

12 `no-unused-vars` **warnings** remain, newly visible and non-blocking (`npm run lint` sets no `--max-warnings`). Most are dead imports and state in `App.jsx` left over from the monolith decomposition (`lazy`, `Suspense`, `ErgTooltip`, `C`, `progTab`/`setProgTab`, `isMid`), plus `PlaceholderCard` in `MobileApp.jsx` and a few older ones.

They're real debt and worth a sweep — but leaving them keeps this a **lint-config change** rather than a dead-code refactor across the entry shell. Happy to follow up.

## How to test manually

```bash
cd web
npx eslint --print-config src/views/CalendarView.jsx   # returns a config, not `undefined`
npm run lint                                           # 0 errors, 12 warnings
```

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — *ESLint config; verified by running the gate both ways against a planted error*
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — *no runtime code changed; the only source edits are comments inside existing catch blocks*

Verified locally: `lint` **0 errors**, `format:check` clean, **713 tests across 58 files**, `build` exit 0, `coverage` exit 0, `check:design-sync` exit 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8RCQ5d8TKHa8DdzMU1Nmc)_