### PR TITLE
test: give the ProgramView renders an explicit time budget (#219)

### DIFF
--- a/web/src/views/__tests__/ProgramView.test.jsx
+++ b/web/src/views/__tests__/ProgramView.test.jsx
@@ -5,7 +5,15 @@ import ProgramView from '../ProgramView.jsx';
 const renderView = () =>
   render(<ProgramView expanded={null} setExpanded={vi.fn()} />);
 
-describe('ProgramView', () => {
+// ProgramView is ~1,900 lines and the default 'phases' tab mounts most of it
+// synchronously, so every test here pays a full render. In isolation that is
+// ~450 ms, but under parallel workers on a cold transform it has been observed
+// at 5352 / 5895 / 6090 ms — over Vitest's 5000 ms default, which fails the
+// pre-push hook and costs a ~2 min full-suite retry (#219). Nothing here
+// awaits: it is render cost, not a race, so a longer budget cannot mask a hang.
+// App.test.jsx already carries `}, 30000)` for the same reason.
+// The real fix is #77's views/program/* decomposition shrinking the render.
+describe('ProgramView', { timeout: 15000 }, () => {
   it('renders the sub-nav and the phases tab by default', () => {
     renderView();
     expect(screen.getByRole('button', { name: /phases/i })).toBeInTheDocument();


### PR DESCRIPTION
Closes #219

## What changed and why

`renders the sub-nav and the phases tab by default` intermittently failed on Vitest's **5000 ms default** when the full suite ran with parallel workers — observed at **5352, 5895 and 6090 ms** while landing #208 and #218.

That fails the `pre-push` hook (`cd web && npx vitest run`), and the only remedies are a ~2 min full-suite retry or `--no-verify`, which `CLAUDE.md` forbids. It cost three extra full-suite runs across two PRs.

`ProgramView.jsx` is ~1,900 lines and the default `phases` tab mounts most of it synchronously, so **every test in the file pays a full render**. The issue names one test, but all three go through the same `renderView()` helper and sit at identical risk.

## Why a `describe`-level timeout

The issue suggests option (1), a third argument on each `it()`, matching `App.test.jsx`'s `}, 30000)`. That works — but adding the argument pushes each call past Prettier's line-length heuristic, which re-wraps and re-indents **every test body**: a **51 insertion / 23 deletion** diff for a three-line change.

`describe('ProgramView', { timeout: 15000 }, () => {` is **9 insertions, 1 deletion**, leaves the bodies untouched, and states the thing that's actually true: *every render in this file is expensive*, not three specific assertions.

Not `test.testTimeout` in `vite.config.js` either — that would relax the bound for all 716 tests to fix three.

## Why this can't hide a real failure

Nothing in these tests awaits anything. It is **render cost, not a race**, so a longer budget cannot mask a hang or a deadlock — a genuinely broken render still fails, just later. The rationale sits directly above the `describe`, so the next person doesn't have to guess why 15 s.

## Honest note on verification

**The flake did not reproduce in this container.** Measured here:

| | duration |
|---|---|
| in isolation (3 runs) | 434 / 419 / 476 ms |
| during a full-suite run (2 runs) | 547 / 441 ms |

That's ~9–11% of the 5 s limit. This machine is evidently less contended than the one that hit it — and the issue itself notes it *"passes every time in isolation"*, so isolation numbers were never going to reproduce it.

**The 15000 ms budget is sized off the reported failures (up to 6090 ms), not off these numbers.**

What I could verify is that the budget is genuinely enforced rather than decorative — dropping it to 50 ms times out all three tests, and restoring it passes:

```
--- describe timeout 50ms (render ~450ms) ---
3 tests: "Test timed out in 50ms."
--- restored to 15000ms ---
Tests  3 passed (3)
```

## Follow-up

The real fix is #77's `views/program/*` decomposition shrinking the render. This removes the papercut in the meantime.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — *test-only change; verified the budget is enforced by inverting it*
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — *no application code changed*

Verified locally: `lint` **0 errors**, `format:check` clean, **716 tests across 58 files**, `build` exit 0.