### PR TITLE
fix: constrain sessions.status and order the Log by training date (#232 B+D)

### DIFF
--- a/supabase/migrations/010_sessions_status_constraint.sql
+++ b/supabase/migrations/010_sessions_status_constraint.sql
@@ -1,0 +1,49 @@
+-- 010_sessions_status_constraint.sql
+-- Additive + reversible. Closes the gap that let sessions.status hold anything at
+-- all: the column was plain nullable text with no CHECK, so a Coach MCP typo, a
+-- hand edit in the Supabase dashboard, or a future write path inventing 'skipped'
+-- would all be accepted silently.
+--
+-- Consumers already fail closed on an unknown value (utils/sessionStatus.js is an
+-- allow-list, useTSSHistory filters server-side with .in(...)), so a bad value
+-- makes a session go visibly missing rather than counting as phantom training.
+-- That is a mitigation, not a fix - the hazard is that the column accepts it.
+--
+-- Safe on current data, verified before writing rather than assumed: 92 rows,
+-- four distinct statuses (actual 35, cancelled 32, completed 23, planned 2), and
+-- ZERO nulls. Every row already satisfies both constraints below.
+--
+-- No writer breaks either. All three insert paths already name a status:
+--   web/src/components/LogSessionForm.jsx:81  -> 'completed' (since #221)
+--   web/src/views/ErgLiveView.jsx             -> 'logged'
+--   web/src/hooks/useOfflineQueue.js:75       -> spreads the ErgLiveView row
+--
+-- RLS is untouched. The four owner policies on public.sessions
+-- (001_enable_rls.sql:29-46) are column-agnostic, so nothing here needs a policy
+-- edit.
+
+-- Deliberately NO DEFAULT. A default is the exact failure this migration exists
+-- to close: a write path that forgets `status` would land silently as phantom
+-- training ('completed') or a phantom prescription ('planned') instead of raising.
+-- Every current writer states its intent explicitly; not-null-without-default
+-- forces the next one to do the same.
+ALTER TABLE public.sessions
+  ALTER COLUMN status SET NOT NULL;
+
+-- Added VALID in one step, not NOT VALID + VALIDATE. All 92 rows conform and the
+-- scan is trivial, so the two-step form would buy nothing and leave a second step
+-- to forget. (sessions_date_parseable is NOT VALID for the opposite reason - it
+-- was added over data that could not all be guaranteed to pass.)
+ALTER TABLE public.sessions
+  ADD CONSTRAINT sessions_status_known
+  CHECK (status IN ('actual', 'completed', 'logged', 'planned', 'cancelled'));
+
+COMMENT ON COLUMN public.sessions.status IS
+  'Lifecycle of the session. The canonical list lives in '
+  'web/src/constants/sessionStatus.js and MUST stay in step with the '
+  'sessions_status_known CHECK: COMPLETED_STATUSES = actual | completed | logged '
+  '(all three mean it happened - actual/completed are bulk-imported history, '
+  'logged is written by the live PM5 Bluetooth save path), PLANNED_STATUS = '
+  'planned (a forward-looking prescription, never counts as done), and cancelled '
+  '(a decision worth seeing in the Log but never counted as training). Adding a '
+  'sixth value means editing both this constraint and that constants file.';

--- a/supabase/migrations/010_sessions_status_constraint_rollback.sql
+++ b/supabase/migrations/010_sessions_status_constraint_rollback.sql
@@ -1,0 +1,21 @@
+-- Rollback for 010_sessions_status_constraint.sql. NOT auto-applied.
+--
+-- REVERT THE VERCEL DEPLOY FIRST. The frontend that ships with 010 removes its
+-- null-tolerance: utils/sessionStatus.js used to return true for a null status
+-- (treating legacy rows as completed) and no longer does. Drop the constraints
+-- while that build is live and any NULL-status row that appears afterwards is
+-- silently excluded from loggedSessions - it vanishes from the Log, the recent-4
+-- list and every CTL/ATL/TSB figure, with no error anywhere. Roll the deploy back
+-- to a build whose isCompletedStatus still admits null, THEN run this.
+--
+-- Order matters in the other direction to the forward migration: drop the CHECK
+-- before re-allowing NULL, or the DROP NOT NULL leaves a window where a NULL can
+-- be written that the still-present CHECK would reject anyway.
+
+ALTER TABLE public.sessions
+  DROP CONSTRAINT IF EXISTS sessions_status_known;
+
+ALTER TABLE public.sessions
+  ALTER COLUMN status DROP NOT NULL;
+
+COMMENT ON COLUMN public.sessions.status IS NULL;

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -206,7 +206,7 @@ export default function App() {
 
   const ergSessions = loggedSessions.filter((e) => e._isErg);
   const strengthSessions = loggedSessions.filter((e) => e.exercises);
-  const latestErg = ergSessions[0]; // dbSessions are newest-first
+  const latestErg = ergSessions[0]; // dbSessions are training-date-desc
   // Was hardcoded at 55000. The logged erg sessions actually sum to ~216km, so
   // the headline understated the work by about 4x.
   const totalErgDist = ergSessions.reduce((m, e) => m + (e.distance_m ?? 0), 0);

--- a/web/src/__tests__/App.test.jsx
+++ b/web/src/__tests__/App.test.jsx
@@ -2,9 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 // App.jsx fetches sessions directly via the supabase client:
-//   supabase.from('sessions').select('*').order('created_at', { ascending: false })
-// The chain's terminal `.order()` is awaited as a thenable, so mock it to
-// resolve with representative rows covering every render branch of the mapping.
+//   supabase.from('sessions').select('*')
+//     .order('date_iso', { ascending: false, nullsFirst: false })
+//     .order('id', { ascending: false })
+// Two chained .order() calls (#232-D), so `order` returns the chain and the
+// chain itself is the thenable — resolving with representative rows covering
+// every render branch of the mapping.
 const rows = [
   {
     id: 'erg-1',
@@ -83,13 +86,16 @@ const rows = [
   },
 ];
 
+const sessionsChain = {
+  select: () => sessionsChain,
+  order: () => sessionsChain,
+  then: (resolve, reject) =>
+    Promise.resolve({ data: rows, error: null }).then(resolve, reject),
+};
+
 vi.mock('../supabaseClient.js', () => ({
   supabase: {
-    from: () => ({
-      select: () => ({
-        order: () => Promise.resolve({ data: rows, error: null }),
-      }),
-    }),
+    from: () => sessionsChain,
   },
 }));
 

--- a/web/src/hooks/__tests__/useSessionLog.test.js
+++ b/web/src/hooks/__tests__/useSessionLog.test.js
@@ -11,16 +11,29 @@ vi.mock('../../supabaseClient.js', () => ({
 
 import { useSessionLog } from '../useSessionLog.js';
 
+// The hook chains .order('date_iso').order('id').then(...), so `order` has to
+// return the chain rather than a Promise, and the chain itself has to be
+// thenable. orderCalls records the arguments so a test can assert the ordering
+// contract directly instead of inferring it from row order.
+let orderCalls = [];
+
 function mockQuery(data, error = null) {
+  orderCalls = [];
   const chain = {
     select: () => chain,
-    order: () => Promise.resolve({ data, error }),
+    order: (column, opts) => {
+      orderCalls.push([column, opts]);
+      return chain;
+    },
+    then: (resolve, reject) =>
+      Promise.resolve({ data, error }).then(resolve, reject),
   };
   fromMock.mockReturnValue(chain);
 }
 
 beforeEach(() => {
   fromMock.mockReset();
+  orderCalls = [];
 });
 
 const ergRow = {
@@ -49,7 +62,7 @@ describe('useSessionLog', () => {
         date: '06/15/26',
         type: 'cycling',
         label: 'z2 spin',
-        status: null,
+        status: 'actual',
       },
     ]);
     const { result } = renderHook(() => useSessionLog());
@@ -67,7 +80,7 @@ describe('useSessionLog', () => {
     const bike = sessions[1];
     expect(bike._isErg).toBe(false);
     expect(bike._isCycling).toBe(true);
-    expect(bike.status).toBe(null);
+    expect(bike.status).toBe('actual');
   });
 
   it('sets dbStatus error and falls back to the seed on supabase error', async () => {
@@ -98,7 +111,7 @@ describe('useSessionLog', () => {
         date: '06/12/26',
         type: 'strength',
         label: 'Upper A',
-        status: null,
+        status: 'actual',
       },
     ]);
     const { result } = renderHook(() => useSessionLog());
@@ -124,6 +137,77 @@ describe('useSessionLog', () => {
     });
     await waitFor(() => expect(result.current.allSessions).toHaveLength(2));
     expect(result.current.allSessions[1]._id).toBe(4);
+  });
+});
+
+// ── #232-D: training-date order, not insertion order ──────────────
+// The hook used to .order('created_at', { ascending: false }). That is
+// INSERTION order: a session imported or edited late sorted as "most recent"
+// however long ago it was actually done. Measured against the live table, the
+// latest-erg tile named the 7/14/26 session while 8/6, 8/4, 8/2 and 7/30 all
+// existed — 23 days stale.
+describe('useSessionLog — orders by training date (#232-D)', () => {
+  it('D-AC1 requests date_iso desc with NULLS LAST, then id as a tiebreak', async () => {
+    mockQuery([ergRow]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    // nullsFirst is asserted explicitly: postgrest-js omits the clause entirely
+    // when it is undefined, and Postgres defaults descending to NULLS FIRST,
+    // which would float a date the generated column could not parse to the top
+    // as "most recent".
+    expect(orderCalls).toEqual([
+      ['date_iso', { ascending: false, nullsFirst: false }],
+      ['id', { ascending: false }],
+    ]);
+    expect(orderCalls.some(([column]) => column === 'created_at')).toBe(false);
+  });
+
+  it('D-AC2 does not float a late-created, early-dated row to the top', async () => {
+    // As the database returns them under date_iso desc. Row 99 was inserted
+    // last (highest id, latest created_at) but trained first, so under the old
+    // created_at ordering it arrived at position 0 and became `latestErg`.
+    mockQuery([
+      {
+        id: 2,
+        date: '8/6/26',
+        type: 'erg',
+        label: 'UT1 50min',
+        status: 'actual',
+      },
+      {
+        id: 3,
+        date: '8/4/26',
+        type: 'erg',
+        label: 'build 40min',
+        status: 'actual',
+      },
+      {
+        id: 99,
+        date: '7/14/26',
+        type: 'erg',
+        label: 'backfilled months later',
+        status: 'actual',
+      },
+    ]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    const logged = result.current.loggedSessions;
+    expect(logged[0]._id).toBe(2);
+    expect(logged[0].date).toBe('8/6/26');
+    expect(logged.at(-1)._id).toBe(99);
+  });
+
+  it('D-AC3 excludes a null status now that the column is NOT NULL (010)', async () => {
+    // Migration 010 means the database cannot produce this row. If one ever
+    // reaches the predicate anyway, isCompletedStatus fails closed: the session
+    // goes visibly missing rather than counting as phantom training.
+    mockQuery([
+      { id: 1, date: '8/6/26', type: 'erg', label: 'real', status: 'actual' },
+      { id: 2, date: '8/5/26', type: 'erg', label: 'impossible', status: null },
+    ]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    expect(result.current.loggedSessions.map((e) => e._id)).toEqual([1]);
   });
 });
 

--- a/web/src/hooks/useSessionLog.js
+++ b/web/src/hooks/useSessionLog.js
@@ -19,7 +19,18 @@ export function useSessionLog() {
     supabase
       .from('sessions')
       .select('*')
-      .order('created_at', { ascending: false })
+      // date_iso, not created_at: created_at is INSERTION order, which is only
+      // training order by coincidence. A bulk-imported or late-edited session
+      // sorted as "most recent" regardless of when it was actually done — the
+      // latest-erg tile named a 7/14 session while 8/6, 8/4, 8/2 and 7/30 all
+      // existed (#232-D). Matches useErgSessions.js:55-56, including why
+      // nullsFirst is mandatory: postgrest-js omits the clause entirely when it
+      // is undefined and Postgres defaults descending to NULLS FIRST, which
+      // would float an unparseable date to the top as "most recent".
+      // id breaks ties — the PM5 save path suffixes labels with hh:mm, so two
+      // sessions can share a date.
+      .order('date_iso', { ascending: false, nullsFirst: false })
+      .order('id', { ascending: false })
       .then(({ data, error }) => {
         if (error) {
           setDbStatus('error');
@@ -38,9 +49,10 @@ export function useSessionLog() {
               prs: r.prs,
               exercises: r.exercises || undefined,
               coachNote: r.coach_note || undefined,
-              // status drives planned-vs-actual reconciliation. null legacy rows
-              // are treated as actual (completed history) everywhere downstream.
-              status: r.status || null,
+              // status drives planned-vs-actual reconciliation. Never null:
+              // sessions.status is NOT NULL with a CHECK allow-list as of
+              // migration 010, so there is nothing left to coalesce.
+              status: r.status,
               // flat erg metrics (the `splits` field was removed from the schema)
               distance_m: r.distance_m,
               avg_watts: r.avg_watts,
@@ -59,8 +71,8 @@ export function useSessionLog() {
   useEffect(() => {
     fetchSessions();
   }, []);
-  // The merged list every display + helper uses. DB sessions are newest,
-  // so they go first; the hardcoded seed follows.
+  // The merged list every display + helper uses. DB sessions come back in
+  // training-date order (newest first); the hardcoded seed follows.
   const allSessions = [...dbSessions, ...sessionLog];
 
   // ── THREE-WAY SPLIT: counted / shown / planned ────────────────
@@ -72,9 +84,9 @@ export function useSessionLog() {
   // forward-looking prescriptions and appear in neither.
   // loggedKeys derives from the COUNTED set: a cancelled session must never
   // reconcile a planned prescription as done.
-  // Both lists are built in one pass so the created_at-desc order established
-  // by the query above survives — the display object does not carry created_at,
-  // so a split-and-remerge could not reproduce it.
+  // Both lists are built in one pass so the date_iso-desc order established by
+  // the query above survives — the display object does not carry date_iso, so a
+  // split-and-remerge could not reproduce it.
   const loggedSessions = [];
   const logDisplaySessions = [];
   const plannedSessions = [];

--- a/web/src/utils/__tests__/sessionStatus.test.js
+++ b/web/src/utils/__tests__/sessionStatus.test.js
@@ -3,9 +3,13 @@ import { COMPLETED_STATUSES } from '../../constants/sessionStatus.js';
 import { isCompletedStatus } from '../sessionStatus.js';
 
 describe('isCompletedStatus', () => {
-  it('AC3 treats null and undefined as completed (LogSessionForm writes no status)', () => {
-    expect(isCompletedStatus(null)).toBe(true);
-    expect(isCompletedStatus(undefined)).toBe(true);
+  it('AC3 does NOT treat null or undefined as completed', () => {
+    // This inverted with migration 010. The branch admitting null existed
+    // because LogSessionForm inserted without a `status` field; #221 made it
+    // write 'completed' explicitly, and 010 made sessions.status NOT NULL
+    // behind a CHECK, so the database cannot produce one at all.
+    expect(isCompletedStatus(null)).toBe(false);
+    expect(isCompletedStatus(undefined)).toBe(false);
   });
 
   it.each(COMPLETED_STATUSES)('AC4 counts a %s session', (status) => {
@@ -13,9 +17,10 @@ describe('isCompletedStatus', () => {
   });
 
   it('AC5 fails CLOSED on an unknown status — deliberate, not an oversight', () => {
-    // sessions.status has no CHECK constraint, so an unknown sixth value can
-    // appear. Excluding it hides the session loudly rather than counting
-    // phantom training silently.
+    // sessions_status_known (migration 010) now rejects a sixth value at the
+    // database, but this stays the second line of defence: excluding an
+    // unknown hides the session loudly rather than counting phantom training
+    // silently.
     expect(isCompletedStatus('skipped')).toBe(false);
     expect(isCompletedStatus('')).toBe(false);
   });

--- a/web/src/utils/sessionStatus.js
+++ b/web/src/utils/sessionStatus.js
@@ -2,19 +2,17 @@ import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
 
 // Does this session's status mean "training that actually happened"?
 //
-// null/undefined is admitted, and that branch is LOAD-BEARING — not defensive
-// padding. LogSessionForm.jsx:72-81 inserts a session without naming a `status`
-// field at all, so every session Scott saves through the app's own "Log Session"
-// form lands with status NULL. A pure COMPLETED_STATUSES.includes() check would
-// make those sessions vanish the instant they were saved.
+// A pure allow-list. null/undefined is NOT admitted: migration 010 made
+// sessions.status NOT NULL behind a CHECK constraint, so the database can no
+// longer produce one. The branch that used to admit null was justified by
+// LogSessionForm inserting without a `status` field — #221 made it write
+// 'completed' explicitly (LogSessionForm.jsx:81), which left the branch dead
+// before the constraint removed the last way to reach it.
 //
-// Everything else is an allow-list, not an exclude-list. There is no CHECK
-// constraint on sessions.status, so an unknown sixth value can appear at any
-// time; failing closed hides it loudly (Scott looks for a session and it is
-// missing) rather than counting phantom training silently. It also matches
-// useTSSHistory.js:17, which already excludes unknown statuses server-side via
-// .in('status', COMPLETED_STATUSES).
+// Failing closed is deliberate. An unknown value hides the session loudly —
+// Scott looks for it and it is missing — rather than counting phantom training
+// silently. It also matches useTSSHistory.js:17, which excludes unknown
+// statuses server-side via .in('status', COMPLETED_STATUSES).
 export function isCompletedStatus(status) {
-  if (status == null) return true;
   return COMPLETED_STATUSES.includes(status);
 }


### PR DESCRIPTION
Refs #232 — that is the drafting-notes PR these follow-ups came from, not an issue, so it does not auto-close. Follow-up C is filed separately as #242.

## What changed and why

Builds follow-ups **B** and **D** from `coach/followups-194.md`: `sessions.status` can no longer hold an unknown or missing value, and the Log orders by when training happened rather than when the row was inserted.

They ship together because they are coupled through `utils/sessionStatus.js` — B removes the last way a null can reach `isCompletedStatus`, so the branch admitting one has to go in the same change.

### Status of all four follow-ups

| | Follow-up | Outcome |
|---|---|---|
| **A** | `useErgSessions` filters `status='logged'`, matching zero rows | Already fixed by #235 before this ran — verified, not re-filed |
| **B** | No CHECK constraint on `sessions.status` | **This PR** |
| **C** | Mixed cancelled+done days leave no trace on the calendar | Filed as #242 (enhancement, not a bug — see below) |
| **D** | `useSessionLog` orders by `created_at` | **This PR** |

### B — `sessions.status` was unconstrained

Plain nullable text, no CHECK. A Coach MCP typo, a hand edit in the Supabase dashboard, or a future write path inventing `'skipped'` were all accepted silently. Consumers already fail closed on an unknown value, but that is a mitigation — the hazard was that the column accepted it.

Migration `010_sessions_status_constraint.sql` adds `NOT NULL` plus a `sessions_status_known` allow-list, with a rollback file alongside.

**Deliberately no DEFAULT.** The drafting notes floated one. A default is the exact failure the constraint exists to close: a writer that forgets `status` would land silently as phantom training (`'completed'`) or a phantom prescription (`'planned'`) instead of raising. All three insert paths already state their intent.

**Added VALID in one step**, not `NOT VALID` + `VALIDATE` — all 92 rows conform and the scan is trivial, so the two-step form would only leave a second step to forget.

### D — `useSessionLog` ordered by insertion, not training date

`.order('created_at', …)` meant a session imported or edited late sorted as "most recent" however long ago it was actually done. Now `date_iso` desc with `NULLS LAST` plus an `id` tiebreak, matching `useErgSessions.js:55-56`.

## Before / after — measured, not asserted

Queried against the live table, completed statuses only, `type <> 'Test'`:

| pos | before (`created_at`) | after (`date_iso`) |
|---|---|---|
| **1** | **`7/14/26` — UT1 Steady 50min @ 158W** | **`8/6/26` — UT1 Steady 50min @ 164W** |
| 2 | `8/4/26` — 40min progressive build | `8/4/26` — 40min progressive build |
| 3 | `8/2/26` — UT1 45min Ramp SR | `8/2/26` — UT1 45min Ramp SR |
| 4 | `7/30/26` — UT1 Steady 45min @ 157W | `7/30/26` — UT1 Steady 45min @ 157W |

The latest-erg tile was naming a session **23 days staler** than the actual most recent one, with three newer sessions sitting below it. Positions 2–4 are unchanged, so this is the only visible movement in the recent-4 list. "Last sRPE" is unaffected — every row in the top 4 has `srpe` null under both orderings.

## Migration verification

Applied via `apply_migration`, then read back:

```
sessions_status_known => CHECK (status = ANY (ARRAY['actual','completed','logged','planned','cancelled']))
status_nullable       => NO
total_rows            => 92
distribution          => actual=35, cancelled=32, completed=23, planned=2
```

Constraint is **valid**, not `NOT VALID`. Row count and distribution unchanged.

Probed all three rejection paths against the live table — unknown status, explicit NULL, and omitted status. All three rejected, **92 rows and 0 probe rows leaked** afterwards.

Supabase security + performance advisors run post-DDL: only pre-existing findings, none touching `sessions`, nothing new introduced.

## Not in the original notes

Two things this PR fixes that the drafting notes didn't record:

1. **`utils/sessionStatus.js`'s comment was already wrong**, independent of the migration. It declared the null branch "LOAD-BEARING" and cited `LogSessionForm.jsx:72-81` inserting without a status — #221 made that line write `status: 'completed'` explicitly. The branch was dead before the constraint removed the last way to reach it.
2. **Two supabase mocks would have thrown.** `useSessionLog.test.js` and `App.test.jsx` both defined `order` as a terminal Promise, so the second chained `.order()` called `.order` on a Promise. Both are now chainable, and `useSessionLog.test.js` records the arguments so the ordering contract is asserted directly rather than inferred from row order.

## C was re-characterised

The notes framed C as a done-vs-cancelled rendering defect. Verified — it isn't: cancelled sessions never reach `dayStatus`, because all five call sites of the status-blind helpers pass `loggedSessions`, and `logDisplaySessions` reaches only `LogView`. Those 7 days render `done` correctly and the 16 cancelled-only dates render `missed` correctly. What's missing is that a dropped session leaves no trace — additive UI work. Filed at #242 with that framing so nobody hunts for a defect #194 and #211 already closed.

## How to test manually

Open Overview and the Log on the preview. The latest-erg tile should name the **8/6/26** session, not 7/14/26, and the Log should read in training-date order.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — 720 tests pass across 58 files; new `#232-D` block asserts the ordering contract, the late-created/early-dated case, and null exclusion; `sessionStatus.test.js` AC3 inverted to pin the removed behaviour. Coverage: lines 84.76% / functions 79.87% / branches 77.67%, all above the ratchet (80 / 75 / 72)
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no new runtime surface; the ordering change is a query argument

---
_Generated by [Claude Code](https://claude.ai/code/session_017qkwjR61snwGxwSgwLKf3W)_