### PR TITLE
fix(design): verify conventions.md's contrast claims, and correct two stale docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ legacy `sessions.date` text pattern); RLS single-owner policy like the modern ta
 - **sRPE** — How hard a session felt on a 1–10 scale (subjective).
 - **CP** (Critical Power) — The highest power you can sustain indefinitely.
   **~205W provisional (rowing)**; revalidate via rested 1-min + 4-min tests.
-  Rowing zones off this anchor: **UT2 113–144 / UT1 144–164 / AT 164–205 W**.
+  Rowing zones off this anchor: **UT2 113–144 / UT1 144–164 / AT 164–185 W**.
 - **Current model — pure base + strength** (reverted from polarised on 2026-06-29):
   rowing is aerobic volume only (UT1/UT2 — no programmed threshold/VO₂); the bike
   is a complementary Z1/Z2 aerobic carrier, never a programmed intensity source;

--- a/web/.design-sync/STATE_OF_PLAY.md
+++ b/web/.design-sync/STATE_OF_PLAY.md
@@ -7,8 +7,11 @@ neither — it is a status check, and it goes stale quickly._
 Rendered version: https://claude.ai/code/artifact/e16750c2-4d67-4bc2-99a3-7fae8ca450dc
 
 > **Verdict.** The Claude Design project has never been opened. Separately, `main`
-> moved underneath the synced design system and the design-sync build is now
+> moved underneath the synced design system and the design-sync build was
 > **broken on `main`** — verified by reproduction, not inferred from a diff.
+>
+> **Update 2026-08-24:** both live defects in §2 are fixed and neither blocks a
+> re-sync. The project still has not been opened.
 
 ---
 
@@ -44,7 +47,14 @@ invisible to every check above — not missing, just out of view.
 
 ## 2. Live defects
 
-### 2.1 The design-sync build is broken on `main` — blocks any re-sync
+### 2.1 ~~The design-sync build is broken on `main`~~ — **fixed**
+
+> **Resolved.** `85eab51` (#224) repaired the barrel and #225 added the CI guard this
+> section asks for at the end. Re-verified at `ad2a8bd`: `entry.jsx` exports
+> `derivePaceZones`, `previews/PaceTrendChart.tsx` derives locally from it, the bundle
+> builds (esbuild, 963 kb), and `npm run check:design-sync` passes. **A re-sync is no
+> longer blocked by this.** Kept below for the record.
+
 
 `d15d334` (#203) removed the static `PACE_ZONES` export from `trainingConfig.js`,
 deliberately, so a seed-derived second set of zone bands cannot diverge from the live
@@ -67,7 +77,14 @@ was not sufficient; the barrel wants a CI guard that builds `entry.jsx` on any
 `web/src` change, because the same failure recurs whenever a synced export is renamed
 or removed.
 
-### 2.2 `conventions.md` ships a contrast failure into every generated design
+### 2.2 ~~`conventions.md` ships a contrast failure into every generated design~~ — **fixed**
+
+> **Resolved by #262's rewrite**, which drops the `THEME.muted` recommendation
+> entirely: section labels are now `#43485a`, which measures 5.26 on the light ground
+> `#bcc5dd` and 9.08 on a white card — both pass AA. Note this was also fixed once in
+> `85eab51` (#224) and then reverted by `e61092c` (#240), so it has now been closed
+> twice; `npm run check:design-sync` verifies the published ratios from here on.
+
 
 The synced conventions file recommends `THEME.muted` at `fontSize: 9` on
 `surface`/`raised` panels. Both pairings fail WCAG AA (this is §1.6 of the brief,
@@ -137,7 +154,8 @@ Better than either option on the table — and the same commit is what broke the
 
 | Priority | Work |
 |---|---|
-| **Do first** | Repair the barrel (`PACE_ZONES` -> `derivePaceZones`) and fix the `muted` -> `textSubtle` contrast in `conventions.md`; rebuild and re-sync. One small PR, both defects. |
+| ~~Do first~~ | ~~Repair the barrel and fix the `muted` contrast in `conventions.md`~~ — **both closed** (§2.1, §2.2). The barrel landed in `85eab51` (#224) with a guard in #225; the contrast landed there too, was reverted by `e61092c` (#240), and is closed again by #262's rewrite. |
+| **Do first** | Open the project. Every remaining item in §1 needs an interactive `/design-login`, which no agent session can do. |
 | Record | Two couplings into `NOTES.md`: `dtsPropsFor` must document `style` once the primitives ship, or the design agent codes against a contract that denies the seam exists; `cfg.extraFonts` must carry the Plex woff2 files once self-hosted, or generated designs keep rendering in fallback after the app is fixed. |
 | Coordinate | Close §8.1 and §8.2 in `DESIGN_BRIEF.md` — both decided but still written as open. Fix the numbering while there: §8 currently reads 1, 2, 2, 3, 4, 5, 6, 7. |
 | Consider | A CI guard that builds `entry.jsx`, per §2.1. |

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -93,4 +93,16 @@ export default [
       },
     },
   },
+  {
+    // Node build/CI scripts. They are in the lint scope because the design-sync
+    // guard lives here and is CI-enforced — a gate that is itself ungated is how
+    // the barrel broke in the first place.
+    files: ['scripts/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+      },
+    },
+  },
 ];

--- a/web/package.json
+++ b/web/package.json
@@ -10,9 +10,9 @@
     "size": "node scripts/check-bundle-size.mjs",
     "test": "vitest run",
     "test:e2e": "playwright test",
-    "lint": "eslint src/",
-    "format": "prettier --write src/",
-    "format:check": "prettier --check src/",
+    "lint": "eslint src/ scripts/",
+    "format": "prettier --write src/ scripts/",
+    "format:check": "prettier --check src/ scripts/",
     "check:design-sync": "node scripts/check-design-sync-entry.mjs",
     "prepare": "husky"
   },

--- a/web/scripts/check-design-sync-entry.mjs
+++ b/web/scripts/check-design-sync-entry.mjs
@@ -20,7 +20,7 @@
 //   npm run check:design-sync
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const configPath = join(webRoot, '.design-sync', 'config.json');
@@ -78,6 +78,92 @@ if (!existsSync(entry)) {
   }
 }
 
