### PR TITLE
feat: surface cancelled sessions on the calendar day strip

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -173,6 +173,7 @@ export default function App() {
 
   const {
     loggedSessions,
+    cancelledSessions,
     logDisplaySessions,
     plannedSessions,
     loggedKeys,
@@ -372,7 +373,11 @@ export default function App() {
 
           {/* ── CALENDAR VIEW ── */}
           {view === 'calendar' && (
-            <CalendarView loggedSessions={loggedSessions} isWide={isWide} />
+            <CalendarView
+              loggedSessions={loggedSessions}
+              cancelledSessions={cancelledSessions}
+              isWide={isWide}
+            />
           )}
 
           {/* ── PROGRAM VIEW ── */}

--- a/web/src/__tests__/App.test.jsx
+++ b/web/src/__tests__/App.test.jsx
@@ -156,6 +156,9 @@ vi.mock('../views/CalendarView.jsx', () => ({
     <div>
       <div>CalendarView-stub</div>
       <div data-testid="calendar-counted">{props.loggedSessions?.length}</div>
+      <div data-testid="calendar-cancelled">
+        {props.cancelledSessions?.length}
+      </div>
     </div>
   ),
 }));
@@ -301,6 +304,7 @@ describe('App', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'CALENDAR' }));
     expect(screen.getByTestId('calendar-counted')).toHaveTextContent('2');
+    expect(screen.getByTestId('calendar-cancelled')).toHaveTextContent('1');
 
     fireEvent.click(screen.getByRole('button', { name: 'LOG' }));
     expect(screen.getByTestId('logview-shown')).toHaveTextContent('3');

--- a/web/src/constants/sessionStatus.js
+++ b/web/src/constants/sessionStatus.js
@@ -9,3 +9,8 @@ export const COMPLETED_STATUSES = ['actual', 'completed', 'logged'];
 // happened. Deliberately NOT in COMPLETED_STATUSES: it must never clear a
 // benchmark, only reschedule one.
 export const PLANNED_STATUS = 'planned';
+
+// A session that was decided against — a deviation from the plan, not training
+// that happened. Scalar rather than an array: unlike COMPLETED_STATUSES it has
+// exactly one spelling in the CHECK allow-list.
+export const CANCELLED_STATUS = 'cancelled';

--- a/web/src/hooks/__tests__/useSessionLog.test.js
+++ b/web/src/hooks/__tests__/useSessionLog.test.js
@@ -361,3 +361,77 @@ describe('useSessionLog — cancelled is shown but not counted (#194)', () => {
     expect(shownOnly.every((e) => e.status === 'cancelled')).toBe(true);
   });
 });
