### PR TITLE
fix: use npm ci in the SessionStart hook so it stops rewriting the lockfile

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -14,6 +14,17 @@ echo "[session-start] Installing npm dependencies..."
 # The app is the web/ workspace child. The repo root package.json declares
 # only husky, so a bare `npm install` here leaves web/node_modules absent and
 # vitest/eslint/vite unavailable for the whole session.
-npm install --prefix web
+#
+# `ci`, not `install`: install REWRITES package-lock.json whenever the runner's
+# npm differs from the one that generated it — here it stripped every "libc"
+# field off the optional platform deps, which is a silent lockfile downgrade
+# that then shows up as uncommitted changes in an otherwise untouched tree.
+# `ci` installs strictly from the lockfile and never writes to it.
+#
+# It also fails loudly if package.json and the lockfile disagree, rather than
+# quietly resolving something new. Under `set -e` that aborts the hook, which
+# is the right outcome: a session built on a lockfile nobody committed is worse
+# than a session that tells you to fix the lockfile.
+npm ci --prefix web
 
 echo "[session-start] Done. Run from web/: npm run lint | npm test | npm run build"


### PR DESCRIPTION
Follow-up to #231.

## What changed and why

#231 fixed the hook to install the `web/` workspace instead of the repo root, but kept `npm install`. On a runner whose npm differs from the one that generated `package-lock.json`, **`install` rewrites the lockfile.** Here it stripped the `"libc"` metadata off every optional platform dependency:

```
10  -      "libc": [
 6  -        "glibc"
 4  -        "musl"
```

No `version`, `resolved` or `integrity` change — purely a silent downgrade of the platform hints npm uses to skip incompatible optional deps. It surfaced as uncommitted changes in a tree nobody had touched, repeatedly across today's session, and committing it would have quietly degraded the lockfile for every other machine.

`npm ci` installs strictly from the lockfile and never writes to it.

## Verified, not assumed

**Claim 1 — it installs the deps and leaves the lockfile alone:**

```
rm -rf web/node_modules && npm ci --prefix web

lockfile sha before: a62b7bdaa631a524
lockfile sha after:  a62b7bdaa631a524   ← unchanged
git sees 0 changes to the lockfile
475 packages installed; vitest / eslint / vite all present (3/3)
```

**Claim 2 — the trade-off is that it aborts on a lockfile mismatch.** Tested by adding a dep to `package.json` without updating the lock:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json ... are in sync.
npm error Missing: left-pad@1.3.0 from lock file
exit 1
```

Under `set -euo pipefail` that aborts the hook. **That's the right outcome** — a session built on a lockfile nobody committed is worse than a session that tells you to fix the lockfile. Both behaviours are written into the comment so the next reader doesn't have to rediscover why it's `ci`.

## A note on the CI signal

This changes `.claude/` only, so `Detect web changes` correctly finds no `web/` changes and **Lint & Format, Test & Coverage, Build, Playwright and Lighthouse all report `skipped`, not `success`** — the same situation as #231. Branch protection counts `skipped` as passing (that's the documented reason `ci-web.yml` filters at the job level rather than with `on.paths`), but those checks are not evidence of anything here.

What actually stands behind this change: the two verification runs above, `bash -n` on the hook, and a full local gate run on an untouched `web/` — lint 0 problems, 717 tests across 58 files, build exit 0, design-sync guard exit 0.

## How to test manually

```bash
sha256sum web/package-lock.json
rm -rf web/node_modules
npm ci --prefix web
sha256sum web/package-lock.json   # identical
git status --short                # clean
```

With `npm install` the same sequence leaves 30 deletions in the lockfile.

## Checklist

- [x] CI is green (lint, test, build) — *see the note above: skipped, not run, and correctly so*
- [x] Tests cover the change, or I've noted why they don't — *shell hook; verified by running the command both ways and diffing the lockfile*
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — *no application code changed*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8RCQ5d8TKHa8DdzMU1Nmc)_