### PR TITLE
fix: captureError mistitles non-Error exceptions, and swallowed Supabase errors

### DIFF
--- a/web/src/hooks/__tests__/useCoachWiring.test.js
+++ b/web/src/hooks/__tests__/useCoachWiring.test.js
@@ -8,7 +8,18 @@ import React from 'react';
 // function, and vi.mock is file-scoped and hoisted, so a test that needs the
 // real hook machinery cannot live alongside it.
 
-const insertMock = vi.fn(() => Promise.resolve({ error: null }));
+const insertMock = vi.fn((row) =>
+  Promise.resolve({ error: insertErrorFor(row) })
+);
+const deleteEqMock = vi.fn(() => Promise.resolve({ error: deleteError }));
+const getUserMock = vi.fn(() => getUserResult());
+
+// Same mutable-module-state idiom as sessionRows/vitalsState below: the mock
+// factory is hoisted, so per-test overrides have to reach it through bindings.
+// insertErrorFor takes the row so a test can fail one role's insert only.
+let insertErrorFor = () => null;
+let deleteError = null;
+let getUserResult = () => Promise.resolve({ data: { user: { id: 'u1' } } });
 
 vi.mock('../../supabaseClient.js', () => ({
   supabase: {
@@ -19,15 +30,19 @@ vi.mock('../../supabaseClient.js', () => ({
           limit: () => Promise.resolve({ data: [], error: null }),
         }),
       }),
-      delete: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      delete: () => ({ eq: (...args) => deleteEqMock(...args) }),
     }),
     auth: {
       getSession: () =>
         Promise.resolve({ data: { session: { access_token: 'test-token' } } }),
-      getUser: () => Promise.resolve({ data: { user: { id: 'u1' } } }),
+      getUser: (...args) => getUserMock(...args),
     },
   },
 }));
