### PR TITLE
docs: name the doctrine_sha Routine as it actually exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,8 +171,8 @@ legacy `sessions.date` text pattern); RLS single-owner policy like the modern ta
   **This anchor is self-maintaining — it is the one exception to "Scott authorises".**
   Two halves: `.github/workflows/doctrine-sha-guard.yml` *detects* drift on any push
   touching the doctrine docs and opens a tracking issue (CI has no DB access, so it
-  cannot fix it), and the **`Reconcile doctrine_sha anchor`** Routine *applies* the
-  supersede nightly at 21:00 UTC, then closes that issue. It no-ops when the anchor
+  cannot fix it), and the **`Supabase Doctrine_SHA anchor update`** Routine *applies* the
+  supersede nightly at 01:00 UTC, then closes that issue. It no-ops when the anchor
   already matches, only ever touches `doctrine_sha`, and stops rather than improvises
   on any ambiguity. Do not hand-supersede this key unless the Routine is disabled.
 - **Lanes:** Code owns the schema (tables, structural seed, migrations); Coach owns


### PR DESCRIPTION
## What

Two words and a number in `CLAUDE.md`:

| | was | now |
|---|---|---|
| Routine name | `Reconcile doctrine_sha anchor` | `Supabase Doctrine_SHA anchor update` |
| Schedule | nightly at 21:00 UTC | nightly at 01:00 UTC |

## Why

The Routine described in #244 had to be rebuilt through the claude.ai Routines UI. A Routine created from inside a Claude Code session comes back `created_via: meta_mcp` with no connector set, and the `connectors` parameter is refused for this org — so it could never hold a Supabase connector, and this job is nothing but a Supabase write. The rebuilt one carries the same nine connectors the other Routines have, and came back under a different name and hour.

The name is load-bearing rather than cosmetic. The same paragraph instructs a future session: *"Do not hand-supersede this key unless the Routine is disabled."* Checking whether it is disabled means finding it by name, and the old name now resolves to nothing — so the instruction quietly inverts into "hand-supersede freely".

## Verification

The rebuilt Routine has fired once. It read the anchor, found it already at the canonical SHA (`0bec279`, hand-superseded earlier today while the loop was still broken), and no-opped — no write, no new row. That is the intended step-3 path and the one worth testing: the expensive failure for this job is writing when it should not.

Merging this trips `doctrine-sha-guard.yml` again, since it touches a doctrine doc. That is the point — this time the Routine is live and should supersede the anchor to this commit and close the issue on its own at 01:00 UTC, which is the first end-to-end exercise of the detect/apply loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8RCQ5d8TKHa8DdzMU1Nmc)_