### PR TITLE
feat: render the whole event ladder, not the first five (#228, #215)

### DIFF
--- a/web/src/views/CalendarView.jsx
+++ b/web/src/views/CalendarView.jsx
@@ -81,11 +81,14 @@ export default function CalendarView({ loggedSessions, isWide }) {
   }
   const todayMode = firstMode;
   const todayCycle = MICROCYCLE[todayMode] || MICROCYCLE.home;
-  // Slice BEFORE sort: which five entries are visible stays a ladder decision,
-  // only their order is a severity one. .slice() copies, so the memoized hook
-  // result is never mutated.
+  // The whole ladder renders, ordered by severity (#228). It used to be capped
+  // at the first five by position, which hid the 2k Test, the 1000m tune-ups
+  // and the TARGET champs entirely — and meant a benchmark going overdue deep
+  // in the ladder could never surface, however loud (#215). Severity order is
+  // what keeps nine rows from being wallpaper: anything actionable floats.
+  // .slice() still copies, so .sort() never mutates the memoized hook result.
   const visibleEvents = benchmarkStatuses
-    .slice(0, 5)
+    .slice()
     .sort(compareBenchmarkSeverity);
   return (
     <>
@@ -256,7 +259,8 @@ export default function CalendarView({ loggedSessions, isWide }) {
                 gap: 10,
                 marginBottom: 6,
                 paddingBottom: 6,
-                borderBottom: i < 4 ? '1px solid #3e3e5a' : 'none',
+                borderBottom:
+                  i < visibleEvents.length - 1 ? '1px solid #3e3e5a' : 'none',
               }}
             >
               <div

--- a/web/src/views/__tests__/CalendarView.test.jsx
+++ b/web/src/views/__tests__/CalendarView.test.jsx
@@ -142,9 +142,10 @@ describe('CalendarView', () => {
     );
   });
 
