### PR TITLE
test: pin the clock in the benchmark integration block (#215 follow-up)

### DIFF
--- a/web/src/views/__tests__/CalendarView.benchmark.test.jsx
+++ b/web/src/views/__tests__/CalendarView.benchmark.test.jsx
@@ -73,9 +73,22 @@ beforeEach(() => {
 });
 
 describe('CalendarView + useBenchmarkStatuses (integration, unmocked hook)', () => {
-  // Every ladder window below is in the past for any real "today" from
-  // 2026-08-20 on, so the outcome does not drift with the wall clock. The day
-  // count inside the badge does, hence the prefix match.
+  // The clock is pinned. These OVERDUE counts used to be wall-clock stable for
+  // a reason that no longer holds: the panel rendered only EVENT_LADDER[0..4],
+  // whose windows are all 2026 and all elapsed. Since #228 the whole ladder
+  // renders, so the 2k Test (~Mid Jan 27) and the tune-ups (Late Jan 27) join
+  // it — and every count below would silently go 1 -> 3 and 2 -> 4 once those
+  // windows elapse in early 2027. Verified by running this file at 2027-02-15:
+  // five tests fail. Pinned to the same date the reschedule block uses.
+  // The day count inside the badge still varies, hence the prefix match.
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 7, 22));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it('badges only the 5k Time Trial row once both CP tests are linked', async () => {
     mockSessions(PAYLOAD);
     renderView();
@@ -206,10 +219,10 @@ describe('CalendarView + a rescheduled benchmark (integration)', () => {
   const CP2_OVERDUE = [{ ...PAYLOAD[0], status: 'cancelled' }, PAYLOAD[1]];
   const RETEST_LABEL = 'CP RETEST — 1min + 4min max';
 
-  // The clock is pinned for these two only. Every other case in this file rests
-  // on windows that are past for any real "today", but a FUTURE planned date is
-  // future only relative to the real one — unpinned, this pair would silently
-  // invert on 12 Sep 2026 rather than keep testing what it was written to test.
+  // Pinned for the same reason as the block above, plus one of its own: a
+  // FUTURE planned date is future only relative to the real clock — unpinned,
+  // this pair would silently invert on 12 Sep 2026 rather than keep testing
+  // what it was written to test.
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date(2026, 7, 22));


### PR DESCRIPTION
Follow-up to #238. **This fixes a latent break that PR introduced and I shipped.**

## What went wrong

#238 widened the ladder panel from `EVENT_LADDER.slice(0, 5)` to the whole ladder. #215's maintenance note had flagged the risk explicitly:

> The `toHaveLength(1)` / `toHaveLength(2)` badge-count assertions in `CalendarView.benchmark.test.jsx` are only time-stable **because** the slice currently hides indices 5+. Whoever widens the slice inherits those and will need to revisit them.

I didn't. The full suite passed, so I merged.

The `unmocked hook` describe block asserts OVERDUE badge counts against the real resolver on the **real clock**, and its comment claimed that was safe:

> *"Every ladder window below is in the past for any real today from 2026-08-20 on, so the outcome does not drift with the wall clock."*

True only while the panel rendered indices 0–4 — all 2026 windows, all elapsed. Indices 5 and 6 (**2k Test** ~Mid Jan 27, **tune-ups** Late Jan 27) now render, and they're future today and past from early 2027.

## Verified, not reasoned about

Running that file with the clock at **2027-02-15**:

```
× badges only the 5k Time Trial row once both CP tests are linked
× badges CP Test #2 as well when its linked retest was cancelled
× shows no outage line once the read succeeds
× clears only the 5k badge when a session carries benchmark_key 5k-tt
× leaves the 5k overdue when a session names it but carries no link

AssertionError: expected […] to have a length of 2 but got 4
AssertionError: expected […] to have a length of 1 but got 3

Tests  5 failed | 4 passed (9)
```

Counts go 1 → 3 and 2 → 4 — exactly the two extra benchmarks. **The suite would have started failing around Jan 2027**, for a reason nobody would have connected back to a ladder-rendering change five months earlier.

## The fix

Pin the block to `2026-08-22` — the same date the reschedule block directly below already uses, for the same class of reason.

Re-verified the pin actually holds by forcing the *outer* clock to 2027-02-15 and re-running: **9/9 pass**, where 5 failed before.

Both stale comments are corrected. The second block's *"every other case in this file rests on windows that are past for any real today"* was false for the same reason.

## Why pinning rather than deriving the counts

These tests are about the **resolver's link logic** — does a `benchmark_key` clear a badge, does a cancelled retest leave one standing. Calendar drift isn't what they exist to check, and a count derived from "however many windows have elapsed today" would assert almost nothing. Pinning keeps each assertion meaningful and makes the intended scenario explicit.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — *test-only; verified both at today's date and at the future date that broke it*
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — *no application code changed*

Verified locally: `lint` **0 problems**, `format:check` clean, **717 tests across 58 files**, `build` exit 0, `coverage` exit 0, `check:design-sync` exit 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8RCQ5d8TKHa8DdzMU1Nmc)_