### PR TITLE
fix(coach): correct the AT band in the handover, and guard every published zone band

### DIFF
--- a/.github/workflows/zone-bands.yml
+++ b/.github/workflows/zone-bands.yml
@@ -1,0 +1,44 @@
+name: Zone bands
+
+# Rowing zone bands are derived from the live rowing_cp anchor by
+# derivePaceZones() — they are not constants. Any watt figure written into prose
+# is a snapshot, and the same wrong AT ceiling (205 W, the CP anchor restated as
+# the band's top) reached three separate documents before anything caught it:
+# CLAUDE.md (#266), web/.design-sync/CLAUDE.md (#268) and
+# coach/CODE_TO_COACH_HANDOVER.md (#275).
+#
+# A zone check already existed by #268 and still missed the third copy, because
+# it lived in the design-sync guard — which runs inside ci-web.yml's lint job,
+# gated on 'web/**'. A change to coach/ or the repo-root CLAUDE.md never
+# triggered it. This workflow exists so the guard fires on the documents it is
+# meant to protect, not only on the ones that happen to sit under web/.
+#
+# The script imports trainingConfig.js directly and has no third-party
+# dependencies, so this needs node and a checkout — no npm ci.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - 'web/src/constants/trainingConfig.js'
+      - 'web/src/utils/pace.js'
+      - 'web/scripts/check-zone-bands.mjs'
+      - '.github/workflows/zone-bands.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zone-bands-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Zone bands match derivePaceZones
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - run: node web/scripts/check-zone-bands.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,7 @@ Every PR is gated by three GitHub Actions jobs that must pass before merge:
 | `Lint & Format` | ESLint errors + Prettier formatting + `npm audit --audit-level=high` |
 | `Test & Coverage` | All Vitest tests pass; coverage meets the ratcheting thresholds in `web/vite.config.js` (`test.coverage.thresholds` — the **only** source of truth for the numbers), raised as extractions add tests |
 | `Build` | `npm run build` exits 0 (runs only after Test passes) |
+| `Zone bands` | Every rowing zone band published in any tracked `.md` recomputes against `derivePaceZones()` (`npm run check:zones`). **Path-filtered on `**/*.md`, not `web/**`** — the earlier version lived in the design-sync guard and so never fired on `coach/` or the repo-root `CLAUDE.md`, which is how the same wrong AT ceiling reached three documents (#266, #268, #275). |
 
 Coverage thresholds live in `web/vite.config.js` (`test.coverage.thresholds`) and
 **ratchet upward**. Scope is explicit — `coverage.all` + `include: ['src/**']`

--- a/coach/CODE_TO_COACH_HANDOVER.md
+++ b/coach/CODE_TO_COACH_HANDOVER.md
@@ -15,10 +15,15 @@ not taken from the handover text alone. Changes:
 - **Model** reverted from polarised → **pure base + strength** (bike is complementary
   Z1/Z2 only; 2 Upper + 2 Lower per week; Lowers ≥3 days apart).
 - **CP anchor** ~190W → **~205W provisional (rowing)** + zones UT2 113–144 /
-  UT1 144–164 / AT 164–205 W. Revalidate via rested 1-min + 4-min.
+  UT1 144–164 / AT **164–185** W. Revalidate via rested 1-min + 4-min.
+  *(Corrected 2026-08-24: this originally read `AT 164–205 W`, restating the CP
+  anchor as the band's ceiling. `derivePaceZones(205)` yields 164–185. The same
+  error reached repo `CLAUDE.md` and `.design-sync/CLAUDE.md`, fixed in #266 and
+  #268; the design-sync copies are now checked against the code by
+  `npm run check:design-sync`.)*
 - **Supabase Schema** section rewritten to the real **13 tables / 22 migrations**
   (the whole strength subsystem), with corrected `sessions` columns (`date` is text
-  `MM/DD/YY`, targets live in `label` + `coach_note`), corrected `vitals`, the
+  `M/D/YY` unpadded, targets live in `label` + `coach_note`), corrected `vitals`, the
   strength-logging convention, and the data-layer gotchas.
 - **Vitals source**: Google Health **CSV → API** auto-sync.
 - **Coaching data model** recorded: Coach writes to the DB via the Supabase MCP
@@ -56,8 +61,14 @@ Claude Code auto-loads it every session; keep it correct and neither side drifts
 - **Bridge discipline persists**: Scott authorises consequential/destructive/schema
   changes; review structure before material writes; **read back every write**. Honour
   the data-layer gotchas (explicit `user_id` UUID — `auth.uid()` doesn't resolve through
-  the connector; `sessions.date` is text, order via `to_date(...,'MM/DD/YY')`;
+  the connector; `sessions.date` is text **`M/D/YY`, unpadded** — write it, never order
+  by it; order by the generated `date_iso` date column (`nullsFirst: false` on desc);
   `UNIQUE(date,label)`; vitals upsert on `(user_id,date)`).