+
+vi.mock('../../utils/sentry.js', () => ({ captureError: vi.fn() }));
+
+import { captureError } from '../../utils/sentry.js';
 
 let sessionRows = [];
 let vitalsState = {
@@ -101,7 +116,13 @@ beforeEach(() => {
   sessionRows = [];
   tssRows = [];
   vitalsState = { latest: null, readinessScore: 0, readinessLabel: 'FATIGUED' };
+  insertErrorFor = () => null;
+  deleteError = null;
+  getUserResult = () => Promise.resolve({ data: { user: { id: 'u1' } } });
   insertMock.mockClear();
+  deleteEqMock.mockClear();
+  getUserMock.mockClear();
+  captureError.mockClear();
   localStorage.clear();
 });
 
@@ -295,5 +316,195 @@ describe('useCoach sends the training context', () => {
     expect(body.context).not.toContain('Recent sessions');
     expect(body.context).not.toContain('undefined');
     expect(body.context).not.toContain('NaN');
+  });
+});
+
+// postgrest-js resolves with `{ error }` rather than rejecting, so before #276
+// every one of these failures was invisible — not merely uncaught.
+// The initial coach_messages query resolves a tick after mount and replaces
+// whatever setQueryData put there, so an optimistic user message written before
+// it settles is silently dropped. Let it land first.
+async function settleInitialQuery() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe('useCoach reports its own failures', () => {
+  function renderCoach() {
+    return renderHook(() => useCoach(), { wrapper: makeWrapper() });
+  }
+
+  it('reports a failed user-message insert without breaking the turn', async () => {
+    const failure = { code: '42501', message: 'permission denied' };
+    insertErrorFor = (row) => (row.role === 'user' ? failure : null);
+    const fetchMock = stubFetch();
+
+    const { result } = renderCoach();
+    await settleInitialQuery();
+    await act(async () => {
+      await result.current.sendMessage('how is my load?');
+    });
+
+    expect(captureError).toHaveBeenCalledWith(failure, {
+      source: 'useCoach',
+      op: 'insertUserMessage',
+    });
+    // The turn still ran: the request went out and the reply landed.
+    expect(fetchMock).toHaveBeenCalled();
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('reports a failed assistant-message insert on the message_stop path', async () => {
+    const failure = { code: '42501', message: 'permission denied' };
+    insertErrorFor = (row) => (row.role === 'assistant' ? failure : null);
+    stubFetch();
+
+    const { result } = renderCoach();
+    await act(async () => {
+      await result.current.sendMessage('how is my load?');
+    });
+
+    expect(captureError).toHaveBeenCalledWith(failure, {
+      source: 'useCoach',
+      op: 'insertAssistantMessage',
+      finalised: true,
+    });
+  });
+
+  it('distinguishes the stream-ended-without-stop fallback insert', async () => {
+    const failure = { code: '42501', message: 'permission denied' };
+    insertErrorFor = (row) => (row.role === 'assistant' ? failure : null);
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        body: {
+          getReader() {
+            const frames = [
+              'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"cut short"}}\n',
+            ];
+            let i = 0;
+            return {
+              read() {
+                if (i >= frames.length) return Promise.resolve({ done: true });
+                return Promise.resolve({
+                  done: false,
+                  value: new globalThis.TextEncoder().encode(frames[i++]),
+                });
+              },
+            };
+          },
+        },
+      })
+    );
+
+    const { result } = renderCoach();
+    await act(async () => {
+      await result.current.sendMessage('how is my load?');
+    });
+
+    expect(captureError).toHaveBeenCalledWith(failure, {
+      source: 'useCoach',
+      op: 'insertAssistantMessage',
+      finalised: false,
+    });
+  });
+
+  it('reports a non-ok coach-chat response and still surfaces the UI error', async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('upstream exploded'),
+      })
+    );
+
+    const { result } = renderCoach();
+    await act(async () => {
+      await result.current.sendMessage('how is my load?');
+    });
+
+    const call = captureError.mock.calls.find(
+      ([, ctx]) => ctx?.op === 'sendMessage'
+    );
+    expect(call).toBeDefined();
+    expect(call[0]).toBeInstanceOf(Error);
+    expect(call[1]).toEqual({
+      source: 'useCoach',
+      op: 'sendMessage',
+      model: 'sonnet',
+    });
+    // Regression guard: reporting is additive, the existing UI state stands.
+    await waitFor(() => expect(result.current.error).toContain('Coach error'));
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.streamingContent).toBe('');
+  });
+});
+
+describe('useCoach clearHistory', () => {
+  async function seedTwoMessages(result) {
+    stubFetch();
+    await settleInitialQuery();
+    await act(async () => {
+      await result.current.sendMessage('how is my load?');
+    });
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+  }
+
+  it('clears the list when the delete succeeds', async () => {
+    const { result } = renderHook(() => useCoach(), { wrapper: makeWrapper() });
+    await seedTwoMessages(result);
+
+    await act(async () => {
+      await result.current.clearHistory();
+    });
+
+    expect(deleteEqMock).toHaveBeenCalledWith('user_id', 'u1');
+    await waitFor(() => expect(result.current.messages).toHaveLength(0));
+    expect(captureError).not.toHaveBeenCalled();
+  });
+
+  // Clearing the UI on a failed delete only hides rows the server still has.
+  it('reports a failed delete and leaves the list intact', async () => {
+    const { result } = renderHook(() => useCoach(), { wrapper: makeWrapper() });
+    await seedTwoMessages(result);
+    captureError.mockClear();
+    deleteError = { code: '42501', message: 'permission denied' };
+
+    await act(async () => {
+      await result.current.clearHistory();
+    });
+
+    expect(captureError).toHaveBeenCalledWith(deleteError, {
+      source: 'useCoach',
+      op: 'clearHistory',
+    });
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.error).toBe(
+      'Could not clear history — please try again'
+    );
+  });
+
+  it('catches a rejecting getUser instead of leaking an unhandled rejection', async () => {
+    const { result } = renderHook(() => useCoach(), { wrapper: makeWrapper() });
+    await seedTwoMessages(result);
+    captureError.mockClear();
+    const authFailure = new Error('auth session missing');
+    getUserResult = () => Promise.reject(authFailure);
+
+    await act(async () => {
+      await expect(result.current.clearHistory()).resolves.toBeUndefined();
+    });
+
+    expect(captureError).toHaveBeenCalledWith(authFailure, {
+      source: 'useCoach',
+      op: 'clearHistory',
+    });
+    expect(deleteEqMock).not.toHaveBeenCalled();
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.error).toBe(
+      'Could not clear history — please try again'
+    );
   });
 });