-  // AC5 — five permanent warnings in ladder order is the same wallpaper the
-  // feature exists to remove. What is actionable has to be at the top.
-  it('AC5 sorts the visible rows overdue → upcoming → the rest', () => {
+  // AC5 — nine permanent warnings in ladder order is the same wallpaper the
+  // feature exists to remove. What is actionable has to be at the top; severity
+  // order is what makes rendering the whole ladder (#228) survivable.
+  it('AC5 sorts every row overdue → upcoming → the rest', () => {
     const states = quietStates();
     states[4] = { ...states[4], status: 'overdue', daysOverdue: 12 };
     states[1] = { ...states[1], status: 'upcoming', daysUntilStart: 3 };
@@ -152,24 +153,27 @@ describe('CalendarView', () => {
     renderView();
 
     const rows = ladderRowTexts();
-    expect(rows).toHaveLength(5);
+    expect(rows).toHaveLength(EVENT_LADDER.length);
     expect(rows[0]).toContain(EVENT_LADDER[4].name);
     expect(rows[0]).toContain('OVERDUE · 12d');
     expect(rows[1]).toContain(EVENT_LADDER[1].name);
     expect(rows[1]).toContain('DUE · 3d');
-    // The quiet remainder keeps ladder order behind them.
-    expect(rows.slice(2).map((t) => t.includes(EVENT_LADDER[0].name))).toEqual([
-      true,
-      false,
-      false,
-    ]);
+    // Everything still quiet keeps ladder order behind the loud rows — the tie
+    // break is the ladder index, so this is the full remainder, in sequence.
+    const quietOrder = EVENT_LADDER.map((e, i) => i).filter(
+      (i) => i !== 4 && i !== 1
+    );
+    expect(rows.slice(2)).toHaveLength(quietOrder.length);
+    quietOrder.forEach((ladderIndex, row) => {
+      expect(rows[row + 2]).toContain(EVENT_LADDER[ladderIndex].name);
+    });
   });
 
-  // Slicing happens BEFORE sorting, so severity reorders the visible five but
-  // never changes which five they are. Without that order a benchmark going
-  // overdue deep in the ladder — the 2k Test, when its Jan 2027 window elapses
-  // — would silently displace a nearer event from the panel.
-  it('AC5 sorts within the visible five without changing which five they are', () => {
+  // The inverse of what this test used to assert. The panel was capped at the
+  // first five by position, so a benchmark going overdue deep in the ladder —
+  // the 2k Test, once its Jan 2027 window elapses — could never surface however
+  // loud it got (#215). It now surfaces AND outranks the quiet rows.
+  it('AC5 surfaces a benchmark that goes overdue deep in the ladder (#215)', () => {
     const states = quietStates();
     const deep = states.length - 1;
     expect(deep).toBeGreaterThan(4);
@@ -178,11 +182,19 @@ describe('CalendarView', () => {
     renderView();
 
     const rows = ladderRowTexts();
-    expect(rows).toHaveLength(5);
-    expect(rows.join(' ')).not.toContain(EVENT_LADDER[deep].name);
-    expect(screen.queryByText(/OVERDUE · 400d/)).toBeNull();
-    // Untouched ladder order behind the cut.
-    expect(rows[0]).toContain(EVENT_LADDER[0].name);
+    expect(rows).toHaveLength(EVENT_LADDER.length);
+    expect(rows[0]).toContain(EVENT_LADDER[deep].name);
+    expect(rows[0]).toContain('OVERDUE · 400d');
+  });
+
+  // The TARGET entry is the season's whole point and index 7 — it was outside
+  // the old cut, so its distinct colour branch in this view was unreachable.
+  it('renders the TARGET champs entry that the cut used to hide (#228)', () => {
+    renderView();
+    const rows = ladderRowTexts();
+    const target = EVENT_LADDER.find((e) => e.kind === 'TARGET');
+    expect(target).toBeDefined();
+    expect(rows.join(' ')).toContain(target.name);
   });
 
   it('AC4/AC5 renders a rescheduled badge and sorts it below the loud rows', () => {
@@ -215,24 +227,31 @@ describe('CalendarView', () => {
   });
 });
 
-// The rendered slice is EVENT_LADDER.slice(0, 5) — indices 0-2 are benchmarks,
-// 3-4 are competitions. A competition has no `key`, so a control on one of
-// those rows could only ever write a null slug.
+// The whole ladder renders now (#228), so every kind='benchmark' entry gets a
+// control — five of the nine, not the three the old cut left visible. The other
+// four (two competitions, the TARGET, the optional sprint) carry no `key`, so a
+// control on those rows could only ever write a null slug.
 describe('CalendarView benchmark link control', () => {
-  it('renders the control on the three visible benchmark rows and on neither competition', () => {
+  it('renders a control on every benchmark row and on no other kind', () => {
     renderView();
     const controls = screen.getAllByRole('button', { name: /^Link a session/ });
-    expect(controls.map((b) => b.getAttribute('aria-label'))).toEqual([
-      'Link a session to CP Test #1 (4-min)',
-      'Link a session to CP Test #2 (2nd duration)',
-      'Link a session to 5k Time Trial',
-    ]);
-    expect(
-      screen.queryByRole('button', { name: /Erg Power Series/ })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: /C2 Monthly/ })
-    ).not.toBeInTheDocument();
+    // Derived from the ladder, not hardcoded: adding a benchmark should extend
+    // this list rather than silently pass. All rows are quiet here, so severity
+    // ties break on ladder index and DOM order is ladder order.
+    expect(controls.map((b) => b.getAttribute('aria-label'))).toEqual(
+      EVENT_LADDER.filter((e) => e.kind === 'benchmark').map(
+        (e) => `Link a session to ${e.name}`
+      )
+    );
+    expect(controls).toHaveLength(5);
+    for (const name of [
+      /Erg Power Series/,
+      /C2 Monthly/,
+      /World Rowing Virtual Indoor Champs/,
+      /WR Virtual Indoor Sprints/,
+    ]) {
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument();
+    }
   });
 
   // Every state is 'unknown' while the sessions read is pending or failed.


### PR DESCRIPTION
Closes #228
Closes #215

## What changed and why

The Calendar ladder panel capped itself at `EVENT_LADDER.slice(0, 5)`. Indices 0–4 are three benchmarks and two competitions, so **four of the nine entries never rendered at all**:

| idx | kind | name | date |
|---:|---|---|---|
| 5 | `benchmark` | 2k Test | ~Mid Jan 27 |
| 6 | `benchmark` | 1000m + 1-min tune-ups | Late Jan 27 |
| 7 | **`TARGET`** | World Rowing Virtual Indoor Champs | Late Feb 27 |
| 8 | `optional` | WR Virtual Indoor Sprints | Early Mar 27 |

Three consequences:

- **The `TARGET` entry — the season's whole point — was invisible**, and the distinct `#ff2d55` colour branch this view carries for `kind === 'TARGET'` was unreachable code.
- **The cut was positional, so severity couldn't rescue it.** A benchmark going overdue deep in the ladder could never surface however loud it got — the 2k Test would stay hidden through the entirety of its overdue window (#215, "bites Feb 2027").
- **Only 3 of the 5 benchmarks were badge-visible**, so the other two could only be linked by Coach writing `benchmark_key` directly — there was no row to click. All five now carry a link control.

## Why the cap existed, and why nine rows is now fine

The cap was a deliberate decision, not an oversight — the test comment said it plainly: *"five permanent warnings in ladder order is the same wallpaper the feature exists to remove."*

What makes nine rows survivable is that **severity ordering already landed in #192/#214**: overdue → upcoming → scheduled → quiet, ties broken on ladder index. The panel leads with whatever is actionable, and the quiet remainder sits below in ladder order. The cap was solving a problem the sort now solves better — and solving it in a way that *created* #215.

`borderBottom` moves from a hardcoded `i < 4` to `i < visibleEvents.length - 1`, which is exactly what `ProgramYear.jsx:273` already does for the same ladder. **The two views that render `EVENT_LADDER` are consistent now** — CalendarView was the odd one out.

## Tests: two acceptance criteria inverted, not deleted

**`AC5 sorts within the visible five without changing which five they are`** existed specifically to assert a deep-overdue entry must *not* surface. That's now the opposite of desired behaviour, so it's inverted and renamed — `AC5 surfaces a benchmark that goes overdue deep in the ladder (#215)` — asserting it appears *and* takes row 0.

Two others were made derive-from-the-ladder rather than hardcoded, so adding a benchmark extends them instead of silently passing:

- the severity test computes its expected quiet remainder from `EVENT_LADDER` instead of asserting three rows;
- the link-control test builds its expected aria-labels from every `kind === 'benchmark'` entry.

Added one test that the `TARGET` entry renders at all.

## Scope note

No mobile change needed — I checked, and the ladder panel exists only in the desktop `CalendarView`. The `slice(0, 5)` in `MobileAnalytics.jsx` is an unrelated "5 most recent sessions" list.

The panel is now roughly 80% taller. That's the accepted trade for the entries being reachable; worth an eye on the Vercel preview.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser

Verified locally: `lint` **0 problems**, `format:check` clean, **717 tests across 58 files**, `build` exit 0, `coverage` exit 0, `check:design-sync` exit 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8RCQ5d8TKHa8DdzMU1Nmc)_