### PR TITLE
fix(design): give every .design-sync file one owner, and stop the two-way flow

### DIFF
--- a/web/.design-sync/CODE-TO-DESIGN.md
+++ b/web/.design-sync/CODE-TO-DESIGN.md
@@ -130,10 +130,14 @@ freeze the contradiction into another bundle. **Re-sync after the role rename la
 (#248), which is when those references move in lockstep with the code. Re-run
 `node .design-sync/gen-css.mjs` first — step one of every sync. Tracked as #258.
 
-While re-syncing, verify how `CLAUDE.md` reaches the design agent. `readmeHeader` inlining
-is the only channel *confirmed* to work; whether the app auto-loads a file by that name is
-unverified. If it does not, point `readmeHeader` at it. The behavioural test: ask for a
-chart and see whether it produces a labelled axis and a computed caption unprompted.
+**Done — `readmeHeader` now points at `CLAUDE.md`.** This section asked for it, and it
+was the right call for a second reason: `readmeHeader` previously pushed `conventions.md`
+*up*, over the copy the design project owns. That was a two-way flow with nothing
+arbitrating it. `ownership.json` now declares the direction per file and
+`npm run check:design-sync` fails if `config.json` ever names a design-owned path again.
+
+The behavioural test still stands: ask for a chart and see whether it produces a labelled
+axis and a computed caption unprompted.
 
 ## Build order — when the designs become buildable
 

--- a/web/.design-sync/NOTES.md
+++ b/web/.design-sync/NOTES.md
@@ -13,6 +13,37 @@ before re-running the sync.
   `.design-sync/`, `.ds-sync/` and `ds-bundle/` are all package-relative, and
   every command below is run from `web/`.
 
+## Who owns what
+
+`ownership.json` is the machine-readable answer, and `npm run check:design-sync`
+enforces it. Three owners:
+
+- **`repo`** — written here, pushed to the design project. Listed below.
+- **`design`** — authored in the design project; the copy here is a **read-only
+  mirror** committed so a code session can read it (`conventions.md`,
+  `HANDOFF.md`, `ISSUES-load-states.md`, `PROJECT-CONTEXT.md`, `designs/*`).
+  **Do not edit these here** — the next download overwrites you, and `config.json`
+  is forbidden from referencing them.
+- **`local`** — working documents, neither pushed nor mirrored (this file,
+  `STATE_OF_PLAY.md`, `DESIGN_BRIEF.md`).
+
+### Why the manifest exists
+
+`conventions.md` used to move in both directions with nothing arbitrating it.
+`config.json` pushed the repo's copy up as `readmeHeader`, while
+`PROJECT-CONTEXT.md` declared the design project the source of truth and
+`HANDOFF.md` §3 authored it outright. Whichever side acted last silently won —
+which is how `e61092c` (#240) replaced `85eab51` (#224)'s measured dark contrast
+ratios with the light palette's, in the one file guaranteed to reach the design
+agent's prompt.
+
+The fix is one-directional ownership, checked rather than agreed: `readmeHeader`
+now points at **`CLAUDE.md`** — the domain briefing, which the repo genuinely owns
+because the domain lives in the code — and the guard fails if `config.json` ever
+names a `design`-owned path again. As a side effect the synced design system stops
+shipping a second, stale copy of the style guide, which is the "Known tension"
+`PROJECT-CONTEXT.md` records.
+
 ## Sync inputs this repo owns
 
 | File | Why it exists |
@@ -22,6 +53,8 @@ before re-running the sync.
 | `.design-sync/base.css` | Generated. The token layer (`--color-*`) plus the app ground. Wired as `cfg.cssEntry`. |
 | `.design-sync/docs/*.md` | Per-component docs. Their `category:` frontmatter is what sets the DS pane groups (session / metrics / charts / tooltips / feedback / mobile) — without them everything lands in `general`. |
 | `.design-sync/previews/*.tsx` | Authored preview stories, one file per component. |
+| `.design-sync/CLAUDE.md` | **`cfg.readmeHeader`** — the domain briefing, and the one input guaranteed to be inlined into the design agent's prompt. Glossary, the five destinations, which numbers are real, the chart rules. |
+| `.design-sync/CODE-TO-DESIGN.md` | Dated bulletin of what changed in the app since the last sync. Written at sync time. |
 | `scripts/check-design-sync-entry.mjs` | Guards the barrel: bundles `entry.jsx` with rolldown and checks every `componentSrcMap` path still exists. `npm run check:design-sync`, wired into CI (#225). |
 
 ## Gotchas

--- a/web/.design-sync/STATE_OF_PLAY.md
+++ b/web/.design-sync/STATE_OF_PLAY.md
@@ -96,8 +96,9 @@ muted      #7e7e9a on surface #1a1a2e -> 4.34  FAIL AA
 textSubtle #aaaacc on raised  #2a2a48 -> 6.13  pass
 ```
 
-`conventions.md` is inlined into the design agent's prompt, so the failure reproduces
-in every mockup it builds. `textSubtle` is a clean swap.
+`conventions.md` was the `readmeHeader` at the time, so the failure reproduced in every
+mockup built from it. `textSubtle` is a clean swap. (Since #258, `readmeHeader` points at
+`CLAUDE.md` and `conventions.md` is design-owned — see `ownership.json`.)
 
 ---
 

--- a/web/.design-sync/config.json
+++ b/web/.design-sync/config.json
@@ -55,5 +55,5 @@
       "cardMode": "column"
     }
   },
-  "readmeHeader": ".design-sync/conventions.md"
+  "readmeHeader": ".design-sync/CLAUDE.md"
 }

--- a/web/.design-sync/ownership.json
+++ b/web/.design-sync/ownership.json
@@ -1,0 +1,49 @@
+{
+  "$comment": [
+    "Who owns each file in .design-sync/, and which direction it moves.",
+    "",
+    "conventions.md used to move both ways with nothing arbitrating: config.json",
+    "pushed the repo's copy up as readmeHeader, while PROJECT-CONTEXT.md declared",
+    "the design project the source of truth and HANDOFF.md §3 authored it. Whichever",
+    "side acted last silently won — which is how #240 replaced #224's measured",
+    "contrast ratios. This file makes the direction explicit per path, and",
+    "check:design-sync enforces it.",
+    "",
+    "owner=repo   — written here, pushed to the design project. The repo wins.",
+    "owner=design — authored in the design project, committed here as a read-only",
+    "               mirror so a code session can read it. Never pushed back up;",
+    "               config.json must not reference these or the loop returns.",
+    "owner=local  — working documents. Neither pushed nor mirrored."
+  ],
+  "owners": {
+    "repo": {
+      "pushed": true,
+      "paths": [
+        "config.json",
+        "ownership.json",
+        "entry.jsx",
+        "gen-css.mjs",
+        "base.css",
+        "CLAUDE.md",
+        "CODE-TO-DESIGN.md",
+        "docs/*.md",
+        "previews/*.tsx"
+      ]
+    },
+    "design": {
+      "pushed": false,
+      "paths": [
+        "conventions.md",
+        "HANDOFF.md",
+        "ISSUES-load-states.md",
+        "PROJECT-CONTEXT.md",
+        "designs/*.html",
+        "designs/README.md"
+      ]
+    },
+    "local": {
+      "pushed": false,
+      "paths": ["NOTES.md", "STATE_OF_PLAY.md", "DESIGN_BRIEF.md"]
+    }
+  }
+}

--- a/web/scripts/check-design-sync-entry.mjs
+++ b/web/scripts/check-design-sync-entry.mjs
@@ -18,7 +18,7 @@
 // failure being guarded.
 //
 //   npm run check:design-sync
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -81,8 +81,8 @@ if (!existsSync(entry)) {
 // 3. Every contrast claim conventions.md publishes must survive arithmetic, and
 //    every --color-* it names must exist.
 //
-//    conventions.md is the readmeHeader — the one input guaranteed to be inlined
-//    into the design agent's prompt, so a wrong number here reaches every design.
+//    conventions.md is the design project's style guide and is mirrored here, so a
+//    wrong ratio in it reaches every design built against it.
 //    Its own revision history is the argument for checking it: #224 measured the
 //    ratios, #240 replaced them with a different palette's, and #262 records that
 //    "four separate AA failures were shipped during this revision, every one of
@@ -92,6 +92,7 @@ const conventionsRel = '.design-sync/conventions.md';
 const conventionsPath = join(webRoot, conventionsRel);
 
 let claimsChecked = 0;
+let classified = 0;
 
 if (!existsSync(conventionsPath)) {
   failures.push(`${conventionsRel} is missing`);
@@ -216,6 +217,123 @@ for (const rel of ['.design-sync/CLAUDE.md', '.design-sync/conventions.md']) {
   }
 }
 
+// 5. Every file in .design-sync/ has a declared owner, and nothing design-owned
+//    is pushed back at the design project.
+//
+//    conventions.md used to move both ways with nothing arbitrating it: config.json
+//    pushed the repo's copy up as readmeHeader while PROJECT-CONTEXT.md declared the
+//    project the source of truth and HANDOFF.md §3 authored it. Whichever side acted
+//    last silently won — which is how #240 replaced #224's measured contrast ratios
+//    with a different palette's. ownership.json declares the direction per path; this
+//    check is what makes the declaration binding.
+const ownershipRel = '.design-sync/ownership.json';
+const ownershipPath = join(webRoot, ownershipRel);
+const dsRoot = join(webRoot, '.design-sync');
+
+if (!existsSync(ownershipPath)) {
+  failures.push(
+    `${ownershipRel} is missing — every .design-sync file needs an owner`
+  );
+} else {
+  let owners;
+  try {
+    ({ owners } = JSON.parse(readFileSync(ownershipPath, 'utf8')));
+  } catch (e) {
+    failures.push(`${ownershipRel} is not valid JSON — ${e.message}`);
+    owners = null;
+  }
+
+  if (owners) {
+    //  Only the two glob shapes actually used: "dir/*.ext" and a literal path.
+    const matches = (pattern, rel) => {
+      const star = pattern.indexOf('*');
+      if (star === -1) return pattern === rel;
+      const head = pattern.slice(0, star);
+      const tail = pattern.slice(star + 1);
+      return (
+        rel.startsWith(head) &&
+        rel.endsWith(tail) &&
+        !rel.slice(head.length, rel.length - tail.length).includes('/')
+      );
+    };
+
+    const walk = (dir, prefix = '') => {
+      const out = [];
+      for (const name of readdirSync(dir)) {
+        const abs = join(dir, name);
+        const rel = prefix ? `${prefix}/${name}` : name;
+        if (statSync(abs).isDirectory()) out.push(...walk(abs, rel));
+        else out.push(rel);
+      }
+      return out;
+    };
+
+    const onDisk = walk(dsRoot);
+    classified = onDisk.length;
+    const rules = Object.entries(owners).flatMap(([owner, spec]) =>
+      (spec.paths ?? []).map((pattern) => ({
+        owner,
+        pattern,
+        pushed: spec.pushed,
+      }))
+    );
+
+    const ownerOf = (rel) => {
+      const hits = rules.filter((r) => matches(r.pattern, rel));
+      return hits.length === 1 ? hits[0] : hits;
+    };
+
+    for (const rel of onDisk) {
+      const hit = ownerOf(rel);
+      if (Array.isArray(hit)) {
+        failures.push(
+          hit.length === 0
+            ? `${ownershipRel} does not classify .design-sync/${rel} — declare it ` +
+                'repo (pushed), design (mirrored down) or local (neither)'
+            : `${ownershipRel} classifies .design-sync/${rel} ${hit.length} times: ` +
+                hit.map((h) => `${h.owner} via "${h.pattern}"`).join(', ')
+        );
+      }
+    }
+
+    for (const { pattern } of rules) {
+      if (!onDisk.some((rel) => matches(pattern, rel))) {
+        failures.push(
+          `${ownershipRel} lists "${pattern}", which matches no file in .design-sync/`
+        );
+      }
+    }
+
+    //  The load-bearing check: anything config.json uploads must be repo-owned.
+    const pushInputs = [
+      ['entry', cfg.entry],
+      ['cssEntry', cfg.cssEntry],
+      ['docsDir', cfg.docsDir],
+      ['readmeHeader', cfg.readmeHeader],
+    ].filter(([, v]) => typeof v === 'string');
+
+    for (const [key, value] of pushInputs) {
+      const rel = value.replace(/^\.design-sync\//, '');
+      const hits = rules.filter(
+        (r) => matches(r.pattern, rel) || r.pattern.startsWith(`${rel}/`)
+      );
+      const designOwned = hits.filter((h) => h.owner === 'design');
+      if (designOwned.length) {
+        failures.push(
+          `config.json ${key} points at "${value}", which ownership.json says the ` +
+            'design project owns. Pushing it would overwrite the source of truth — ' +
+            "this is the loop that lost #224's contrast ratios."
+        );
+      } else if (!hits.length) {
+        failures.push(
+          `config.json ${key} points at "${value}", which ${ownershipRel} does not ` +
+            'classify'
+        );
+      }
+    }
+  }
+}
+
 if (failures.length) {
   console.error('\ndesign-sync entry guard FAILED\n');
   for (const f of failures) console.error(`  ✗ ${f}\n`);
@@ -231,6 +349,8 @@ if (failures.length) {
 }
 
 console.log(
-  'design-sync: barrel bundles, every componentSrcMap path resolves, and ' +
-    `${claimsChecked} published contrast claim(s) in conventions.md recompute.`
+  'design-sync: barrel bundles, every componentSrcMap path resolves, ' +
+    `${claimsChecked} published contrast claim(s) recompute, and all ` +
+    `${classified} files in .design-sync/ have a declared owner with nothing ` +
+    'design-owned being pushed back.'
 );


### PR DESCRIPTION
Refs #258, #262.

## What changed and why

`conventions.md` moved in **both directions** with nothing arbitrating it. Three documents disagreed about who owns it:

| Source | Says |
|---|---|
| `config.json:58` | `readmeHeader: .design-sync/conventions.md` — pushes the **repo's** copy **up** |
| `PROJECT-CONTEXT.md` | project is "✅ source of truth", repo is a "mirror" — flows **down** |
| `HANDOFF.md:176` | §3 titled *"Replacement for `web/.design-sync/conventions.md`"* — design **authors** it |

Whichever side acted last silently won. That's not hypothetical — it's how `e61092c` (#240) replaced `85eab51` (#224)'s measured dark contrast ratios with the light palette's, in the file that was then guaranteed to reach the design agent's prompt. A re-sync today would have pushed the repo's copy back over whatever the design side has changed since.

`NOTES.md`'s "Sync inputs this repo owns" table didn't even list `conventions.md` — the one file the repo was actually pushing.

### The fix

`ownership.json` declares the direction per path, and `check:design-sync` enforces it:

| Owner | Meaning |
|---|---|
| `repo` | written here, pushed to the design project |
| `design` | authored in the project; **read-only mirror** here so a code session can read it |
| `local` | working docs — neither pushed nor mirrored |

Three checks:
- every file in `.design-sync/` is classified **exactly once**
- no manifest entry matches nothing (stale entries fail)
- **nothing `config.json` uploads may be design-owned** ← this is the fix; the rest keeps the manifest honest

### `readmeHeader` now points at `CLAUDE.md`

The repo needs *something* as the design system's README, and `conventions.md` was the wrong choice because the repo doesn't own it. `CLAUDE.md` — the domain briefing — is the right one, because the domain genuinely lives in the code (its own header says so).

`CODE-TO-DESIGN.md` had already asked for this: *"If it does not, point `readmeHeader` at it."* It also means the synced design system stops shipping a second, stale copy of the style guide — the "Known tension" `PROJECT-CONTEXT.md` records. And it resolves `CLAUDE.md` having had **no wiring at all**, which was the original item.

## How to test manually

```
npm run check:design-sync
# → ...1 published contrast claim(s) recompute, and all 42 files in
#   .design-sync/ have a declared owner with nothing design-owned being pushed back.
```

Verified by mutation:

| Mutation | Result |
|---|---|
| Repoint `readmeHeader` at `conventions.md` (the original bug) | `...which ownership.json says the design project owns. Pushing it would overwrite the source of truth — this is the loop that lost #224's contrast ratios.` |
| Unclassified file appears | `does not classify .design-sync/SCRATCH.md — declare it repo, design or local` |
| Manifest lists something gone | `lists "GONE.md", which matches no file in .design-sync/` |

## Not done on purpose

**Design-owned files are untouched.** `PROJECT-CONTEXT.md` still describes the old arrangement and `conventions.md` still carries claims that follow from it — correcting those is a change to make **on the design side**, not in a mirror this manifest now declares read-only. Editing them here would be the same clobber this PR exists to prevent.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — the guard is verified by mutation, matching how `check-design-sync-entry.mjs` was already built; no app source under `web/src/` is touched, so the 740-test suite is a regression check here
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no runtime code changed

---
_Generated by [Claude Code](https://claude.ai/code/session_019CvTYRBHUm8gmBTFk4gwmT)_