+// 3. Every contrast claim conventions.md publishes must survive arithmetic, and
+//    every --color-* it names must exist.
+//
+//    conventions.md is the readmeHeader — the one input guaranteed to be inlined
+//    into the design agent's prompt, so a wrong number here reaches every design.
+//    Its own revision history is the argument for checking it: #224 measured the
+//    ratios, #240 replaced them with a different palette's, and #262 records that
+//    "four separate AA failures were shipped during this revision, every one of
+//    them a colour chosen against a background that was darkened afterwards".
+//    Ratios in prose do not recompute themselves.
+const conventionsRel = '.design-sync/conventions.md';
+const conventionsPath = join(webRoot, conventionsRel);
+
+let claimsChecked = 0;
+
+if (!existsSync(conventionsPath)) {
+  failures.push(`${conventionsRel} is missing`);
+} else {
+  const md = readFileSync(conventionsPath, 'utf8');
+
+  const relLum = (hex) => {
+    const ch = [1, 3, 5]
+      .map((i) => parseInt(hex.slice(i, i + 2), 16) / 255)
+      .map((v) => (v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4));
+    return 0.2126 * ch[0] + 0.7152 * ch[1] + 0.0722 * ch[2];
+  };
+  const ratio = (a, b) => {
+    const [hi, lo] = [relLum(a), relLum(b)].sort((x, y) => y - x);
+    return (hi + 0.05) / (lo + 0.05);
+  };
+
+  //  "#43485a   (verified 4.5:1+ against #bcc5dd)" — a floor the pair must clear.
+  for (const m of md.matchAll(
+    /(#[0-9a-fA-F]{6})[^\n]*?([0-9]+(?:\.[0-9]+)?):1\+?\s*against\s*(#[0-9a-fA-F]{6})/g
+  )) {
+    const [, fg, floor, bg] = m;
+    claimsChecked += 1;
+    const real = ratio(fg, bg);
+    if (real < Number(floor)) {
+      failures.push(
+        `${conventionsRel} claims ${fg} clears ${floor}:1 against ${bg}; ` +
+          `it is ${real.toFixed(2)}`
+      );
+    }
+  }
+
+  //  "muted #7e7e9a on raised #2a2a48 -> 3.50" — an exact published ratio.
+  for (const m of md.matchAll(
+    /(#[0-9a-fA-F]{6})\s+on\s+[a-zA-Z]*\s*(#[0-9a-fA-F]{6})\s*->\s*([0-9]+\.[0-9]{2})/g
+  )) {
+    const [, fg, bg, claimed] = m;
+    claimsChecked += 1;
+    const real = ratio(fg, bg);
+    if (Math.abs(real - Number(claimed)) > 0.01) {
+      failures.push(
+        `${conventionsRel} says ${fg} on ${bg} is ${claimed}; it is ` +
+          real.toFixed(2)
+      );
+    }
+  }
+
+  //  Any --color-* it names must actually be generated from THEME.
+  const named = [...md.matchAll(/--color-([a-zA-Z][a-zA-Z0-9]*)/g)].map(
+    (m) => m[1]
+  );
+  if (named.length) {
+    try {
+      const { THEME } = await import(
+        pathToFileURL(join(webRoot, 'src/constants/theme.js')).href
+      );
+      for (const key of [...new Set(named)]) {
+        if (!(key in THEME)) {
+          failures.push(
+            `${conventionsRel} names --color-${key}, which theme.js does not ` +
+              'define — it will resolve to nothing in a generated design'
+          );
+        }
+      }
+    } catch (e) {
+      failures.push(
+        `src/constants/theme.js could not be imported — ${e?.message ?? e}`
+      );
+    }
+  }
+}
+
 if (failures.length) {
   console.error('\ndesign-sync entry guard FAILED\n');
   for (const f of failures) console.error(`  ✗ ${f}\n`);
@@ -93,5 +179,6 @@ if (failures.length) {
 }
 
 console.log(
-  'design-sync: barrel bundles and every componentSrcMap path resolves.'
+  'design-sync: barrel bundles, every componentSrcMap path resolves, and ' +
+    `${claimsChecked} published contrast claim(s) in conventions.md recompute.`
 );


### PR DESCRIPTION
Refs #258, #262 — deliberately not `Closes`. #258's acceptance criteria all live on claude.ai/design and need an interactive `/design-login`; this makes a future re-sync safer, it does not perform one.

## What changed and why

Three corrections found while working #258, kept separate from #262 which landed the design workstream itself.

**1. `conventions.md`'s contrast claims are now recomputed, not trusted.**

`conventions.md` is the `readmeHeader` — the one input guaranteed to be inlined into the design agent's prompt — so a wrong ratio in it reaches every generated design. Its own revision history is the argument for checking it rather than trusting it:

- #224 measured the ratios
- #240 replaced them with a different palette's
- #262's commit message records that *"four separate AA failures were shipped during this revision, every one of them a colour chosen against a background that was darkened afterwards"*

Ratios in prose do not recompute themselves. `npm run check:design-sync` now verifies:

- every `N:1+ against #hex` floor survives arithmetic
- every exact `#fg on #bg -> N.NN` recomputes
- every `--color-*` named exists in `THEME`, or it resolves to nothing in a design

The success line prints how many claims it verified, so a pattern that stops matching shows up as a count drop rather than a silent pass. Today: `1 published contrast claim(s) in conventions.md recompute.`

**2. `STATE_OF_PLAY.md` listed both §2 defects as live and "blocks any re-sync".** Neither is:

| Defect | Status |
|---|---|
| §2.1 barrel / build broken | Fixed in `85eab51` (#224), guard in #225. Re-verified at `ad2a8bd` — bundle builds, `check:design-sync` passes |
| §2.2 contrast failure | Fixed in #224 → **reverted by `e61092c` (#240)** → closed again by #262, which drops the `THEME.muted` recommendation for `#43485a` (5.26 on the light ground, 9.08 on a white card, both pass AA) |

**3. `CLAUDE.md` gave the AT band as `164–205 W`.** `derivePaceZones(205)` yields **164–185**; 205 is the CP anchor itself, not AT's ceiling. UT2 and UT1 were already correct.

**4. `lint` and `format:check` covered `src/` only**, so the CI-enforced design-sync guard was itself ungated. Both now include `scripts/`, with Node globals for `scripts/**/*.mjs`.

## How to test manually

```
npm run check:design-sync   # 1 claim verified
```

Negative-tested all three checks — each fails as expected:

| Mutation | Result |
|---|---|
| Falsify the AA floor (darken the ground) | `claims #43485a clears 4.5:1 against #5a6070; it is 1.44` |
| Publish a wrong exact ratio | `says #7e7e9a on #2a2a48 is 9.99; it is 3.50` |
| Name `--color-accent` (not in `THEME`) | `theme.js does not define — it will resolve to nothing` |

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — the guard is verified by mutation rather than by unit test, matching how `check-design-sync-entry.mjs` was already built; no app source under `web/src/` is touched, so the 720-test suite is a regression check here
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no runtime code changed

---
_Generated by [Claude Code](https://claude.ai/code/session_019CvTYRBHUm8gmBTFk4gwmT)_