+  *(Corrected 2026-08-24: this originally said to order via `to_date(...,'MM/DD/YY')`.
+  `CLAUDE.md` now forbids that outright — `to_date` is STABLE, so it cannot be indexed
+  or used in a generated column — and `date_iso` exists precisely to replace it. The
+  padded `MM/DD/YY` was wrong too; the write format is unpadded `M/D/YY`. Take
+  `CLAUDE.md`'s* Supabase Schema *section as authoritative over anything here.)*
 
 ## Deferred / open items (not done this session)
 

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint src/ scripts/",
     "format": "prettier --write src/ scripts/",
     "format:check": "prettier --check src/ scripts/",
+    "check:zones": "node scripts/check-zone-bands.mjs",
     "check:design-sync": "node scripts/check-design-sync-entry.mjs",
     "prepare": "husky"
   },

--- a/web/scripts/check-design-sync-entry.mjs
+++ b/web/scripts/check-design-sync-entry.mjs
@@ -165,59 +165,7 @@ if (!existsSync(conventionsPath)) {
   }
 }
 
-// 4. Any zone band published in the design-sync docs must match derivePaceZones.
-//
-//    The same wrong AT ceiling reached two separate files: the repo CLAUDE.md and
-//    .design-sync/CLAUDE.md both gave AT as 164-205 W. 205 is the CP anchor, which
-//    sits one line above in both — the band's ceiling is 185. #266 fixed one copy
-//    and missed the other, which is the argument for checking rather than reading.
-//
-//    Bands are derived from CP, so anything written down is a snapshot. Verify the
-//    snapshot against the function at the CP the doc itself quotes.
-for (const rel of ['.design-sync/CLAUDE.md', '.design-sync/conventions.md']) {
-  const abs = join(webRoot, rel);
-  if (!existsSync(abs)) continue;
-  const md = readFileSync(abs, 'utf8');
-
-  //  "UT2 / UT1 / AT — ... 113-144 / 144-164 / 164-185 W"
-  const line = md.match(
-    /UT2[^\n]*?AT[^\n]*?([0-9]+)[–-]([0-9]+)\s*\/\s*([0-9]+)[–-]([0-9]+)\s*\/\s*([0-9]+)[–-]([0-9]+)\s*W/
-  );
-  if (!line) continue;
-
-  const cpMatch = md.match(/~([0-9]{2,4})\s*W/);
-  const cp = cpMatch ? Number(cpMatch[1]) : null;
-  if (!cp) {
-    failures.push(
-      `${rel} publishes UT2/UT1/AT watt bands but names no CP to derive them from`
-    );
-    continue;
-  }
-
-  try {
-    const { derivePaceZones } = await import(
-      pathToFileURL(join(webRoot, 'src/constants/trainingConfig.js')).href
-    );
-    const zones = derivePaceZones(cp);
-    const claimed = line.slice(1).map(Number);
-    ['UT2', 'UT1', 'AT'].forEach((name, i) => {
-      const z = zones.find((x) => x.zone === name);
-      const [lo, hi] = [claimed[i * 2], claimed[i * 2 + 1]];
-      if (z.wattsLow !== lo || z.wattsHigh !== hi) {
-        failures.push(
-          `${rel} gives ${name} as ${lo}-${hi} W; derivePaceZones(${cp}) yields ` +
-            `${z.wattsLow}-${z.wattsHigh}`
-        );
-      }
-    });
-  } catch (e) {
-    failures.push(
-      `src/constants/trainingConfig.js could not be imported — ${e?.message ?? e}`
-    );
-  }
-}
-
-// 5. Every file in .design-sync/ has a declared owner, and nothing design-owned
+// 4. Every file in .design-sync/ has a declared owner, and nothing design-owned
 //    is pushed back at the design project.
 //
 //    conventions.md used to move both ways with nothing arbitrating it: config.json

