### PR TITLE
fix: show the erg history ErgView was filtering away (#206)

### DIFF
--- a/web/src/hooks/__tests__/useErgSessions.test.js
+++ b/web/src/hooks/__tests__/useErgSessions.test.js
@@ -6,6 +6,8 @@ import React from 'react';
 const fromMock = vi.fn();
 const orderMock = vi.fn();
 const limitMock = vi.fn();
+const eqMock = vi.fn();
+const inMock = vi.fn();
 
 vi.mock('../../supabaseClient.js', () => ({
   supabase: {
@@ -15,6 +17,7 @@ vi.mock('../../supabaseClient.js', () => ({
 
 import { useErgSessions } from '../useErgSessions.js';
 import { wattsToPace500 } from '../../utils/pace.js';
+import { COMPLETED_STATUSES } from '../../constants/sessionStatus.js';
 
 function makeWrapper() {
   const client = new QueryClient({
@@ -52,7 +55,14 @@ function mockQuery(data, error = null, cp = 205) {
     }
     const chain = {
       select: () => chain,
-      eq: () => chain,
+      eq: (...args) => {
+        eqMock(...args);
+        return chain;
+      },
+      in: (...args) => {
+        inMock(...args);
+        return chain;
+      },
       order: (...args) => {
         orderMock(...args);
         return chain;
@@ -70,6 +80,48 @@ beforeEach(() => {
   fromMock.mockReset();
   orderMock.mockReset();
   limitMock.mockReset();
+  eqMock.mockReset();
+  inMock.mockReset();
+});
+
+describe('useErgSessions — the completed-status filter (#206)', () => {
+  // The live table holds 35 'actual' + 23 'completed' rows and ZERO 'logged'
+  // ones, so `.eq('status','logged')` matched nothing and ErgView rendered an
+  // empty list while 23 erg sessions sat in the database.
+  it('filters on every completed status, not just one', async () => {
+    mockQuery([]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(inMock).toHaveBeenCalledWith('status', COMPLETED_STATUSES);
+  });
+
+  it('never narrows the query to a single status', async () => {
+    mockQuery([]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(eqMock).not.toHaveBeenCalledWith('status', expect.anything());
+  });
+
+  it('returns bulk-imported history that carries actual/completed', async () => {
+    mockQuery([
+      { id: 1, date: '6/23/26', type: 'erg', label: 'a', status: 'actual' },
+      { id: 2, date: '6/24/26', type: 'erg', label: 'b', status: 'completed' },
+      { id: 3, date: '6/25/26', type: 'erg', label: 'c', status: 'logged' },
+    ]);
+    const { result } = renderHook(() => useErgSessions(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data.map((s) => s.status)).toEqual([
+      'logged',
+      'completed',
+      'actual',
+    ]);
+  });
 });
 
 describe('useErgSessions', () => {

--- a/web/src/hooks/useErgSessions.js
+++ b/web/src/hooks/useErgSessions.js
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../supabaseClient.js';
 import { wattsToPace500, formatPace, classifyZone } from '../utils/pace.js';
 import { toISODate } from '../utils/dateFormat.js';
+import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
 import { useAnchors } from './useAnchors.js';
 
 export function enrich(s, cp) {
@@ -36,7 +37,13 @@ export function useErgSessions() {
           'id, date, type, label, duration, srpe, status, distance_m, avg_watts, avg_hr'
         )
         .eq('type', 'erg')
-        .eq('status', 'logged')
+        // Every other consumer of "did this session happen?" reads
+        // COMPLETED_STATUSES (useTSSHistory, useCoach, MobileAnalytics,
+        // benchmarkStatus). This hook was the one place that hardcoded a single
+        // status, and it picked the one the bulk-imported history does not use:
+        // the live table holds 'actual' and 'completed' rows and zero 'logged'
+        // ones, so the erg list rendered empty (#206).
+        .in('status', COMPLETED_STATUSES)
         // date_iso, not date: sessions.date is TEXT "M/D/YY" and sorts lexically, so
         // a LIMIT over it returns the wrong SET of rows (#187). nullsFirst is
         // mandatory — postgrest-js omits the clause entirely when it is undefined,


### PR DESCRIPTION
Closes #206

## What changed and why

`useErgSessions` queried `.eq('status', 'logged')`. Every other consumer of *"did this session actually happen?"* reads `COMPLETED_STATUSES` — `useTSSHistory`, `useCoach`, `MobileAnalytics`, `benchmarkStatus`, and the shared `isCompleted()` helper. This hook was the **only** place that hardcoded a single status, and it picked the one the data doesn't use.

Counted against the live table just now:

| status | rows | of which erg |
|---|---:|---:|
| `actual` | 35 | 5 |
| `cancelled` | 32 | 11 |
| `completed` | 23 | 18 |
| `planned` | 2 | 0 |
| **`logged`** | **0** | **0** |

So the filter matched **nothing**. ErgView has been rendering an empty list while **23 completed erg sessions** sat in the table.

`'logged'` isn't dead code — `ErgLiveView.jsx:618` writes it on the PM5 Bluetooth save path. It simply has no rows yet, which is exactly why this survived review: the code path that *produces* the status exists, so the filter reads plausible. Only counting rows shows it never matches.

Swapped to `.in('status', COMPLETED_STATUSES)`. Nothing else in the hook changes — the `date_iso` ordering from #187 and the 50-row limit are untouched.

## Tests

Three regression tests. The mock chain gains `.in()` / `.eq()` capture so the **filter itself** is assertable, rather than inferred from whatever rows the mock returns:

- `filters on every completed status, not just one` — asserts `.in('status', COMPLETED_STATUSES)`
- `never narrows the query to a single status` — asserts `.eq` is never called with `status`, so the old shape can't come back in a different spelling
- `returns bulk-imported history that carries actual/completed` — an `actual`, a `completed` and a `logged` row all survive to the hook's output

**Verified both ways:** restoring `.eq('status','logged')` fails two of the three; the fix passes all 22 in the file.

## How to test manually

Open the Erg tab. Before this change it lists nothing; after, it lists the erg history (23 sessions in the live data).

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

Verified locally: `lint` **0 errors**, `format:check` clean, **716 tests across 58 files**, `build` exit 0, `coverage` exit 0, `check:design-sync` exit 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8RCQ5d8TKHa8DdzMU1Nmc)_