--- a/web/src/hooks/__tests__/useOfflineQueue.test.js
+++ b/web/src/hooks/__tests__/useOfflineQueue.test.js
@@ -14,6 +14,9 @@ vi.mock('../../supabaseClient', () => ({
   },
 }));
 
+vi.mock('../../utils/sentry.js', () => ({ captureError: vi.fn() }));
+
+import { captureError } from '../../utils/sentry.js';
 import {
   enqueueSession,
   useOfflineQueue,
@@ -41,6 +44,7 @@ beforeEach(async () => {
   localStorage.clear();
   insertMock.mockReset();
   getUserMock.mockReset();
+  captureError.mockClear();
   insertMock.mockResolvedValue({ error: null });
   // navigator.onLine defaults to true under jsdom; ensure drain runs.
   Object.defineProperty(navigator, 'onLine', {
@@ -97,9 +101,8 @@ describe('useOfflineQueue drainQueue user_id backfill', () => {
 
   it('retains rows that fail to insert so they can be retried', async () => {
     getUserMock.mockResolvedValue({ data: { user: { id: 'user-123' } } });
-    insertMock.mockResolvedValue({
-      error: { code: '08006', message: 'network' },
-    });
+    const failure = { code: '08006', message: 'network' };
+    insertMock.mockResolvedValue({ error: failure });
     enqueueSession({ date: '2026-06-25', type: 'erg' });
 
     renderHook(() => useOfflineQueue(), {
@@ -109,6 +112,11 @@ describe('useOfflineQueue drainQueue user_id backfill', () => {
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     const remaining = JSON.parse(localStorage.getItem(QUEUE_KEY));
     expect(remaining).toHaveLength(1);
+    await waitFor(() => expect(captureError).toHaveBeenCalledTimes(1));
+    expect(captureError).toHaveBeenCalledWith(failure, {
+      source: 'useOfflineQueue',
+      op: 'drainQueue',
+    });
   });
 });
 
@@ -237,6 +245,9 @@ describe('useOfflineQueue legacy-row migration', () => {
     await waitFor(() => expect(insertMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(result.current.pending).toBe(0));
     expect(localStorage.getItem(QUEUE_KEY)).toBe('[]');
+    // A duplicate-key conflict means the row already landed — reporting it
+    // would turn every successful offline retry into Sentry noise.
+    expect(captureError).not.toHaveBeenCalled();
   });
 
   it('inserts each row at most once when two drains race', async () => {

--- a/web/src/hooks/useCoach.js
+++ b/web/src/hooks/useCoach.js
@@ -11,6 +11,7 @@ import {
 } from '../constants/sessionStatus.js';
 import { toISODate, toLogDate } from '../utils/dateFormat.js';
 import { parseDurationMinutes } from '../utils/duration.js';
+import { captureError } from '../utils/sentry.js';
 
 // One microcycle, with room for the two-a-day Wednesday — a training week runs
 // to more than seven rows. The questions this context serves ("how's my
@@ -170,9 +171,18 @@ export function useCoach() {
     setError(null);
 
     try {
-      await supabase
+      // postgrest-js resolves with `{ error }` instead of rejecting, so an
+      // insert whose result is discarded fails invisibly. Report and carry on:
+      // the message is already in the query cache and the turn still runs.
+      const { error: userInsertErr } = await supabase
         .from('coach_messages')
         .insert({ role: 'user', content: userText, model });
+      if (userInsertErr) {
+        captureError(userInsertErr, {
+          source: 'useCoach',
+          op: 'insertUserMessage',
+        });
+      }
 
       const currentMessages =
         queryClient.getQueryData(['coach_messages']) ?? [];
@@ -246,9 +256,16 @@ export function useCoach() {
                 model,
                 created_at: new Date().toISOString(),
               };
-              await supabase
+              const { error: stopInsertErr } = await supabase
                 .from('coach_messages')
                 .insert({ role: 'assistant', content: finalContent, model });
+              if (stopInsertErr) {
+                captureError(stopInsertErr, {
+                  source: 'useCoach',
+                  op: 'insertAssistantMessage',
+                  finalised: true,
+                });
+              }
               queryClient.setQueryData(['coach_messages'], (old) => [
                 ...(old ?? []),
                 assistantMsg,
@@ -271,9 +288,16 @@ export function useCoach() {
           model,
           created_at: new Date().toISOString(),
         };
-        await supabase
+        const { error: fallbackInsertErr } = await supabase
           .from('coach_messages')
           .insert({ role: 'assistant', content: finalContent, model });
+        if (fallbackInsertErr) {
+          captureError(fallbackInsertErr, {
+            source: 'useCoach',
+            op: 'insertAssistantMessage',
+            finalised: false,
+          });
+        }
         queryClient.setQueryData(['coach_messages'], (old) => [
           ...(old ?? []),
           assistantMsg,
@@ -283,6 +307,7 @@ export function useCoach() {
         setIsStreaming(false);
       }
     } catch (err) {
+      captureError(err, { source: 'useCoach', op: 'sendMessage', model });
       setError(err.message || 'Failed to get a response');
       setIsStreaming(false);
       setStreamingContent('');
@@ -291,12 +316,27 @@ export function useCoach() {
   };
 
   const clearHistory = async () => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) return;
-    await supabase.from('coach_messages').delete().eq('user_id', user.id);
-    queryClient.setQueryData(['coach_messages'], []);
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      const { error: delErr } = await supabase
+        .from('coach_messages')
+        .delete()
+        .eq('user_id', user.id);
+      // A failed delete leaves the rows on the server, so clearing the list
+      // here would only hide them until the next refetch brought them back.
+      if (delErr) {
+        captureError(delErr, { source: 'useCoach', op: 'clearHistory' });
+        setError('Could not clear history — please try again');
+        return;
+      }
+      queryClient.setQueryData(['coach_messages'], []);
+    } catch (err) {
+      captureError(err, { source: 'useCoach', op: 'clearHistory' });
+      setError('Could not clear history — please try again');
+    }
   };
 
   return {

--- a/web/src/hooks/useOfflineQueue.js
+++ b/web/src/hooks/useOfflineQueue.js
@@ -5,6 +5,7 @@ import { Network } from '@capacitor/network';
 import { supabase } from '../supabaseClient';
 import { toLogDate } from '../utils/dateFormat.js';
 import { invalidateSessionQueries } from '../utils/invalidateSessionQueries.js';
+import { captureError } from '../utils/sentry.js';
 
 const QUEUE_KEY = 'erg_pending_sessions';
 
@@ -73,7 +74,10 @@ async function drainQueue() {
       const { _queuedAt, ...rest } = session;
       const row = { ...rest, user_id: rest.user_id ?? user?.id };
       const { error } = await supabase.from('sessions').insert(row);
-      if (error && !isDuplicate(error)) failed.push(session);
+      if (error && !isDuplicate(error)) {
+        captureError(error, { source: 'useOfflineQueue', op: 'drainQueue' });
+        failed.push(session);
+      }
     }
     writeQueue(failed);
     return q.length - failed.length;

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -43,7 +43,15 @@ const queryClient = new QueryClient({
   queryCache: new QueryCache({ onError: handleQueryError }),
   mutationCache: new MutationCache({ onError: handleMutationError }),
   defaultOptions: {
-    queries: { staleTime: 60_000, retry: 2, refetchOnWindowFocus: false },
+    queries: {
+      staleTime: 60_000,
+      // Reads DO report to Sentry through the QueryCache sink — the
+      // read-vs-write asymmetry once observed was this retry's backoff delaying
+      // onError, not a swallowed error. Investigated and closed in #276; the
+      // mutation path simply has no retry override, so it lands near-instantly.
+      retry: 2,
+      refetchOnWindowFocus: false,
+    },
   },
 });
 

--- a/web/src/utils/__tests__/sentry.test.js
+++ b/web/src/utils/__tests__/sentry.test.js
@@ -113,4 +113,135 @@ describe('captureError', () => {
     captureError(null);
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
+
+  it('passes a real Error through untouched, with no fingerprint', () => {
+    const error = new Error('boom');
+    captureError(error, { source: 'useSessionLog' });
+
+    const [captured, options] = Sentry.captureException.mock.calls[0];
+    expect(captured).toBe(error);
+    expect(options).toEqual({ extra: { source: 'useSessionLog' } });
+    expect(options).not.toHaveProperty('fingerprint');
+  });
+
+  // The bug this replaces: postgrest-js rejects with a plain object, and Sentry
+  // titled every one of them "[object Object]" — one merged, unreadable issue.
+  it('wraps a postgrest error object so the issue is titled by its message', () => {
+    captureError(
+      {
+        code: '42501',
+        details: 'row violates policy',
+        hint: 'check RLS',
+        message: 'permission denied for table sessions',
+      },
+      { source: 'useSessions' }
+    );
+
+    const [captured, options] = Sentry.captureException.mock.calls[0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toBe('permission denied for table sessions');
+    expect(captured.message).not.toBe('[object Object]');
+    expect(options.extra.source).toBe('useSessions');
+    expect(options.extra.originalError).toMatchObject({
+      code: '42501',
+      details: 'row violates policy',
+      hint: 'check RLS',
+    });
+  });
+
+  it('namespaces the original fields so they cannot collide with context keys', () => {
+    captureError(
+      { code: '42501', message: 'denied' },
+      { code: 'caller-supplied' }
+    );
+
+    const { extra } = Sentry.captureException.mock.calls[0][1];
+    expect(extra.code).toBe('caller-supplied');
+    expect(extra.originalError.code).toBe('42501');
+  });
+
+  it('does not deep-copy nested payloads out of the original error', () => {
+    captureError({ message: 'denied', row: { user_id: 'u1', srpe: 9 } });
+
+    const { extra } = Sentry.captureException.mock.calls[0][1];
+    expect(extra.originalError).not.toHaveProperty('row');
+  });
+
+  // Default grouping is stacktrace-led, so two different postgrest codes from
+  // the same call site would otherwise merge into a single issue.
+  it('fingerprints a wrapped error by its postgrest code', () => {
+    captureError({ code: '42501', message: 'denied' });
+
+    expect(Sentry.captureException.mock.calls[0][1].fingerprint).toEqual([
+      '{{ default }}',
+      '42501',
+    ]);
+  });
+
+  it('falls back to the message when the wrapped error has no code', () => {
+    captureError({ message: 'network request failed' });
+
+    expect(Sentry.captureException.mock.calls[0][1].fingerprint).toEqual([
+      '{{ default }}',
+      'network request failed',
+    ]);
+  });
+
+  // postgrest-js emits code: '' (never absent) for client-side/network
+  // failures. ?? would not fall through on an empty string; the discriminator
+  // must, or every network failure fingerprints as ['{{ default }}', ''].
+  it('falls back to the message when the postgrest code is an empty string', () => {
+    captureError({ code: '', message: 'network request failed' });
+
+    expect(Sentry.captureException.mock.calls[0][1].fingerprint).toEqual([
+      '{{ default }}',
+      'network request failed',
+    ]);
+  });
+
+  it('gives a message-less object something better than "[object Object]"', () => {
+    captureError({});
+
+    const captured = Sentry.captureException.mock.calls[0][0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).not.toBe('[object Object]');
+    expect(captured.message.length).toBeGreaterThan(0);
+  });
+
+  it('survives a circular error object', () => {
+    const circular = { code: 'X1' };
+    circular.self = circular;
+
+    captureError(circular);
+
+    const captured = Sentry.captureException.mock.calls[0][0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).not.toBe('[object Object]');
+    expect(captured.message).toContain('code');
+  });
+
+  it('wraps a thrown string into an Error carrying that string', () => {
+    captureError('something went wrong');
+
+    const [captured, options] = Sentry.captureException.mock.calls[0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toBe('something went wrong');
+    expect(options.extra.originalError).toEqual({
+      value: 'something went wrong',
+    });
+  });
+
+  it('carries the original name onto the wrapped error', () => {
+    captureError({ name: 'PostgrestError', message: 'denied' });
+
+    expect(Sentry.captureException.mock.calls[0][0].name).toBe(
+      'PostgrestError'
+    );
+  });
+
+  it('leaves the default Error name alone when the original has none', () => {
+    captureError({ message: 'denied' });
+
+    expect(Sentry.captureException.mock.calls[0][0].name).toBe('Error');
+  });
 });

--- a/web/src/utils/sentry.js
+++ b/web/src/utils/sentry.js
@@ -48,10 +48,67 @@ export function initSentry() {
   return true;
 }
 
+// postgrest-js rejects with a plain `{ code, details, hint, message }` object,
+// not an Error. Sentry titles a non-Error capture by stringifying it, so every
+// Supabase failure in the app arrived as one issue called "[object Object]".
+// Wrapping restores a real message and stack without changing anything for the
+// call sites that already pass an Error.
+function toError(value) {
+  if (value instanceof Error) return value;
+
+  let msg;
+  if (typeof value?.message === 'string' && value.message) {
+    msg = value.message;
+  } else if (value !== null && typeof value === 'object') {
+    try {
+      msg = JSON.stringify(value);
+    } catch {
+      // Circular reference — the keys still say more than "[object Object]".
+      msg = `Non-serialisable error object (${Object.keys(value).join(', ')})`;
+    }
+    if (!msg || msg === '{}') msg = 'Empty error object';
+  } else {
+    msg = String(value);
+  }
+
+  const wrapped = new Error(msg);
+  if (typeof value?.name === 'string' && value.name) wrapped.name = value.name;
+  return wrapped;
+}
+
+// The fields a postgrest error actually carries. Copied shallowly and only when
+// scalar: sendDefaultPii is false above, and a deep copy of an arbitrary
+// rejection would drag row payloads into Sentry.
+function originalFields(value) {
+  if (value === null || typeof value !== 'object')
+    return { value: String(value) };
+  const out = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (v === null || ['string', 'number', 'boolean'].includes(typeof v)) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
 // Single call site for everything that wants to report a handled error. Hooks
 // and caches pass their own identifying context so an issue in Sentry says
 // which query or mutation produced it, not just that "something threw".
 export function captureError(error, context) {
   if (!error) return;
-  Sentry.captureException(error, context ? { extra: context } : undefined);
+
+  if (error instanceof Error) {
+    Sentry.captureException(error, context ? { extra: context } : undefined);
+    return;
+  }
+
+  const wrapped = toError(error);
+  // Every wrapped error is thrown from the same few call sites, so Sentry's
+  // stacktrace-led default grouping merges unrelated DB failures into one
+  // issue. Appending the postgrest code (or the message) splits them again.
+  const discriminator = error?.code || wrapped.message;
+  Sentry.captureException(wrapped, {
+    extra: { ...context, originalError: originalFields(error) },
+    fingerprint: ['{{ default }}', String(discriminator)],
+  });
 }


### PR DESCRIPTION
Closes #276

## What changed and why

Two related Sentry reporting gaps found in a post-merge verification pass on #271.

**1. `captureError` mistitled non-`Error` exceptions.** `web/src/utils/sentry.js`'s `captureError()` passed non-`Error` values (postgrest-js's plain `{code, details, hint, message}` shape) straight to `Sentry.captureException`, so every Supabase failure that reached it was titled the generic "Object captured as exception with keys: ...". A `toError()` helper now wraps non-`Error` inputs in a real `Error` using the postgrest message when present, preserves `code`/`details`/`hint` under `extra.originalError`, and sets a Sentry `fingerprint` on the wrapped path only so distinct postgrest errors from the same call site don't over-group under Sentry's stacktrace-led default grouping.

**2. Root cause of the read-vs-write reporting asymmetry — identified, and it's not what the original hypothesis guessed.** The 9 standard `useQuery` read hooks (`useSessions`, `useVitals`, `useAnchors`, `useTSSHistory`, `useErgSessions`, `useBenchmarkSessions`, `useStrengthPRs`, `useVitalsSync`, plus the `coach_messages` query in `useCoach`) all `throw` their Supabase error correctly and are reported by the `QueryCache`/`MutationCache` sink wired in `main.jsx`. The asymmetry actually observed is **retry-backoff timing**: queries retry twice with backoff (≈3s) before `onError` fires, while mutations have no retry override and report near-instantly — a short manual observation window ends before a blocked read finishes retrying. That's recorded in a comment next to `main.jsx`'s `retry: 2` so it isn't re-investigated.

Two **real** swallow bugs were found instead, in code that talks to `supabase-js` directly rather than through react-query:
- `useOfflineQueue.js`'s `drainQueue` silently retried genuine insert failures without reporting them (duplicate-key `23505` conflicts correctly stay silent — that's expected "already delivered" behaviour, verified by a negative-assertion test).
- `useCoach.js`'s three `coach_messages` inserts discarded their `{data, error}` result entirely — postgrest-js resolves rather than rejects without `.throwOnError()`, which this codebase never calls, so these failures were never observed, not merely caught-and-swallowed. `clearHistory`'s delete had the same gap, plus no try/catch at all around a rejecting `getUser()`.

Both now report through `captureError`, matching the `useSessionLog.js` precedent (`{source, op}` context shape). Failed coach-message inserts stay report-only (no throw, no send-UX change — a follow-up issue can decide whether to surface this in the UI). `clearHistory` reports a delete failure, now surfaces it to the user via the existing `error` state (previously a failed clear was a silent no-op), and no longer clears the UI's message list when the server-side delete actually failed.

## How to test manually

Covered by the extended Vitest suite (see below) — no manual steps needed.

## Checklist

- [x] CI is green (lint, test, build) — verified locally: `npm test` (772/772 passing), `npm run lint` (clean), `npm run format:check` (clean), `npm run build` (clean), `npx vitest run --coverage` (per-file gates on `sentry.js` and `useCoach.js`, plus the global floor, all clear)
- [x] Tests cover the change — new/extended cases in `sentry.test.js`, `useOfflineQueue.test.js`, `useCoachWiring.test.js`
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser
- [x] Visual change: none
- [x] Stays inside the property boundary — no colour/spacing/type values touched; this is error-handling logic only

---

_Ran through the `/orchestrate` pipeline (research → spec → build → test verification → review + validate), with human approval gates on the spec and pre-ship review. Both judges (Code Reviewer, Reality Checker) reviewed the diff; two should-fix findings from the Reality Checker were applied before this push: a `??`/`||` fingerprint bug that would have silently defeated the over-grouping fix on every network-level failure (postgrest emits `code: ''`, not absent), and a silent UX dead-end where a failed `clearHistory` gave the user no feedback at all._


---
_Generated by [Claude Code](https://claude.ai/code/session_01U72PeXfLHwoLhY543pFyxJ)_