--- a/web/scripts/check-zone-bands.mjs
+++ b/web/scripts/check-zone-bands.mjs
@@ -1,0 +1,126 @@
+// Guards every published rowing zone band against the code that derives it.
+//
+// The bands come from derivePaceZones(cp) — they are not constants, they move
+// whenever the rowing_cp anchor is revalidated. Anything written into prose is a
+// snapshot, and snapshots do not recompute themselves.
+//
+// This is not hypothetical. The same wrong AT ceiling of 205 W — the CP anchor
+// restated as the band's top, where CP sits a line above in every one of them —
+// reached three separate documents:
+//
+//   CLAUDE.md                        fixed in #266
+//   web/.design-sync/CLAUDE.md       fixed in #268
+//   coach/CODE_TO_COACH_HANDOVER.md  fixed in #275
+//
+// #266 fixed one copy and missed the other two because it grepped one file.
+// #268 caught the second only because check:design-sync had grown a zone check
+// by then — and missed the third because that check scanned .design-sync/ only.
+// Scanning every tracked markdown file is what closes the class.
+//
+//   npm run check:zones
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(webRoot, '..');
+
+const configPath = join(webRoot, 'src/constants/trainingConfig.js');
+if (!existsSync(configPath)) {
+  console.error('check:zones: src/constants/trainingConfig.js is missing.');
+  process.exit(1);
+}
+const { derivePaceZones } = await import(pathToFileURL(configPath).href);
+
+let files;
+try {
+  files = execFileSync('git', ['ls-files', '*.md'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .filter(Boolean);
+} catch (e) {
+  console.error(`check:zones: could not list tracked markdown — ${e.message}`);
+  process.exit(1);
+}
+
+// Markdown emphasis lands inside the numbers (`AT **164–185** W`) and the bands
+// wrap across lines in at least one document, so normalise before matching:
+// drop emphasis and backticks, collapse all whitespace to single spaces.
+const normalise = (s) => s.replace(/[*`]/g, '').replace(/\s+/g, ' ');
+
+// Three real phrasings have to match, so anchor on UT2 and read the next three
+// ranges in order rather than assuming where the labels sit:
+//   "UT2 113-144 / UT1 144-164 / AT 164-185 W"   labels interleaved
+//   "UT2 / UT1 / AT - ... 113-144 / 144-164 / 164-185 W"   labels grouped
+//  The separator class must be [\\s\\S], not [^0-9]: the labels themselves contain
+//  digits ("UT1", "UT2"), so a no-digits class cannot step over them and the
+//  interleaved phrasing never matches. That bug made this guard find 1 band of 3.
+const BAND = new RegExp(
+  'UT2\\b[\\s\\S]{0,200}?' +
+    '(\\d{1,4})[–-](\\d{1,4})[\\s\\S]{0,40}?' +
+    '(\\d{1,4})[–-](\\d{1,4})[\\s\\S]{0,40}?' +
+    '(\\d{1,4})[–-](\\d{1,4})\\s*W',
+  'g'
+);
+
+const failures = [];
+let checked = 0;
+
+for (const rel of files) {
+  const text = normalise(readFileSync(join(repoRoot, rel), 'utf8'));
+
+  for (const m of text.matchAll(BAND)) {
+    //  A band statement names all three zones. Prose that merely mentions
+    //  "UT1/UT2" (there is plenty) must not be read as a published band.
+    if (!/\bAT\b/.test(m[0]) || !/\bUT1\b/.test(m[0])) continue;
+
+    //  Derive against the CP the document itself quotes, so a doc written for a
+    //  different anchor is not reported as wrong when it is merely historical.
+    const cpMatch = text.slice(0, m.index).match(/~(\d{2,4})\s?W(?![^ ]*\/)/g);
+    const cp = cpMatch
+      ? Number(cpMatch[cpMatch.length - 1].match(/\d+/)[0])
+      : null;
+    if (!cp) {
+      failures.push(
+        `${rel} publishes UT2/UT1/AT bands but names no CP to derive them from`
+      );
+      continue;
+    }
+
+    checked += 1;
+    const zones = derivePaceZones(cp);
+    const claimed = m.slice(1, 7).map(Number);
+
+    ['UT2', 'UT1', 'AT'].forEach((name, i) => {
+      const z = zones.find((x) => x.zone === name);
+      const [lo, hi] = [claimed[i * 2], claimed[i * 2 + 1]];
+      if (z.wattsLow !== lo || z.wattsHigh !== hi) {
+        failures.push(
+          `${rel} gives ${name} as ${lo}-${hi} W; derivePaceZones(${cp}) yields ` +
+            `${z.wattsLow}-${z.wattsHigh}`
+        );
+      }
+    });
+  }
+}
+
+if (failures.length) {
+  console.error('\nzone band guard FAILED\n');
+  for (const f of failures) console.error(`  ✗ ${f}\n`);
+  console.error(
+    'A rowing zone band written into prose has drifted from the code.\n\n' +
+      'The bands are derived from the live rowing_cp anchor by derivePaceZones();\n' +
+      'they are not constants. Either correct the prose to what the function\n' +
+      'returns at the CP that document quotes, or stop publishing watt figures\n' +
+      'there and point at derivePaceZones(cp) instead.\n'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `check:zones: ${checked} published zone band(s) across ${files.length} tracked ` +
+    'markdown files match derivePaceZones.'
+);


### PR DESCRIPTION
Refs #258, #266, #268.

Two commits: fix the third copy of a wrong zone band, then close the class so there isn't a fourth.

---

## 1. The handover corrections

`coach/CODE_TO_COACH_HANDOVER.md` is dated (2026-07-01), but its header says *"Paste into Coach chat when you want the two interfaces re-synced."* So stale facts in it reach a **live coaching context** rather than sitting harmlessly in a log.

Three fixes, each **annotated inline** rather than silently rewritten, since the document records what was done at the time:

| | Was | Now |
|---|---|---|
| AT band | `164–205 W` | `164–185 W` — `derivePaceZones(205)` yields this; 205 is the CP anchor, restated as the band's ceiling |
| Ordering | `to_date(...,'MM/DD/YY')` | order by generated `date_iso` — `CLAUDE.md:216` forbids `to_date` outright (it's STABLE, so it can't be indexed or used in a generated column) |
| Date format | `MM/DD/YY` | `M/D/YY` unpadded, in both places |

The ordering one is the sharper hazard: it sat inside the *"honour the data-layer gotchas"* list a DB-writing agent is told to follow, so it affected every read ordering rather than one number.

Table counts (13/22, now 14/23) and the SessionStart infra-gap section (closed by #231, #241) stay as historical record.

---

## 2. The guard, and why the existing one didn't fire

The AT band was wrong in **three** documents and took **three PRs** to find them all:

| File | Fixed by |
|---|---|
| `CLAUDE.md` | #266 |
| `web/.design-sync/CLAUDE.md` | #268 |
| `coach/CODE_TO_COACH_HANDOVER.md` | this PR |

A zone check already existed by #268. It didn't catch the third copy because it lived in `check-design-sync-entry.mjs`, which runs inside `ci-web.yml`'s lint job **gated on `web/**`** — so a change to `coach/` or the repo-root `CLAUDE.md` never triggered it. The guard was real; it just never ran on the files that needed it. **Widening the scan without widening the trigger would have repeated that**, so both halves move:

- **`web/scripts/check-zone-bands.mjs`** — scans every tracked `.md` via `git ls-files` and recomputes each published UT2/UT1/AT band against `derivePaceZones`, using the CP *each document itself quotes*, so a historical doc isn't judged against today's anchor. Removed from the design-sync guard, which keeps barrel + contrast + ownership.
- **`.github/workflows/zone-bands.yml`** — runs it on `pull_request` for `**/*.md`, `trainingConfig.js`, `pace.js` and the script. No `npm ci`; the script has no third-party imports.

### Two bugs the first cut had, both found by testing rather than reading

1. **It reported 1 band across 284 files when there are 3.** The separator class was `[^0-9]` — but the labels contain digits (`UT1`, `UT2`), so it couldn't step over them and only the grouped phrasing ever matched. `[\s\S]` fixes it. Had I trusted the passing run, the guard would have shipped blind to two of the three files it exists for.
2. Bands **wrap across lines** in `coach/` and carry markdown emphasis *inside* the numbers (`AT **164–185** W`), so the text is normalised before matching.

## How to test manually

```
npm run check:zones
# check:zones: 3 published zone band(s) across 284 tracked markdown files match derivePaceZones.
```

Verified by mutating each file in turn — every one is reported independently:

| Mutation | Result |
|---|---|
| `164–185` → `164–205` in `CLAUDE.md` | 1 failure |
| same in `web/.design-sync/CLAUDE.md` | 1 failure |
| same in `coach/CODE_TO_COACH_HANDOVER.md` | 1 failure |
| `UT2 113–144` → `100–144` | `gives UT2 as 100-144 W; derivePaceZones(205) yields 113-144` |
| clean tree | passes |

This PR triggers the new workflow itself, so it self-tests.

## Checklist

- [x] CI is green — note the `web/**` gates path-filter out for `coach/`-only diffs; the new `Zone bands` job is filtered on `**/*.md` precisely so it *doesn't*
- [x] Tests cover the change, or I've noted why they don't — the guard is verified by mutation, matching how `check-design-sync-entry.mjs` was already built; locally 753 tests, lint, format, `check:design-sync` and `check:zones` all pass
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no runtime code changed