+
+// ── #242: cancelled carried as its own list for the day strip ─────
+// The calendar needs to mark a day where a session was cancelled without
+// re-inspecting `status` in the view. The list is a strict subset of the SHOWN
+// set and disjoint from the COUNTED set — that relationship is the contract.
+describe('useSessionLog — cancelled sessions are carried separately (#242)', () => {
+  it('AC1 puts cancelled session 61 in its own list, out of the counted one', async () => {
+    mockQuery([
+      session61,
+      {
+        id: 62,
+        date: '7/6/26',
+        type: 'erg',
+        label: 'UT2 60min',
+        status: 'completed',
+      },
+    ]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    expect(result.current.cancelledSessions.map((e) => e._id)).toEqual([61]);
+    expect(result.current.loggedSessions.some((e) => e._id === 61)).toBe(false);
+    expect(result.current.logDisplaySessions.some((e) => e._id === 61)).toBe(
+      true
+    );
+  });
+
+  it('AC2 adds a fourth accumulator without perturbing the other three', async () => {
+    mockQuery(distributionRows());
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    expect(result.current.cancelledSessions).toHaveLength(32);
+    expect(result.current.loggedSessions).toHaveLength(58);
+    expect(result.current.logDisplaySessions).toHaveLength(90);
+    expect(result.current.plannedSessions).toHaveLength(2);
+    const counted = new Set(result.current.loggedSessions.map((e) => e._id));
+    expect(
+      result.current.cancelledSessions.every((e) => !counted.has(e._id))
+    ).toBe(true);
+  });
+
+  it('AC3 preserves date_iso-desc order inside the cancelled list', async () => {
+    // Same ordering guarantee as the counted list: the rows arrive in
+    // date_iso-desc order and the single pass must not reshuffle them.
+    mockQuery([
+      {
+        id: 2,
+        date: '8/6/26',
+        type: 'erg',
+        label: 'UT1 50min',
+        status: 'cancelled',
+      },
+      {
+        id: 3,
+        date: '8/4/26',
+        type: 'erg',
+        label: 'build 40min',
+        status: 'actual',
+      },
+      {
+        id: 99,
+        date: '7/14/26',
+        type: 'erg',
+        label: 'backfilled months later',
+        status: 'cancelled',
+      },
+    ]);
+    const { result } = renderHook(() => useSessionLog());
+    await waitFor(() => expect(result.current.dbStatus).toBe('ok'));
+    const cancelled = result.current.cancelledSessions;
+    expect(cancelled.map((e) => e._id)).toEqual([2, 99]);
+    expect(cancelled[0].date).toBe('8/6/26');
+    expect(cancelled.at(-1).date).toBe('7/14/26');
+  });
+});

--- a/web/src/hooks/useSessionLog.js
+++ b/web/src/hooks/useSessionLog.js
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../supabaseClient.js';
 import { normType } from '../utils/formatting.js';
-import { isCompletedStatus } from '../utils/sessionStatus.js';
+import {
+  isCompletedStatus,
+  isCancelledStatus,
+} from '../utils/sessionStatus.js';
 
 // ── SESSION LOG (add entries here as block progresses) ──────────
 
@@ -75,20 +78,24 @@ export function useSessionLog() {
   // training-date order (newest first); the hardcoded seed follows.
   const allSessions = [...dbSessions, ...sessionLog];
 
-  // ── THREE-WAY SPLIT: counted / shown / planned ────────────────
+  // ── FOUR-WAY SPLIT: counted / shown / cancelled / planned ─────
   // One list, two questions. `loggedSessions` is the COUNTED set — training
   // that actually happened — and drives reconciliation, recent sessions and
   // analytics. `logDisplaySessions` is the SHOWN set — everything with a
   // record, cancelled included — because a cancelled session is a decision
   // worth seeing in the Log, just not one worth counting. Planned rows are
   // forward-looking prescriptions and appear in neither.
+  // `cancelledSessions` is a strict subset of `logDisplaySessions` and disjoint
+  // from `loggedSessions`, carried separately so a view can render a deviation
+  // without re-inspecting `status` itself.
   // loggedKeys derives from the COUNTED set: a cancelled session must never
   // reconcile a planned prescription as done.
-  // Both lists are built in one pass so the date_iso-desc order established by
+  // All lists are built in one pass so the date_iso-desc order established by
   // the query above survives — the display object does not carry date_iso, so a
   // split-and-remerge could not reproduce it.
   const loggedSessions = [];
   const logDisplaySessions = [];
+  const cancelledSessions = [];
   const plannedSessions = [];
   for (const e of allSessions) {
     if (e.status === 'planned') {
@@ -97,6 +104,7 @@ export function useSessionLog() {
     }
     logDisplaySessions.push(e);
     if (isCompletedStatus(e.status)) loggedSessions.push(e);
+    if (isCancelledStatus(e.status)) cancelledSessions.push(e);
   }
   // A planned row is reconciled ("done") once an actual exists for the same
   // date + type. v1 matches on normalized type + date (a planned_id link can
@@ -107,6 +115,7 @@ export function useSessionLog() {
     dbStatus,
     allSessions,
     loggedSessions,
+    cancelledSessions,
     logDisplaySessions,
     plannedSessions,
     loggedKeys,

--- a/web/src/utils/__tests__/sessionStatus.test.js
+++ b/web/src/utils/__tests__/sessionStatus.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { COMPLETED_STATUSES } from '../../constants/sessionStatus.js';
-import { isCompletedStatus } from '../sessionStatus.js';
+import { isCompletedStatus, isCancelledStatus } from '../sessionStatus.js';
 
 describe('isCompletedStatus', () => {
   it('AC3 does NOT treat null or undefined as completed', () => {
@@ -28,5 +28,35 @@ describe('isCompletedStatus', () => {
   it('AC6 does not count planned or cancelled', () => {
     expect(isCompletedStatus('planned')).toBe(false);
     expect(isCompletedStatus('cancelled')).toBe(false);
+  });
+});
+
+// ── #242: the calendar day strip needs to name a deviation ────────
+// A second allow-list, deliberately separate from isCompletedStatus rather
+// than its complement: "not completed" also covers planned and unknown, and
+// neither is a cancellation.
+describe('isCancelledStatus', () => {
+  it('AC1 recognises the one cancelled spelling', () => {
+    expect(isCancelledStatus('cancelled')).toBe(true);
+  });
+
+  it.each(COMPLETED_STATUSES)(
+    'AC2 does not call a %s session cancelled',
+    (status) => {
+      expect(isCancelledStatus(status)).toBe(false);
+    }
+  );
+
+  it('AC3 does not call a planned prescription cancelled', () => {
+    expect(isCancelledStatus('planned')).toBe(false);
+  });
+
+  it('AC4 fails CLOSED on absent or unknown values', () => {
+    // Same posture as isCompletedStatus: an unrecognised value must not paint
+    // a CANCELLED marker onto a day the database never cancelled.
+    expect(isCancelledStatus(null)).toBe(false);
+    expect(isCancelledStatus(undefined)).toBe(false);
+    expect(isCancelledStatus('')).toBe(false);
+    expect(isCancelledStatus('skipped')).toBe(false);
   });
 });

--- a/web/src/utils/sessionStatus.js
+++ b/web/src/utils/sessionStatus.js
@@ -1,4 +1,7 @@
-import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
+import {
+  COMPLETED_STATUSES,
+  CANCELLED_STATUS,
+} from '../constants/sessionStatus.js';
 
 // Does this session's status mean "training that actually happened"?
 //
@@ -15,4 +18,12 @@ import { COMPLETED_STATUSES } from '../constants/sessionStatus.js';
 // statuses server-side via .in('status', COMPLETED_STATUSES).
 export function isCompletedStatus(status) {
   return COMPLETED_STATUSES.includes(status);
+}
+
+// Was this session decided against? A deviation worth showing on the calendar,
+// never one worth counting. Strict equality against the single allowed
+// spelling — same fail-closed posture as isCompletedStatus, so an unknown value
+// is not silently rendered as a cancellation.
+export function isCancelledStatus(status) {
+  return status === CANCELLED_STATUS;
 }

--- a/web/src/views/CalendarView.jsx
+++ b/web/src/views/CalendarView.jsx
@@ -13,12 +13,18 @@ import {
   resolveDay,
   dayStatus,
   daySessions,
+  logEntriesForDate,
 } from '../utils/schedule.js';
 import { compareBenchmarkSeverity } from '../utils/benchmarkStatus.js';
 import { MICROCYCLE, PHASE_CONTEXT } from '../constants/schedule.js';
+import { THEME } from '../constants/theme.js';
 
 // ── CALENDAR VIEW ──
-export default function CalendarView({ loggedSessions, isWide }) {
+export default function CalendarView({
+  loggedSessions,
+  cancelledSessions = [],
+  isWide,
+}) {
   // Resolved once for the FULL ladder. Each state carries its own entry, so the
   // panel below renders from the states themselves — a badge cannot drift onto
   // the wrong row once the rows are re-ordered by severity.
@@ -68,6 +74,10 @@ export default function CalendarView({ loggedSessions, isWide }) {
     if (i >= 0 && mode !== firstMode) sawSwitch = true;
     const sess = resolveDay(d); // override-aware
     const status = dayStatus(d, today0, loggedSessions); // done / today / upcoming / missed
+    // Same status-blind date matcher the completed count runs through, fed the
+    // pre-filtered cancelled list — so the two counts cannot drift apart on the
+    // unpadded M/D/YY key, and schedule.js never learns about status.
+    const cancelledCount = logEntriesForDate(d, cancelledSessions).length;
     days.push({
       date: d,
       dow,
@@ -77,6 +87,7 @@ export default function CalendarView({ loggedSessions, isWide }) {
       mode,
       isOverride: !!(sess && sess.override),
       status,
+      cancelledCount,
     });
   }
   const todayMode = firstMode;
@@ -151,7 +162,13 @@ export default function CalendarView({ loggedSessions, isWide }) {
                 flexDirection: 'column',
                 gap: 3,
                 opacity:
-                  st === 'missed' ? 0.5 : st === 'done' && d.isPast ? 0.85 : 1,
+                  st === 'missed'
+                    ? d.cancelledCount > 0
+                      ? 0.75
+                      : 0.5
+                    : st === 'done' && d.isPast
+                      ? 0.85
+                      : 1,
               }}
             >
               <div
@@ -173,6 +190,18 @@ export default function CalendarView({ loggedSessions, isWide }) {
                 >
                   {statusLabel}
                 </span>
+                {d.cancelledCount > 0 && (
+                  <span
+                    style={{
+                      fontSize: 7,
+                      color: THEME.textSubtle,
+                      letterSpacing: 2,
+                      fontWeight: 700,
+                    }}
+                  >
+                    ⊘ {d.cancelledCount} CANCELLED
+                  </span>
+                )}
                 {d.isOverride && (
                   <span
                     style={{

--- a/web/src/views/__tests__/CalendarView.dayStrip.test.jsx
+++ b/web/src/views/__tests__/CalendarView.dayStrip.test.jsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Mocked at the module boundary, same as CalendarView.test.jsx — vi.mock is
+// per-file, so these have to be repeated. Simplified to quiet defaults: the
+// ladder panel is not under test here, only the day strip above it.
+vi.mock('../../hooks/useBenchmarkStatuses.js', () => ({
+  useBenchmarkStatuses: () => [],
+  useBenchmarkDataUnavailable: () => false,
+}));
+
+vi.mock('../../hooks/useBenchmarkSessions.js', () => ({
+  useBenchmarkSessions: () => ({ data: [] }),
+}));
+
+vi.mock('../../hooks/useLinkBenchmarkSession.js', () => ({
+  useLinkBenchmarkSession: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+import CalendarView from '../CalendarView.jsx';
+
+// Dates are unpadded M/D/YY on purpose. logEntriesForDate builds its key with
+// getMonth()+1 and getDate() — no zero padding — so a '06/23/26' fixture would
+// match nothing and every assertion below would pass vacuously.
+const LOGGED = [
+  {
+    date: '6/23/26',
+    type: 'erg',
+    label: 'CP Test - 4min MAX (GATED)',
+    status: 'completed',
+  },
+  {
+    date: '6/25/26',
+    type: 'strength',
+    label: 'Lower A (RDL-led)',
+    status: 'completed',
+  },
+  {
+    date: '6/25/26',
+    type: 'erg',
+    label: 'Warm-down paddle (post-Lower)',
+    status: 'completed',
+  },
+  {
+    date: '6/29/26',
+    type: 'erg',
+    label: 'UT1 50min steady',
+    status: 'completed',
+  },
+];
+
+const CANCELLED = [
+  {
+    date: '6/23/26',
+    type: 'erg',
+    label: 'UT1 50min steady',
+    status: 'cancelled',
+  },
+  {
+    date: '6/24/26',
+    type: 'erg',
+    label: 'UT2 30min recovery @ 125-135W',
+    status: 'cancelled',
+  },
+  { date: '6/24/26', type: 'strength', label: 'Upper A', status: 'cancelled' },
+  {
+    date: '6/25/26',
+    type: 'cycling',
+    label: 'Bike VO2: 5x3min @ 270-285W',
+    status: 'cancelled',
+  },
+  { date: '6/28/26', type: 'strength', label: 'Upper A', status: 'cancelled' },
+];
+
+function renderView(props = {}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <CalendarView loggedSessions={LOGGED} isWide={false} {...props} />
+    </QueryClientProvider>
+  );
+}
+
+// The strip is the banner div's next sibling; each child is one day cell and
+// each cell's first child is its header row. Index i is day `today - 3 + i`,
+// because CalendarView walks i = -BACK..FWD with BACK = 3. Locating by status
+// text would be ambiguous — '— not logged' and 'UPCOMING' repeat down the strip.
+function stripCells(container) {
+  const banner = within(container).getByText(/YOUR WEEKS/i).parentElement;
+  return Array.from(banner.nextElementSibling.children);
+}
+
+function headerTexts(container) {
+  return stripCells(container).map((c) => c.firstElementChild.textContent);
+}
+
+describe('CalendarView day strip — cancelled marker (#242)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Local-argument constructor: TZ-independent, and the same idiom the
+    // schedule tests use. 26 Jun 26 puts 23 Jun – 9 Jul in the window, which
+    // holds every case as a real date from the live table.
+    vi.setSystemTime(new Date(2026, 5, 26, 9, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('AC6 pins the clock so the window is 23 Jun – 9 Jul', () => {
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    const cells = stripCells(container);
+    expect(cells).toHaveLength(17);
+    expect(cells[0].textContent).toMatch(/23/);
+    expect(cells[3].firstElementChild.textContent).toContain('● TODAY');
+  });
+
+  it('AC1 marks a both-states day differently from a completed-only day', () => {
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    const headers = headerTexts(container);
+    expect(headers[2]).toContain('✓ DONE ×2');
+    expect(headers[2]).toContain('⊘ 1 CANCELLED');
+    // 6/29 is completed-only — the control that proves the marker is not
+    // painted onto every day with a session.
+    expect(headers[6]).toContain('✓ DONE');
+    expect(headers[6]).not.toContain('⊘');
+  });
+
+  it('AC3 reads both facts off one day in a single textContent', () => {
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    const header = headerTexts(container)[2];
+    expect(header).toMatch(/✓ DONE ×2/);
+    expect(header).toMatch(/⊘ 1 CANCELLED/);
+  });
+
+  it('AC2 marks a cancelled-only past day instead of leaving it blank', () => {
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    const headers = headerTexts(container);
+    expect(headers[1]).toContain('— not logged');
+    expect(headers[1]).toContain('⊘ 2 CANCELLED');
+  });
+
+  it('AC5 counts only completed sessions in ×N — cancelled never inflates it', () => {
+    // The regression trap. If a cancelled row leaked into loggedSessions,
+    // 6/23 would read ✓ DONE ×2 and 6/25 ✓ DONE ×3.
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    const headers = headerTexts(container);
+    expect(headers[0]).toContain('✓ DONE');
+    expect(headers[0]).not.toContain('×2');
+    expect(headers[0]).toContain('⊘ 1 CANCELLED');
+    expect(headers[2]).toContain('×2');
+    expect(headers[2]).not.toContain('×3');
+  });
+
+  it('AC8 marks a cancelled-only FUTURE day — a session dropped ahead of time', () => {
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    const headers = headerTexts(container);
+    expect(headers[5]).toContain('UPCOMING');
+    expect(headers[5]).toContain('⊘ 1 CANCELLED');
+  });
+
+  it('leaves a day with no record at all clean', () => {
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    const headers = headerTexts(container);
+    expect(headers[3]).toContain('● TODAY');
+    expect(headers[3]).not.toContain('⊘');
+    expect(headers[4]).not.toContain('⊘');
+  });
+
+  it('lifts a cancelled-only past day from 0.5 to 0.75 opacity', () => {
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    expect(stripCells(container)[1].style.opacity).toBe('0.75');
+  });
+
+  it('AC7 renders identically with an empty list and with the prop omitted', () => {
+    const empty = renderView({ cancelledSessions: [] });
+    const omitted = renderView();
+    const withEmpty = headerTexts(empty.container);
+    const withoutProp = headerTexts(omitted.container);
+    expect(withoutProp).toEqual(withEmpty);
+    expect(withEmpty.join('')).not.toContain('⊘');
+  });
+});
+
+describe('CalendarView day strip — cancelled on today (#242)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 24, 9, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('marks today itself when the day only holds cancellations', () => {
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    const header = headerTexts(container)[3];
+    expect(header).toContain('● TODAY');
+    expect(header).toContain('⊘ 2 CANCELLED');
+  });
+
+  it('leaves a clean past day at 0.5 opacity and unmarked', () => {
+    const { container } = renderView({ cancelledSessions: CANCELLED });
+    const cells = stripCells(container);
+    expect(cells[0].firstElementChild.textContent).toContain('— not logged');
+    expect(cells[0].firstElementChild.textContent).not.toContain('⊘');
+    expect(cells[0].style.opacity).toBe('0.5');
+  });
+});


### PR DESCRIPTION
Closes #242

## What changed and why

The calendar day cell now appends a `⊘ N CANCELLED` marker, so a day where a prescription was dropped is distinguishable from one where it never existed — both when something else was completed that day (7 dates) and when nothing was (16 dates).

## The shape of the change

This is **additive, not a correctness fix**. Cancelled rows never reached `dayStatus`: every caller passes `loggedSessions`, which `useSessionLog` builds through `isCompletedStatus`. Those 7 days rendered `done` because something genuinely *was* completed, and the 16 rendered `missed` because nothing was logged. Both correct. What was missing was the other half of the story.

| state | with a cancellation |
|---|---|
| `✓ DONE ×2` | `✓ DONE ×2` `⊘ 1 CANCELLED` |
| `— not logged` | `— not logged` `⊘ 2 CANCELLED` |
| `● TODAY` | `● TODAY` `⊘ 2 CANCELLED` |
| `UPCOMING` | `UPCOMING` `⊘ 1 CANCELLED` |

A cancelled-only past day also lifts from `0.5` to `0.75` opacity, so a recorded decision no longer dims like an absence. That is the only behavioural change to an existing line.

The `upcoming` + cancelled case is real, not theoretical — 7/2/26 is `Lower B — DROPPED (retest taper)`, cancelled ahead of time during a taper.

## How the #194 contract is kept

`utils/schedule.js` is **not touched**. Its contract says callers must pass an already-filtered list, so the view calls the exported, status-blind `logEntriesForDate` a second time with a pre-filtered cancelled list. The single status check (`isCancelledStatus`) lives one layer up in the hook; `logEntriesForDate` stays a pure date-matcher unaware that one caller feeds it a cancelled-only list. #194's bug was a second status gate *at the point of consumption* — this is the inverse. Reusing the one unpadded `M/D/YY` key builder also means the completed and cancelled counts cannot drift apart on a date-formatting bug.

`statusColor` and `statusLabel` are byte-identical; the marker is a sibling span. That makes "zero-cancelled renders unchanged" a property of the code rather than something tests have to police — and it is why the 16 existing `CalendarView.test.jsx` tests pass with zero edits.

The `×N` suffix stays completed-only: it derives from `dayStatus(...).logged`, which never sees the cancelled list.

## How to test manually

Not required — covered by CI. The cancelled rows are dated 23 Jun – 20 Jul 2026, so none fall inside the calendar's today−3 → today+14 window; the feature **cannot be verified by looking at the calendar today**. That is why the tests are clock-pinned.

`CalendarView.dayStrip.test.jsx` pins the clock to 26 Jun 2026 — the one 17-day window holding all five cases as real dates: both-states with and without a `×N` suffix, cancelled-only past, cancelled-only future, and a clean control. A second block pins 24 Jun so today itself is a cancelled-only day.

## Notes for review

- **Zero hex delta.** `CalendarView.jsx` gains a `THEME` import for the marker only (`THEME.textSubtle`, matching the `CANCELLED` badge `LogEntry` already renders). Its four pre-existing raw-hex literals are deliberately left alone — that migration is #183's.
- The second commit extends the existing R9 prop-wiring guard. The `cancelledSessions = []` default means a dropped prop would silently render zero markers while every test still passed; verified by mutation that removing the prop from `App.jsx` now fails.

Coverage: `CalendarView.jsx` 100/100/90, `sessionStatus.js` 100/100/100, `useSessionLog.js` 100/100/89.47. 740 tests pass.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser
- [ ] Visual change: yes — a new `⊘ N CANCELLED` marker and one opacity value. Not currently observable in the running app (all affected dates are outside the render window), so no screenshot is attachable; the rendered DOM is asserted in `CalendarView.dayStrip.test.jsx` instead.
- [x] Stays inside the property boundary: colour hexes = #183 · box metrics = S6 ·
      type = S-1 (see DESIGN.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTN1v6sUvJJTDRRRcfHkBn)_