### PR TITLE
fix(design): correct the AT band in the design briefing, and check it mechanically

### DIFF
--- a/web/.design-sync/CLAUDE.md
+++ b/web/.design-sync/CLAUDE.md
@@ -54,7 +54,7 @@ Terms that appear on screen. Get these wrong and the design is wrong.
   types after a session.
 - **CP** — critical power, the wattage sustainable more or less indefinitely. ~205W,
   provisional. Every rowing zone derives from it.
-- **UT2 / UT1 / AT** — aerobic training bands off CP: 113–144 / 144–164 / 164–205 W.
+- **UT2 / UT1 / AT** — aerobic training bands off CP: 113–144 / 144–164 / 164–185 W.
   Almost all rowing volume is UT1/UT2; there is no programmed threshold work right now.
 - **Microcycle** — one week's pattern. **Home weeks** load, **FIFO weeks** deload.
 - **Readiness** — a derived morning score from RHR, HRV and sleep against personal

--- a/web/scripts/check-design-sync-entry.mjs
+++ b/web/scripts/check-design-sync-entry.mjs
@@ -164,6 +164,58 @@ if (!existsSync(conventionsPath)) {
   }
 }
 
+// 4. Any zone band published in the design-sync docs must match derivePaceZones.
+//
+//    The same wrong AT ceiling reached two separate files: the repo CLAUDE.md and
+//    .design-sync/CLAUDE.md both gave AT as 164-205 W. 205 is the CP anchor, which
+//    sits one line above in both — the band's ceiling is 185. #266 fixed one copy
+//    and missed the other, which is the argument for checking rather than reading.
+//
+//    Bands are derived from CP, so anything written down is a snapshot. Verify the
+//    snapshot against the function at the CP the doc itself quotes.
+for (const rel of ['.design-sync/CLAUDE.md', '.design-sync/conventions.md']) {
+  const abs = join(webRoot, rel);
+  if (!existsSync(abs)) continue;
+  const md = readFileSync(abs, 'utf8');
+
+  //  "UT2 / UT1 / AT — ... 113-144 / 144-164 / 164-185 W"
+  const line = md.match(
+    /UT2[^\n]*?AT[^\n]*?([0-9]+)[–-]([0-9]+)\s*\/\s*([0-9]+)[–-]([0-9]+)\s*\/\s*([0-9]+)[–-]([0-9]+)\s*W/
+  );
+  if (!line) continue;
+
+  const cpMatch = md.match(/~([0-9]{2,4})\s*W/);
+  const cp = cpMatch ? Number(cpMatch[1]) : null;
+  if (!cp) {
+    failures.push(
+      `${rel} publishes UT2/UT1/AT watt bands but names no CP to derive them from`
+    );
+    continue;
+  }
+
+  try {
+    const { derivePaceZones } = await import(
+      pathToFileURL(join(webRoot, 'src/constants/trainingConfig.js')).href
+    );
+    const zones = derivePaceZones(cp);
+    const claimed = line.slice(1).map(Number);
+    ['UT2', 'UT1', 'AT'].forEach((name, i) => {
+      const z = zones.find((x) => x.zone === name);
+      const [lo, hi] = [claimed[i * 2], claimed[i * 2 + 1]];
+      if (z.wattsLow !== lo || z.wattsHigh !== hi) {
+        failures.push(
+          `${rel} gives ${name} as ${lo}-${hi} W; derivePaceZones(${cp}) yields ` +
+            `${z.wattsLow}-${z.wattsHigh}`
+        );
+      }
+    });
+  } catch (e) {
+    failures.push(
+      `src/constants/trainingConfig.js could not be imported — ${e?.message ?? e}`
+    );
+  }
+}
+
 if (failures.length) {
   console.error('\ndesign-sync entry guard FAILED\n');
   for (const f of failures) console.error(`  ✗ ${f}\n`);


### PR DESCRIPTION
Refs #258, #262, #266.

## What changed and why

#266 fixed the AT zone band in the repo-root `CLAUDE.md`. #262 landed `web/.design-sync/CLAUDE.md` in parallel carrying **the same error**, so the wrong number survived in the worse of the two places — the file a design session reads to learn what the numbers mean, and which is uploaded to the design project.

Both said AT is `164–205 W`. `derivePaceZones(205)` yields **164–185**:

```
UT2 113-144   ✅ was already right
UT1 144-164   ✅ was already right
AT  164-185   ❌ documented as 164-205
```

In both files the CP anchor (`~205 W`) sits one line above, which is how the ceiling got restated as the band's top.

Fixing the second copy by hand would leave the same gap that let this through twice, so it's checked instead. `npm run check:design-sync` now recomputes any UT2/UT1/AT watt bands published in the design-sync docs against `derivePaceZones`, at the CP the document itself quotes.

Same argument as the contrast check in #266: a band derived from a provisional anchor is a snapshot, and snapshots don't recompute themselves. `NOTES.md` already records the version of this that shipped — a bundle frozen at an old CP that *"quietly hands out wrong pace bands."*

## How to test manually

```
npm run check:design-sync
```

Reproduced the shipped bug against the new check:

| Mutation | Result |
|---|---|
| Reintroduce `164–205` | `gives AT as 164-205 W; derivePaceZones(205) yields 164-185` |
| Wrong UT2 floor (`100–144`) | `gives UT2 as 100-144 W; derivePaceZones(205) yields 113-144` |
| Clean tree | passes |

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — the guard is verified by mutation, matching how `check-design-sync-entry.mjs` was already built; no app source under `web/src/` is touched, so the 740-test suite is a regression check here
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no runtime code changed

---
_Generated by [Claude Code](https://claude.ai/code/session_019CvTYRBHUm8gmBTFk4gwmT)_