### PR TITLE
chore: clear the dead code the .jsx lint gate exposed

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -49,7 +49,18 @@ export default [
     rules: {
       ...reactPlugin.configs.recommended.rules,
       ...reactHooksPlugin.configs.recommended.rules,
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      // ignoreRestSiblings covers the deliberate omit-a-key idiom
+      // (`const { _queuedAt, ...rest } = session`), which is a rest-spread
+      // filter, not dead code. varsIgnorePattern extends the existing `_`
+      // convention from arguments to variables so the two agree.
+      'no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
       'no-console': 'off',
       'react/prop-types': 'off',
       'react/react-in-jsx-scope': 'off',

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, Component, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, Component } from 'react';
 import { useSessionLog } from './hooks/useSessionLog.js';
 import { useTSSHistory } from './hooks/useTSSHistory.js';
 import StrengthLogger from './StrengthLogger.jsx';
@@ -14,9 +14,7 @@ import ProgramView from './views/ProgramView.jsx';
 import CalendarView from './views/CalendarView.jsx';
 import PlanView from './views/PlanView.jsx';
 import LogView from './views/LogView.jsx';
-import ErgTooltip from './components/ErgTooltip.jsx';
 import { calcTrainingLoad } from './utils/trainingLoad.js';
-import { C } from './constants/ui.js';
 
 /* ═══════════════════════════════════════════════════════════════
    ERG COACHING DASHBOARD · v1.2 beta
@@ -155,7 +153,6 @@ const strengthTrend = {
 export default function App() {
   const [view, setView] = useState('overview');
   const [expanded, setExpanded] = useState(null);
-  const [progTab, setProgTab] = useState('phases'); // phases | week | year
   const [nowTick, setNowTick] = useState(new Date()); // for date-awareness (day rollover)
   const [vw, setVw] = useState(
     typeof window !== 'undefined' ? window.innerWidth : 1200
@@ -172,7 +169,6 @@ export default function App() {
   }, []);
   // Responsive breakpoints: wider container on desktop, multi-column where it helps.
   const isWide = vw >= 900; // desktop — use the extra width
-  const isMid = vw >= 600; // tablet
   const containerMax = isWide ? 1100 : 680;
 
   const {

--- a/web/src/components/LoadTooltip.jsx
+++ b/web/src/components/LoadTooltip.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { THEME } from '../constants/theme.js';
 
-export default function LoadTooltip({ active, payload, label }) {
+export default function LoadTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const d = payload[0].payload;
   const tsbColor =

--- a/web/src/utils/strengthDraft.js
+++ b/web/src/utils/strengthDraft.js
@@ -4,7 +4,7 @@ export function saveDraft(active) {
   if (!active) return;
   try {
     localStorage.setItem(DRAFT_KEY, JSON.stringify(active));
-  } catch (e) {
+  } catch {
     // QuotaExceededError or SecurityError — best-effort, silently ignore
   }
 }
@@ -19,7 +19,7 @@ export function loadDraft() {
       return null;
     }
     return p;
-  } catch (e) {
+  } catch {
     localStorage.removeItem(DRAFT_KEY);
     return null;
   }

--- a/web/src/views/mobile/MobileApp.jsx
+++ b/web/src/views/mobile/MobileApp.jsx
@@ -9,24 +9,6 @@ import BottomTabBar from '../../components/mobile/BottomTabBar.jsx';
 import ErgLiveView from '../ErgLiveView.jsx';
 import CoachView from '../CoachView.jsx';
 
-function PlaceholderCard({ message }) {
-  return (
-    <div
-      style={{
-        margin: 16,
-        background: '#2a2a48',
-        borderRadius: 12,
-        padding: '40px 20px',
-        textAlign: 'center',
-        color: '#7e7e9a',
-        fontSize: 13,
-      }}
-    >
-      {message}
-    </div>
-  );
-}
-
 export default function MobileApp() {
   const [activeTab, setActiveTab] = useState('analytics');
 


### PR DESCRIPTION
Follow-up to #234 (#227).

## What changed and why

#234 made ESLint visit 35 non-test `.jsx` files for the first time and deliberately left **12 `no-unused-vars` warnings** standing, so that PR stayed a lint-config change rather than a dead-code sweep across the entry shell. This is the sweep.

`npm run lint` now reports **nothing at all** — 0 problems, down from 12 warnings.

## Nine were genuinely dead

Each verified to have **exactly one reference** in its file — its own declaration — before removal:

| File | Symbol | Why it's dead |
|---|---|---|
| `App.jsx` | `lazy`, `Suspense` | imported from react, never used |
| `App.jsx` | `ErgTooltip`, `C` | imported, never used |
| `App.jsx` | `progTab` / `setProgTab` | `useState` never read — `ProgramView` has owned its own sub-tab state since the decomposition |
| `App.jsx` | `isMid` | computed, never used (`isWide` still is) |
| `MobileApp.jsx` | `PlaceholderCard` | local component, not exported, unreferenced |
| `LoadTooltip.jsx` | `label` | unused Recharts tooltip prop |

## Three were intent, not accident — so the code stayed and the rule moved

**`strengthDraft.js` — two `catch (e)`.** The binding is unused and the comment above each already explains the swallow, so these become the optional-catch-binding form `catch {`. No behaviour change.

**`useOfflineQueue.js` — `const { _queuedAt, ...rest } = session`.** This is the deliberate *omit-a-key* idiom: a rest-spread filter that strips a local-only field before the insert. **Deleting it would reintroduce `_queuedAt` into the row sent to Supabase.** `no-unused-vars` has `ignoreRestSiblings` for exactly this case, so that's now on.

`varsIgnorePattern: '^_'` is set alongside it, so the underscore convention means the same thing for variables as `argsIgnorePattern` already made it mean for arguments — the author had already signalled intent with the `_` prefix; the config just didn't honour it.

## Risk

**Nothing here changes runtime behaviour.** Every removal is an unreferenced binding, and the two rule options only affect what gets *reported*. The full diff is 16 insertions / 27 deletions across 5 files, with no incidental reformatting.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — *deletions of unreferenced bindings; the existing 716 tests are the regression net*
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

Verified locally: `lint` **0 problems**, `format:check` clean, **716 tests across 58 files**, `build` exit 0, `coverage` exit 0, `check:design-sync` exit 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8RCQ5d8TKHa8DdzMU1Nmc)_