### PR TITLE
docs: record doctrine_sha as self-maintaining, and why it is the exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,10 +167,20 @@ legacy `sessions.date` text pattern); RLS single-owner policy like the modern ta
   `current_phase`, `current_block`, `doctrine_sha`.
 - **`doctrine_sha`** pins the canonical doctrine commit (this file +
   `.claude/skills/training-science.md`). Doctrine *prose stays in git*; only the SHA
-  lives in a row, so both tools agree which version is live. When a doctrine doc
-  changes, Coach supersedes this anchor.
+  lives in a row, so both tools agree which version is live.
+  **This anchor is self-maintaining — it is the one exception to "Scott authorises".**
+  Two halves: `.github/workflows/doctrine-sha-guard.yml` *detects* drift on any push
+  touching the doctrine docs and opens a tracking issue (CI has no DB access, so it
+  cannot fix it), and the **`Reconcile doctrine_sha anchor`** Routine *applies* the
+  supersede nightly at 21:00 UTC, then closes that issue. It no-ops when the anchor
+  already matches, only ever touches `doctrine_sha`, and stops rather than improvises
+  on any ambiguity. Do not hand-supersede this key unless the Routine is disabled.
 - **Lanes:** Code owns the schema (tables, structural seed, migrations); Coach owns
-  row content (diary, decisions, anchor updates) via scoped writes; Scott authorises.
+  row content (diary, decisions, anchor updates) via scoped writes; Scott authorises
+  — **except `doctrine_sha`**, which is mechanically derived from a git commit rather
+  than a judgement about training, and so is automated (above). Every other anchor —
+  `rowing_cp`, `bike_ftp`, `current_phase`, `current_block`, `drag_factor` — still
+  needs Scott, because each encodes a decision, not a fact.
 
 **Data-layer gotchas (honour on every write):**
 - Supply the `user_id` UUID explicitly on inserts — `auth.uid()` is the column


### PR DESCRIPTION
## What changed and why

Scott's call: `doctrine_sha` maintains itself. `CLAUDE.md` said the opposite in two places — *"When a doctrine doc changes, Coach supersedes this anchor"* and *"Scott authorises"* — so the doc and the intent now disagree. This makes them agree.

The mechanism is two halves that already exist:

| | |
|---|---|
| **detect** | `.github/workflows/doctrine-sha-guard.yml` fires on any push touching `CLAUDE.md` or `.claude/skills/training-science.md` and opens a tracking issue. Its own comment says why it stops there: **CI has no DB access.** |
| **apply** | The `Reconcile doctrine_sha anchor` Routine runs nightly at 21:00 UTC, supersedes the anchor when it has drifted, and closes that issue. |

## Why this one anchor and not the others

Written down rather than left implicit, because "the anchors table is self-maintaining" would be a dangerous over-read:

**`doctrine_sha` is mechanically derived.** It is whatever commit last touched two named files — a fact with exactly one right answer that a script can compute and verify.

**Every other anchor encodes a judgement.** `rowing_cp` is a claim about what Scott can actually hold. `current_phase` is a decision about what he's training for. Neither can be derived from the repo, and automating them would be automating an opinion. The lanes note now says this explicitly instead of implying the table is uniform.

Also records that **hand-superseding this key is now the wrong move** unless the Routine is disabled — two writers to one anchor is precisely how the "one live row per key" invariant gets broken.

## ⚠️ The Routine is currently DISABLED

Worth being explicit, since this doc now describes automation that isn't running yet.

Routines created through the MCP tool store **no MCP connectors**, and `connectors` is unavailable for this org (`create_trigger: the connectors parameter is not available for this organization`). Your three existing routines were all created via the claude.ai UI and each carries the full connector set including Supabase; this one has none.

Since the Routine is entirely a Supabase write, it would have fired nightly and done nothing but report it couldn't run — so I disabled it rather than leave a failing job in the account. **Attaching the Supabase connector in the claude.ai Routines UI and re-enabling is the one-step fix.**

Until that happens, the guard still files the issue and the supersede stays manual — which is the pre-existing behaviour, so nothing regresses in the meantime.

## Note on the CI signal

Doc-only change, so `Detect web changes` finds no `web/` changes and the three required checks report **`skipped`, not `success`**. Behind it: `lint` 0 problems, **717 tests across 58 files** on an untouched `web/`.

Fittingly, merging this will itself trip the doctrine guard and open a fresh `doctrine_sha` tracking issue — which is exactly the loop this documents.

## Checklist

- [x] CI is green (lint, test, build) — *skipped, correctly, for a doc-only change*
- [x] Tests cover the change, or I've noted why they don't — *documentation*
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — *no code changed*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8RCQ5d8TKHa8DdzMU1Nmc)_