### PR TITLE
feat(mobile): animated SplitIQ splash for the cold-start window

### DIFF
--- a/web/.design-sync/base.css
+++ b/web/.design-sync/base.css
@@ -20,6 +20,7 @@
   --color-accentAlt2: #f472b6;
   --color-positiveAlt: #2dd4bf;
   --color-surfaceAlt: #1e1e30;
+  --color-surfaceDeep: #12121f;
   --color-neutral: #3a3a4a;
   --color-textSubtle: #aaaacc;
   --color-textFaint: #6c6c88;

--- a/web/e2e/visual.spec.js
+++ b/web/e2e/visual.spec.js
@@ -53,6 +53,11 @@ async function openAuthed(page, context) {
   await installAppFixtures(context, { now: FIXED_TIME });
   await page.clock.setFixedTime(FIXED_TIME);
   await page.goto('/');
+  // The mobile splash overlays the tab tree, and toBeVisible() ignores
+  // occlusion, so every mobile baseline would capture the splash instead.
+  // The timeout must beat the default 5000ms — that is exactly the splash
+  // ceiling, so a default wait races it.
+  await expect(page.locator('.siq-splash')).toHaveCount(0, { timeout: 10_000 });
 }
 
 // Tab switching is state-only (App.jsx and MobileApp.jsx both hold `view` in

--- a/web/src/components/mobile/SplashScreen.jsx
+++ b/web/src/components/mobile/SplashScreen.jsx
@@ -1,0 +1,65 @@
+import { THEME } from '../../constants/theme.js';
+import { splashCss } from '../../utils/splashCss.js';
+import { usePrefersReducedMotion } from '../../hooks/usePrefersReducedMotion.js';
+
+const CSS = splashCss(THEME);
+
+const MARK_PATH = 'M30 88 C 44 88, 46 40, 62 40 C 78 40, 80 88, 94 88';
+
+export default function SplashScreen() {
+  const reduced = usePrefersReducedMotion();
+  return (
+    <div
+      className={reduced ? 'siq-splash siq-splash--still' : 'siq-splash'}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 2000,
+        background: THEME.bg,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 36,
+        fontFamily: 'ui-sans-serif, system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <style>{CSS}</style>
+      <div className="siq-splash__glow" />
+      <div className="siq-splash__mark">
+        <div className="siq-splash__halo" />
+        <div className="siq-splash__tile" />
+        <svg
+          width="124"
+          height="124"
+          viewBox="0 0 124 124"
+          style={{ position: 'relative', overflow: 'visible' }}
+        >
+          <line className="siq-splash__base" x1="30" y1="88" x2="94" y2="88" />
+          <path className="siq-splash__stroke" d={MARK_PATH} />
+          {/* Left at the SVG origin deliberately: offset-path translates the
+              element to the path point, so a circle authored at cx/cy would land
+              at twice the offset. Engines without motion path hide it instead. */}
+          <circle className="siq-splash__head" r="4" />
+        </svg>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 12,
+        }}
+      >
+        <div className="siq-splash__word">
+          Split<span className="siq-splash__word-iq">IQ</span>
+        </div>
+        <div className="siq-splash__sub">ERG · STRENGTH · BIKE</div>
+      </div>
+      <div className="siq-splash__progress">
+        <div className="siq-splash__track" />
+      </div>
+      <div className="siq-splash__caption">SYNCING TRAINING LOG</div>
+    </div>
+  );
+}

--- a/web/src/components/mobile/__tests__/SplashScreen.test.jsx
+++ b/web/src/components/mobile/__tests__/SplashScreen.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SplashScreen from '../SplashScreen.jsx';
+
+function stubReducedMotion() {
+  vi.stubGlobal('matchMedia', (media) => ({
+    matches: true,
+    media,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SplashScreen', () => {
+  it('renders the fixed brand lockup and caption', () => {
+    render(<SplashScreen />);
+    expect(screen.getByText('SYNCING TRAINING LOG')).toBeInTheDocument();
+    expect(screen.getByText('IQ')).toBeInTheDocument();
+    expect(screen.getByText(/Split/)).toBeInTheDocument();
+    expect(screen.getByText('ERG · STRENGTH · BIKE')).toBeInTheDocument();
+  });
+
+  it('does not ship the mockup status bar', () => {
+    render(<SplashScreen />);
+    expect(screen.queryByText('5:41')).toBeNull();
+    expect(screen.queryByText(/82%/)).toBeNull();
+  });
+
+  it('animates by default', () => {
+    const { container } = render(<SplashScreen />);
+    const root = container.firstChild;
+    expect(root).toHaveClass('siq-splash');
+    expect(root).not.toHaveClass('siq-splash--still');
+  });
+
+  it('switches to the still variant under prefers-reduced-motion', () => {
+    stubReducedMotion();
+    const { container } = render(<SplashScreen />);
+    const root = container.firstChild;
+    expect(root).toHaveClass('siq-splash--still');
+    expect(screen.getByText('IQ')).toBeInTheDocument();
+    expect(screen.getByText('SYNCING TRAINING LOG')).toBeInTheDocument();
+  });
+
+  it('injects exactly one stylesheet', () => {
+    const { container } = render(<SplashScreen />);
+    expect(container.querySelectorAll('style')).toHaveLength(1);
+  });
+});

--- a/web/src/constants/__tests__/theme.test.js
+++ b/web/src/constants/__tests__/theme.test.js
@@ -18,6 +18,7 @@ const EXPECTED_KEYS = [
   'accentAlt2',
   'positiveAlt',
   'surfaceAlt',
+  'surfaceDeep',
   'neutral',
   'textSubtle',
   'textFaint',
@@ -28,9 +29,9 @@ const EXPECTED_KEYS = [
 ];
 
 describe('THEME', () => {
-  it('has exactly the 23 expected keys (no more, no fewer)', () => {
+  it('has exactly the 24 expected keys (no more, no fewer)', () => {
     const keys = Object.keys(THEME);
-    expect(keys).toHaveLength(23);
+    expect(keys).toHaveLength(24);
     expect(keys.sort()).toEqual([...EXPECTED_KEYS].sort());
   });
 
@@ -57,6 +58,7 @@ describe('THEME', () => {
     expect(THEME.accentAlt2).toBe('#f472b6');
     expect(THEME.positiveAlt).toBe('#2dd4bf');
     expect(THEME.surfaceAlt).toBe('#1e1e30');
+    expect(THEME.surfaceDeep).toBe('#12121f');
     expect(THEME.neutral).toBe('#3a3a4a');
     expect(THEME.textSubtle).toBe('#aaaacc');
     expect(THEME.textFaint).toBe('#6c6c88');

--- a/web/src/constants/theme.js
+++ b/web/src/constants/theme.js
@@ -15,6 +15,7 @@ export const THEME = {
   accentAlt2: '#f472b6',
   positiveAlt: '#2dd4bf',
   surfaceAlt: '#1e1e30',
+  surfaceDeep: '#12121f',
   neutral: '#3a3a4a',
   textSubtle: '#aaaacc',
   textFaint: '#6c6c88',

--- a/web/src/hooks/__tests__/useInitialDataReady.test.js
+++ b/web/src/hooks/__tests__/useInitialDataReady.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+  queries: [],
+  listener: null,
+  unsubscribe: null,
+}));
+
+vi.mock('@tanstack/react-query', () => {
+  const cache = {
+    getAll: () => mocks.queries,
+    subscribe: (fn) => {
+      mocks.listener = fn;
+      return mocks.unsubscribe;
+    },
+  };
+  const client = { getQueryCache: () => cache };
+  return { useQueryClient: () => client };
+});
+
+import { useInitialDataReady } from '../useInitialDataReady.js';
+
+const q = (status, fetchStatus) => ({ state: { status, fetchStatus } });
+
+beforeEach(() => {
+  mocks.queries = [];
+  mocks.listener = null;
+  mocks.unsubscribe = vi.fn();
+});
+
+describe('useInitialDataReady', () => {
+  it('stays false while the cache is empty', () => {
+    const { result } = renderHook(() => useInitialDataReady());
+    expect(result.current).toBe(false);
+  });
+
+  it('stays false while a first fetch is in flight', () => {
+    mocks.queries = [q('pending', 'fetching')];
+    const { result } = renderHook(() => useInitialDataReady());
+    expect(result.current).toBe(false);
+  });
+
+  it('latches once the in-flight fetch settles', () => {
+    mocks.queries = [q('pending', 'fetching')];
+    const { result } = renderHook(() => useInitialDataReady());
+    expect(result.current).toBe(false);
+
+    mocks.queries = [q('success', 'idle')];
+    act(() => mocks.listener());
+    expect(result.current).toBe(true);
+  });
+
+  it('latches immediately on a warm cache that never fetches', () => {
+    mocks.queries = [q('success', 'idle')];
+    const { result } = renderHook(() => useInitialDataReady());
+    expect(result.current).toBe(true);
+  });
+
+  it('latches on an errored first fetch — a failure must not block the splash', () => {
+    mocks.queries = [q('error', 'idle')];
+    const { result } = renderHook(() => useInitialDataReady());
+    expect(result.current).toBe(true);
+  });
+
+  it('unsubscribes once latched and never goes back to false', () => {
+    mocks.queries = [q('pending', 'fetching')];
+    const { result, rerender } = renderHook(() => useInitialDataReady());
+
+    mocks.queries = [q('success', 'idle')];
+    act(() => mocks.listener());
+    expect(result.current).toBe(true);
+    expect(mocks.unsubscribe).toHaveBeenCalled();
+
+    mocks.queries = [q('pending', 'fetching')];
+    rerender();
+    expect(result.current).toBe(true);
+  });
+});

--- a/web/src/hooks/__tests__/usePrefersReducedMotion.test.js
+++ b/web/src/hooks/__tests__/usePrefersReducedMotion.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { usePrefersReducedMotion } from '../usePrefersReducedMotion.js';
 
 function stubMatchMedia(matches) {
@@ -51,5 +51,20 @@ describe('usePrefersReducedMotion', () => {
       'change',
       expect.any(Function)
     );
+  });
+
+  // The handler body never ran in any other test, so a wrong event shape
+  // (e.target.matches, an inverted boolean) would have shipped silently.
+  it('follows the preference when it changes while mounted', () => {
+    const listeners = stubMatchMedia(false);
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+
+    const [, handler] = listeners.add.mock.calls[0];
+    act(() => handler({ matches: true }));
+    expect(result.current).toBe(true);
+
+    act(() => handler({ matches: false }));
+    expect(result.current).toBe(false);
   });
 });

--- a/web/src/hooks/__tests__/usePrefersReducedMotion.test.js
+++ b/web/src/hooks/__tests__/usePrefersReducedMotion.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePrefersReducedMotion } from '../usePrefersReducedMotion.js';
+
+function stubMatchMedia(matches) {
+  const listeners = { add: vi.fn(), remove: vi.fn() };
+  vi.stubGlobal('matchMedia', (media) => ({
+    matches,
+    media,
+    onchange: null,
+    addEventListener: listeners.add,
+    removeEventListener: listeners.remove,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+  return listeners;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('usePrefersReducedMotion', () => {
+  // jsdom ships no matchMedia at all. This is the guard that keeps every other
+  // splash test from throwing on mount.
+  it('returns false without throwing when matchMedia is unavailable', () => {
+    expect(typeof window.matchMedia).toBe('undefined');
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('reports the preference when matchMedia says reduce', () => {
+    stubMatchMedia(true);
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('reports false when matchMedia says no preference', () => {
+    stubMatchMedia(false);
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('subscribes to change and cleans up on unmount', () => {
+    const listeners = stubMatchMedia(false);
+    const { unmount } = renderHook(() => usePrefersReducedMotion());
+    expect(listeners.add).toHaveBeenCalledWith('change', expect.any(Function));
+    unmount();
+    expect(listeners.remove).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function)
+    );
+  });
+});

--- a/web/src/hooks/__tests__/useSplashGate.test.js
+++ b/web/src/hooks/__tests__/useSplashGate.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StrictMode } from 'react';
 import { renderHook, act } from '@testing-library/react';
 import {
   useSplashGate,
@@ -145,7 +146,7 @@ describe('useSplashGate', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it('does not restart the clock when enabled toggles mid-splash', () => {
+  it('clears both timers when the gate is disabled mid-splash', () => {
     const { result, rerender } = renderHook((props) => useSplashGate(props), {
       initialProps: {
         enabled: true,
@@ -169,5 +170,25 @@ describe('useSplashGate', () => {
     const { result } = renderHook(() => useSplashGate());
     expect(result.current).toBe(false);
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  // StrictMode double-invokes the arming effect: run, clean up, run again. The
+  // armedRef latch is what stops the second run restarting the clock — without
+  // it the floor never fires and the splash sticks forever in dev.
+  it('keeps one clock across a StrictMode double-mount', () => {
+    const { result } = renderHook((props) => useSplashGate(props), {
+      wrapper: StrictMode,
+      initialProps: {
+        enabled: true,
+        authResolved: true,
+        dataReady: true,
+        dataExpected: true,
+      },
+    });
+    expect(result.current).toBe(true);
+    advance(SPLASH_MIN_MS - 1);
+    expect(result.current).toBe(true);
+    advance(1);
+    expect(result.current).toBe(false);
   });
 });

--- a/web/src/hooks/__tests__/useSplashGate.test.js
+++ b/web/src/hooks/__tests__/useSplashGate.test.js
@@ -172,9 +172,10 @@ describe('useSplashGate', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  // StrictMode double-invokes the arming effect: run, clean up, run again. The
-  // armedRef latch is what stops the second run restarting the clock — without
-  // it the floor never fires and the splash sticks forever in dev.
+  // StrictMode double-invokes the arming effect: run, clean up, run again.
+  // This pins the observable contract — one floor, still 700ms — rather than
+  // the latch's internals; both passes land in the same commit, so the re-armed
+  // delay equals a fresh one and this would also pass without armedRef.
   it('keeps one clock across a StrictMode double-mount', () => {
     const { result } = renderHook((props) => useSplashGate(props), {
       wrapper: StrictMode,

--- a/web/src/hooks/__tests__/useSplashGate.test.js
+++ b/web/src/hooks/__tests__/useSplashGate.test.js
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useSplashGate,
+  SPLASH_MIN_MS,
+  SPLASH_MAX_MS,
+} from '../useSplashGate.js';
+
+const advance = (ms) => act(() => vi.advanceTimersByTime(ms));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useSplashGate', () => {
+  it('holds the splash for the floor even when boot finishes instantly', () => {
+    const { result, rerender } = renderHook((props) => useSplashGate(props), {
+      initialProps: {
+        enabled: true,
+        authResolved: false,
+        dataReady: false,
+        dataExpected: true,
+      },
+    });
+    expect(result.current).toBe(true);
+
+    rerender({
+      enabled: true,
+      authResolved: true,
+      dataReady: true,
+      dataExpected: true,
+    });
+    expect(result.current).toBe(true);
+
+    advance(SPLASH_MIN_MS - 1);
+    expect(result.current).toBe(true);
+
+    advance(1);
+    expect(result.current).toBe(false);
+  });
+
+  it('caps a slow boot at the ceiling', () => {
+    const { result } = renderHook((props) => useSplashGate(props), {
+      initialProps: {
+        enabled: true,
+        authResolved: true,
+        dataReady: false,
+        dataExpected: true,
+      },
+    });
+
+    advance(SPLASH_MAX_MS - 1);
+    expect(result.current).toBe(true);
+
+    advance(1);
+    expect(result.current).toBe(false);
+  });
+
+  it('clears a logged-out boot at the floor instead of riding to the ceiling', () => {
+    const { result } = renderHook((props) => useSplashGate(props), {
+      initialProps: {
+        enabled: true,
+        authResolved: true,
+        dataReady: false,
+        dataExpected: false,
+      },
+    });
+
+    advance(SPLASH_MIN_MS - 1);
+    expect(result.current).toBe(true);
+
+    advance(1);
+    expect(result.current).toBe(false);
+  });
+
+  it('exits immediately on auth rejection, bypassing the floor', () => {
+    const { result, rerender } = renderHook((props) => useSplashGate(props), {
+      initialProps: {
+        enabled: true,
+        authResolved: false,
+        authFailed: false,
+        dataExpected: true,
+      },
+    });
+    advance(100);
+    expect(result.current).toBe(true);
+
+    rerender({
+      enabled: true,
+      authResolved: true,
+      authFailed: true,
+      dataExpected: false,
+    });
+    expect(result.current).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('arms nothing on desktop', () => {
+    const { result } = renderHook((props) => useSplashGate(props), {
+      initialProps: { enabled: false, authResolved: true, dataExpected: true },
+    });
+    expect(result.current).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('never re-shows once dismissed', () => {
+    const { result, rerender } = renderHook((props) => useSplashGate(props), {
+      initialProps: {
+        enabled: true,
+        authResolved: true,
+        dataReady: true,
+        dataExpected: true,
+      },
+    });
+    advance(SPLASH_MIN_MS);
+    expect(result.current).toBe(false);
+
+    rerender({
+      enabled: true,
+      authResolved: true,
+      dataReady: false,
+      dataExpected: true,
+    });
+    expect(result.current).toBe(false);
+
+    advance(SPLASH_MAX_MS);
+    expect(result.current).toBe(false);
+  });
+
+  it('leaves no pending timers on unmount', () => {
+    const { unmount } = renderHook((props) => useSplashGate(props), {
+      initialProps: {
+        enabled: true,
+        authResolved: false,
+        dataExpected: true,
+      },
+    });
+    advance(300);
+    expect(vi.getTimerCount()).toBe(2);
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not restart the clock when enabled toggles mid-splash', () => {
+    const { result, rerender } = renderHook((props) => useSplashGate(props), {
+      initialProps: {
+        enabled: true,
+        authResolved: true,
+        dataReady: true,
+        dataExpected: true,
+      },
+    });
+    advance(400);
+    rerender({
+      enabled: false,
+      authResolved: true,
+      dataReady: true,
+      dataExpected: true,
+    });
+    expect(result.current).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('defaults to hidden when called with no options', () => {
+    const { result } = renderHook(() => useSplashGate());
+    expect(result.current).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/web/src/hooks/useInitialDataReady.js
+++ b/web/src/hooks/useInitialDataReady.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+// True once the first round of queries has settled. Subscribes to the query
+// cache rather than using useIsFetching() because that would re-render the whole
+// app tree on every background refetch for the life of the session; this
+// subscription tears itself down permanently the moment it latches.
+export function useInitialDataReady() {
+  const queryClient = useQueryClient();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (ready) return undefined;
+    const cache = queryClient.getQueryCache();
+    let started = false;
+    const check = () => {
+      const all = cache.getAll();
+      if (all.some((q) => q.state.fetchStatus === 'fetching')) {
+        started = true;
+        return;
+      }
+      // The second disjunct covers a warm PWA cache serving instantly (nothing
+      // is ever observed 'fetching') and a first fetch that errored — an error
+      // settles to status 'error', which must clear the splash, not hold it.
+      if (started || all.some((q) => q.state.status !== 'pending')) {
+        setReady(true);
+      }
+    };
+    check();
+    return cache.subscribe(check);
+  }, [queryClient, ready]);
+
+  return ready;
+}

--- a/web/src/hooks/usePrefersReducedMotion.js
+++ b/web/src/hooks/usePrefersReducedMotion.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+// jsdom ships no window.matchMedia at all, so an unguarded read throws in every
+// test that mounts a component using this. Absent the API, assume motion is fine.
+function reducedMotionQuery() {
+  if (typeof window === 'undefined') return null;
+  if (typeof window.matchMedia !== 'function') return null;
+  return window.matchMedia(QUERY);
+}
+
+export function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(
+    () => reducedMotionQuery()?.matches ?? false
+  );
+
+  useEffect(() => {
+    const mq = reducedMotionQuery();
+    if (!mq) return undefined;
+    const handler = (e) => setReduced(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return reduced;
+}

--- a/web/src/hooks/useSplashGate.js
+++ b/web/src/hooks/useSplashGate.js
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const SPLASH_MIN_MS = 700;
+export const SPLASH_MAX_MS = 5000;
+
+// Owns the whole splash timing decision so main.jsx (coverage-excluded) holds
+// nothing but composition. Plain booleans in, one boolean out — no react-query,
+// no Supabase, no DOM.
+export function useSplashGate({
+  enabled = false,
+  authResolved = false,
+  authFailed = false,
+  dataReady = false,
+  dataExpected = false,
+} = {}) {
+  const [floorElapsed, setFloorElapsed] = useState(false);
+  const [ceilingReached, setCeilingReached] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const armedRef = useRef(null);
+
+  const active = enabled && !authFailed;
+
+  useEffect(() => {
+    if (!active) return undefined;
+    // The latch fixes t=0 at first activation and never moves. Re-running this
+    // effect (a viewport crossing 767px, or StrictMode's double-invoked mount)
+    // re-arms with the REMAINING time rather than restarting the clock.
+    if (armedRef.current === null) armedRef.current = Date.now();
+    const elapsed = Date.now() - armedRef.current;
+    const floor = setTimeout(
+      () => setFloorElapsed(true),
+      Math.max(0, SPLASH_MIN_MS - elapsed)
+    );
+    const ceiling = setTimeout(
+      () => setCeilingReached(true),
+      Math.max(0, SPLASH_MAX_MS - elapsed)
+    );
+    return () => {
+      clearTimeout(floor);
+      clearTimeout(ceiling);
+    };
+  }, [active]);
+
+  // With no session no query ever runs, so dataReady would never latch and a
+  // signed-out boot would sit at the ceiling before showing Login.
+  const booted = authResolved && (dataReady || !dataExpected);
+  const visible =
+    enabled && !authFailed && !ceilingReached && (!floorElapsed || !booted);
+
+  // Monotonic latch, set during render (React's documented way to remember
+  // something across renders without an effect). `visible` is not naturally
+  // monotonic: signing in flips dataExpected false→true, which would otherwise
+  // re-show the splash over an app that is already running.
+  if (!visible && !dismissed) setDismissed(true);
+
+  return visible && !dismissed;
+}

--- a/web/src/hooks/useSplashGate.js
+++ b/web/src/hooks/useSplashGate.js
@@ -22,9 +22,11 @@ export function useSplashGate({
 
   useEffect(() => {
     if (!active) return undefined;
-    // The latch fixes t=0 at first activation and never moves. Re-running this
-    // effect (a viewport crossing 767px, or StrictMode's double-invoked mount)
-    // re-arms with the REMAINING time rather than restarting the clock.
+    // Fixes t=0 at first activation so a re-run of this effect (StrictMode's
+    // double-invoked mount, or a viewport crossing 767px) re-arms with the
+    // REMAINING time rather than a fresh full floor. Belt-and-braces today:
+    // both re-run paths land at elapsed~=0, and the dismissed latch below means
+    // a disable/re-enable can never show the splash again anyway.
     if (armedRef.current === null) armedRef.current = Date.now();
     const elapsed = Date.now() - armedRef.current;
     const floor = setTimeout(

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -298,44 +298,45 @@ function AuthGate() {
     return () => sub.subscription.unsubscribe();
   }, []);
 
+  let body;
   if (session === undefined) {
-    return (
+    body = showSplash ? null : (
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: C.bg,
+          color: C.muted,
+          fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+          fontSize: 12,
+        }}
+      >
+        Loading…
+      </div>
+    );
+  } else if (!session) {
+    body = showSplash ? null : <Login />;
+  } else {
+    body = (
       <>
-        {showSplash ? (
-          <SplashScreen />
-        ) : (
-          <div
-            style={{
-              minHeight: '100vh',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              background: C.bg,
-              color: C.muted,
-              fontFamily: 'ui-sans-serif, system-ui, sans-serif',
-              fontSize: 12,
-            }}
-          >
-            Loading…
-          </div>
-        )}
-        <InstallButton />
+        <SignOutButton />
+        {isMobile ? <MobileApp /> : <App />}
       </>
     );
   }
-  if (!session)
-    return (
-      <>
-        {showSplash ? <SplashScreen /> : <Login />}
-        <InstallButton />
-      </>
-    );
+
+  // One flat shape across all three branches, so the splash keeps a stable
+  // child index. Returning a different fragment per branch remounted it the
+  // moment the session resolved — React reconciles fragment children by index,
+  // so the splash landed on a different slot and replayed its whole entrance
+  // mid-animation. It also overlays rather than replaces once signed in: the
+  // tabs' fetches only start when MobileApp mounts, so it has to be mounted
+  // and fetching underneath.
   return (
     <>
-      <SignOutButton />
-      {isMobile ? <MobileApp /> : <App />}
-      {/* Overlays rather than replaces: the tabs' fetches only start once
-          MobileApp mounts, so it has to be mounted and fetching underneath. */}
+      {body}
       {showSplash && <SplashScreen />}
       <InstallButton />
     </>

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -13,9 +13,12 @@ import App from './App.jsx';
 import { supabase } from './supabaseClient.js';
 import { usePWAInstall } from './hooks/usePWAInstall.js';
 import { useIsMobile } from './hooks/useIsMobile.js';
+import { useSplashGate } from './hooks/useSplashGate.js';
+import { useInitialDataReady } from './hooks/useInitialDataReady.js';
+import SplashScreen from './components/mobile/SplashScreen.jsx';
 import MobileApp from './views/mobile/MobileApp.jsx';
 import { createNotificationChannels } from './utils/notifications.js';
-import { initSentry } from './utils/sentry.js';
+import { initSentry, captureError } from './utils/sentry.js';
 import {
   handleQueryError,
   handleMutationError,
@@ -267,10 +270,28 @@ function InstallButton() {
 // undefined = still checking, null = logged out, object = signed in.
 function AuthGate() {
   const [session, setSession] = useState(undefined);
+  const [authFailed, setAuthFailed] = useState(false);
   const isMobile = useIsMobile();
+  const dataReady = useInitialDataReady();
+  const showSplash = useSplashGate({
+    enabled: isMobile,
+    authResolved: session !== undefined,
+    authFailed,
+    dataReady,
+    dataExpected: !!session,
+  });
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    supabase.auth
+      .getSession()
+      .then(({ data }) => setSession(data.session))
+      .catch((error) => {
+        // Outside react-query, so nothing else captures this. Falling through
+        // to Login is the right recovery, but silently would hide a real outage.
+        captureError(error, { where: 'AuthGate.getSession' });
+        setAuthFailed(true);
+        setSession(null);
+      });
     const { data: sub } = supabase.auth.onAuthStateChange((_event, s) =>
       setSession(s)
     );
@@ -280,20 +301,24 @@ function AuthGate() {
   if (session === undefined) {
     return (
       <>
-        <div
-          style={{
-            minHeight: '100vh',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            background: C.bg,
-            color: C.muted,
-            fontFamily: 'ui-sans-serif, system-ui, sans-serif',
-            fontSize: 12,
-          }}
-        >
-          Loading…
-        </div>
+        {showSplash ? (
+          <SplashScreen />
+        ) : (
+          <div
+            style={{
+              minHeight: '100vh',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: C.bg,
+              color: C.muted,
+              fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+              fontSize: 12,
+            }}
+          >
+            Loading…
+          </div>
+        )}
         <InstallButton />
       </>
     );
@@ -301,7 +326,7 @@ function AuthGate() {
   if (!session)
     return (
       <>
-        <Login />
+        {showSplash ? <SplashScreen /> : <Login />}
         <InstallButton />
       </>
     );
@@ -309,6 +334,9 @@ function AuthGate() {
     <>
       <SignOutButton />
       {isMobile ? <MobileApp /> : <App />}
+      {/* Overlays rather than replaces: the tabs' fetches only start once
+          MobileApp mounts, so it has to be mounted and fetching underneath. */}
+      {showSplash && <SplashScreen />}
       <InstallButton />
     </>
   );

--- a/web/src/utils/__tests__/splashCss.test.js
+++ b/web/src/utils/__tests__/splashCss.test.js
@@ -76,4 +76,47 @@ describe('splashCss', () => {
       expect(selector.startsWith('.siq-splash')).toBe(true);
     }
   });
+
+  // AC4: the loop set must keep running for as long as the splash is mounted.
+  // Dropping `infinite` would leave a frozen frame over an unknown wait.
+  it('loops the four continuous animations for as long as it is mounted', () => {
+    const css = splashCss(THEME);
+    for (const name of ['glow', 'draw', 'head', 'track']) {
+      const rule = css
+        .split('\n')
+        .find((line) => line.includes(`animation: siq-splash-${name} `));
+      expect(rule, `no rule drives siq-splash-${name}`).toBeTruthy();
+      expect(rule).toContain('infinite');
+    }
+  });
+
+  it('runs the entrances once so they settle instead of replaying', () => {
+    const css = splashCss(THEME);
+    for (const name of ['tile', 'halo', 'base', 'word', 'sub']) {
+      const rule = css
+        .split('\n')
+        .find((line) => line.includes(`animation: siq-splash-${name} `));
+      expect(rule, `no rule drives siq-splash-${name}`).toBeTruthy();
+      expect(rule).not.toContain('infinite');
+      expect(rule).toContain('both');
+    }
+  });
+
+  // A new animated element that nobody adds to stillRules() would keep moving
+  // under prefers-reduced-motion, which is the whole failure this guards.
+  it('stills every element it animates', () => {
+    const css = splashCss(THEME);
+    const animated = new Set(
+      [...css.matchAll(/\.(siq-splash__[a-z-]+)\s*\{[^}]*animation:/g)].map(
+        (m) => m[1]
+      )
+    );
+    expect(animated.size).toBeGreaterThan(0);
+    const still = css.slice(css.indexOf('.siq-splash--still'));
+    for (const cls of animated) {
+      expect(still, `${cls} is animated but never stilled`).toContain(
+        `.siq-splash--still .${cls}`
+      );
+    }
+  });
 });

--- a/web/src/utils/__tests__/splashCss.test.js
+++ b/web/src/utils/__tests__/splashCss.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { splashCss } from '../splashCss.js';
+import { THEME } from '../../constants/theme.js';
+
+// Substitution, not "contains no hex" — THEME values ARE hexes, so the only
+// honest proof that a colour came from the token is swapping the token and
+// watching the output follow.
+const SUBSTITUTED = [
+  ['bg', '#010101'],
+  ['cyan', '#ff0000'],
+  ['text', '#020202'],
+  ['textSubtle', '#030303'],
+  ['surfaceAlt', '#040404'],
+  ['surfaceDeep', '#050505'],
+  ['divider', '#060606'],
+];
+
+describe('splashCss', () => {
+  it.each(SUBSTITUTED)(
+    'reads %s from the theme rather than a literal',
+    (key, swapped) => {
+      const css = splashCss({ ...THEME, [key]: swapped });
+      expect(css).toContain(swapped);
+      expect(css).not.toContain(THEME[key]);
+    }
+  );
+
+  it('derives the translucent cyans from the cyan token', () => {
+    const css = splashCss({ ...THEME, cyan: '#010203' });
+    expect(css).toContain('rgba(1, 2, 3');
+    expect(css).not.toContain('rgba(0, 212, 255');
+  });
+
+  it('defines all nine namespaced keyframes', () => {
+    const css = splashCss(THEME);
+    for (const name of [
+      'glow',
+      'tile',
+      'halo',
+      'draw',
+      'head',
+      'base',
+      'word',
+      'sub',
+      'track',
+    ]) {
+      expect(css).toContain(`@keyframes siq-splash-${name}`);
+    }
+  });
+
+  it('emits a still block holding the END state of every entrance', () => {
+    const css = splashCss(THEME);
+    const still = css.slice(css.indexOf('.siq-splash--still'));
+    expect(still).toContain('animation: none !important');
+    expect(still).toContain('stroke-dashoffset: 0');
+    expect(still).toContain('transform: scaleX(1)');
+    expect(still).toMatch(/\.siq-splash__track \{\n\s*display: none;/);
+  });
+
+  it('repeats the still state under a reduced-motion media query', () => {
+    const css = splashCss(THEME);
+    const media = css.indexOf('@media (prefers-reduced-motion: reduce)');
+    expect(media).toBeGreaterThan(-1);
+    const block = css.slice(media);
+    expect(block).toContain('animation: none !important');
+    expect(block).toContain('stroke-dashoffset: 0');
+  });
+
+  it('scopes every selector under .siq-splash', () => {
+    const selectors = splashCss(THEME)
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('.'));
+    expect(selectors.length).toBeGreaterThan(10);
+    for (const selector of selectors) {
+      expect(selector.startsWith('.siq-splash')).toBe(true);
+    }
+  });
+});

--- a/web/src/utils/__tests__/splashCss.test.js
+++ b/web/src/utils/__tests__/splashCss.test.js
@@ -7,7 +7,7 @@ import { THEME } from '../../constants/theme.js';
 // watching the output follow.
 const SUBSTITUTED = [
   ['bg', '#010101'],
-  ['cyan', '#ff0000'],
+  ['accent', '#ff0000'],
   ['text', '#020202'],
   ['textSubtle', '#030303'],
   ['surfaceAlt', '#040404'],
@@ -25,8 +25,8 @@ describe('splashCss', () => {
     }
   );
 
-  it('derives the translucent cyans from the cyan token', () => {
-    const css = splashCss({ ...THEME, cyan: '#010203' });
+  it('derives the translucent accents from the accent token', () => {
+    const css = splashCss({ ...THEME, accent: '#010203' });
     expect(css).toContain('rgba(1, 2, 3');
     expect(css).not.toContain('rgba(0, 212, 255');
   });

--- a/web/src/utils/splashCss.js
+++ b/web/src/utils/splashCss.js
@@ -5,7 +5,7 @@
 // Every colour is interpolated from the passed theme — the palette is
 // mid-migration and a literal hex would silently survive the move.
 
-// Not exported: the two translucent cyans the design calls for have no THEME
+// Not exported: the two translucent accents the design calls for have no THEME
 // token, and inventing one for a one-file detail would be worse than deriving
 // them here.
 function alpha(hex, a) {
@@ -76,7 +76,7 @@ export function splashCss(theme) {
   width: 520px;
   height: 520px;
   border-radius: 50%;
-  background: radial-gradient(circle, ${alpha(theme.cyan, 0.16)} 0%, ${alpha(theme.cyan, 0)} 66%);
+  background: radial-gradient(circle, ${alpha(theme.accent, 0.16)} 0%, ${alpha(theme.accent, 0)} 66%);
   animation: siq-splash-glow 2600ms ease-in-out infinite;
 }
 .siq-splash__mark {
@@ -91,7 +91,7 @@ export function splashCss(theme) {
   position: absolute;
   inset: -6px;
   border-radius: 34px;
-  border: 1px solid ${theme.cyan};
+  border: 1px solid ${theme.accent};
   animation: siq-splash-halo 640ms cubic-bezier(.2, .7, .3, 1) 260ms both;
 }
 .siq-splash__tile {
@@ -112,11 +112,11 @@ export function splashCss(theme) {
 }
 .siq-splash__stroke {
   fill: none;
-  stroke: ${theme.cyan};
+  stroke: ${theme.accent};
   stroke-width: 4.5;
   stroke-linecap: round;
   stroke-dasharray: 260;
-  filter: drop-shadow(0 0 8px ${alpha(theme.cyan, 0.55)});
+  filter: drop-shadow(0 0 8px ${alpha(theme.accent, 0.55)});
   animation: siq-splash-draw 2600ms cubic-bezier(.35, .7, .2, 1) infinite both;
 }
 .siq-splash__head {
@@ -135,7 +135,7 @@ export function splashCss(theme) {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-weight: 700;
   letter-spacing: 0;
-  color: ${theme.cyan};
+  color: ${theme.accent};
 }
 .siq-splash__sub {
   font-size: 9px;
@@ -155,7 +155,7 @@ export function splashCss(theme) {
 .siq-splash__track {
   width: 36%;
   height: 100%;
-  background: linear-gradient(90deg, ${alpha(theme.cyan, 0)}, ${theme.cyan});
+  background: linear-gradient(90deg, ${alpha(theme.accent, 0)}, ${theme.accent});
   animation: siq-splash-track 1500ms cubic-bezier(.55, 0, .45, 1) infinite;
 }
 .siq-splash__caption {

--- a/web/src/utils/splashCss.js
+++ b/web/src/utils/splashCss.js
@@ -1,0 +1,219 @@
+// Stylesheet for the mobile splash (components/mobile/SplashScreen.jsx). It is a
+// string builder rather than inline styles because the splash needs keyframes,
+// and a keyframe cannot be expressed as a style object. Twin of themeCss.js.
+//
+// Every colour is interpolated from the passed theme — the palette is
+// mid-migration and a literal hex would silently survive the move.
+
+// Not exported: the two translucent cyans the design calls for have no THEME
+// token, and inventing one for a one-file detail would be worse than deriving
+// them here.
+function alpha(hex, a) {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+// The reduced-motion resting state is the END of every entrance, not the start —
+// several CSS defaults here (stroke-dashoffset, scaleX(0), opacity 0) are the
+// first keyframe, so merely switching animations off would freeze a half-drawn
+// logo. Emitted twice, from this one template, so the class-driven and
+// media-query-driven copies cannot drift.
+function stillRules(root) {
+  return `${root} .siq-splash__glow,
+${root} .siq-splash__halo,
+${root} .siq-splash__tile,
+${root} .siq-splash__base,
+${root} .siq-splash__stroke,
+${root} .siq-splash__head,
+${root} .siq-splash__word,
+${root} .siq-splash__sub,
+${root} .siq-splash__track {
+  animation: none !important;
+}
+${root} .siq-splash__glow {
+  opacity: .32;
+  transform: none;
+}
+${root} .siq-splash__tile {
+  opacity: 1;
+  transform: none;
+}
+${root} .siq-splash__halo {
+  opacity: 0;
+}
+${root} .siq-splash__base {
+  transform: scaleX(1);
+}
+${root} .siq-splash__stroke {
+  stroke-dashoffset: 0;
+}
+${root} .siq-splash__head {
+  opacity: 0;
+}
+${root} .siq-splash__word {
+  opacity: 1;
+  transform: none;
+}
+${root} .siq-splash__sub {
+  opacity: 1;
+  letter-spacing: 3px;
+}
+${root} .siq-splash__track {
+  display: none;
+}`;
+}
+
+export function splashCss(theme) {
+  return `.siq-splash {
+  overflow: hidden;
+  background: ${theme.bg};
+}
+.siq-splash__glow {
+  position: absolute;
+  width: 520px;
+  height: 520px;
+  border-radius: 50%;
+  background: radial-gradient(circle, ${alpha(theme.cyan, 0.16)} 0%, ${alpha(theme.cyan, 0)} 66%);
+  animation: siq-splash-glow 2600ms ease-in-out infinite;
+}
+.siq-splash__mark {
+  position: relative;
+  width: 124px;
+  height: 124px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.siq-splash__halo {
+  position: absolute;
+  inset: -6px;
+  border-radius: 34px;
+  border: 1px solid ${theme.cyan};
+  animation: siq-splash-halo 640ms cubic-bezier(.2, .7, .3, 1) 260ms both;
+}
+.siq-splash__tile {
+  position: absolute;
+  inset: 0;
+  border-radius: 30px;
+  background: linear-gradient(160deg, ${theme.surfaceAlt} 0%, ${theme.surfaceDeep} 100%);
+  border: 1px solid ${theme.divider};
+  box-shadow: 0 18px 46px rgba(0, 0, 0, .55), inset 0 1px 0 rgba(255, 255, 255, .05);
+  animation: siq-splash-tile 620ms cubic-bezier(.2, .8, .2, 1) both;
+}
+.siq-splash__base {
+  stroke: ${theme.divider};
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  transform-origin: 30px 88px;
+  animation: siq-splash-base 560ms cubic-bezier(.3, .7, .2, 1) 240ms both;
+}
+.siq-splash__stroke {
+  fill: none;
+  stroke: ${theme.cyan};
+  stroke-width: 4.5;
+  stroke-linecap: round;
+  stroke-dasharray: 260;
+  filter: drop-shadow(0 0 8px ${alpha(theme.cyan, 0.55)});
+  animation: siq-splash-draw 2600ms cubic-bezier(.35, .7, .2, 1) infinite both;
+}
+.siq-splash__head {
+  fill: ${theme.text};
+  offset-path: path('M30 88 C 44 88, 46 40, 62 40 C 78 40, 80 88, 94 88');
+  animation: siq-splash-head 2600ms cubic-bezier(.35, .7, .2, 1) infinite both;
+}
+.siq-splash__word {
+  font-size: 34px;
+  font-weight: 600;
+  letter-spacing: -.8px;
+  color: ${theme.text};
+  animation: siq-splash-word 420ms cubic-bezier(.2, .8, .2, 1) 380ms both;
+}
+.siq-splash__word-iq {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 700;
+  letter-spacing: 0;
+  color: ${theme.cyan};
+}
+.siq-splash__sub {
+  font-size: 9px;
+  letter-spacing: 3px;
+  color: ${theme.textSubtle};
+  animation: siq-splash-sub 400ms cubic-bezier(.2, .8, .2, 1) 520ms both;
+}
+.siq-splash__progress {
+  position: absolute;
+  bottom: calc(88px + env(safe-area-inset-bottom, 0px));
+  width: 140px;
+  height: 2px;
+  background: ${theme.surfaceAlt};
+  border-radius: 2px;
+  overflow: hidden;
+}
+.siq-splash__track {
+  width: 36%;
+  height: 100%;
+  background: linear-gradient(90deg, ${alpha(theme.cyan, 0)}, ${theme.cyan});
+  animation: siq-splash-track 1500ms cubic-bezier(.55, 0, .45, 1) infinite;
+}
+.siq-splash__caption {
+  position: absolute;
+  bottom: calc(44px + env(safe-area-inset-bottom, 0px));
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: ${theme.textSubtle};
+}
+@keyframes siq-splash-glow {
+  0%, 100% { opacity: .32; transform: scale(1); }
+  50% { opacity: .72; transform: scale(1.1); }
+}
+@keyframes siq-splash-tile {
+  0% { opacity: 0; transform: scale(.8) rotate(-6deg); }
+  47% { opacity: 1; transform: scale(1.05) rotate(1.5deg); }
+  76% { transform: scale(.99) rotate(0deg); }
+  100% { opacity: 1; transform: scale(1) rotate(0deg); }
+}
+@keyframes siq-splash-halo {
+  0% { opacity: 0; transform: scale(.8); }
+  16% { opacity: .55; }
+  100% { opacity: 0; transform: scale(1.45); }
+}
+@keyframes siq-splash-draw {
+  0%, 14% { stroke-dashoffset: 260; }
+  52%, 100% { stroke-dashoffset: 0; }
+}
+@keyframes siq-splash-head {
+  0%, 14% { opacity: 0; offset-distance: 0%; }
+  20% { opacity: 1; }
+  52% { offset-distance: 100%; opacity: 1; }
+  66%, 100% { offset-distance: 100%; opacity: 0; }
+}
+@keyframes siq-splash-base {
+  0% { transform: scaleX(0); }
+  37%, 100% { transform: scaleX(1); }
+}
+@keyframes siq-splash-word {
+  0% { opacity: 0; transform: translateY(9px); }
+  37%, 100% { opacity: 1; transform: none; }
+}
+@keyframes siq-splash-sub {
+  0% { opacity: 0; letter-spacing: 6px; }
+  48%, 100% { opacity: 1; letter-spacing: 3px; }
+}
+@keyframes siq-splash-track {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(300%); }
+}
+${stillRules('.siq-splash--still')}
+@media (prefers-reduced-motion: reduce) {
+${stillRules('.siq-splash')}
+}
+@supports not (offset-path: path('M 0 0')) {
+  .siq-splash__head {
+    display: none;
+  }
+}
+`;
+}

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -258,6 +258,27 @@ export default defineConfig({
           functions: 80,
           branches: 70,
         },
+        'src/hooks/useSplashGate.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/hooks/useInitialDataReady.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/hooks/usePrefersReducedMotion.js': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
+        'src/utils/splashCss.js': { lines: 80, functions: 80, branches: 70 },
+        'src/components/mobile/SplashScreen.jsx': {
+          lines: 80,
+          functions: 80,
+          branches: 70,
+        },
       },
     },
   },


### PR DESCRIPTION
Closes #283

## What changed and why

Replaces the bare `Loading…` text on the mobile cold-start path with the animated SplitIQ splash from the approved design (concept 2a), gated on a 700 ms floor / 5000 ms ceiling so it neither flashes on a warm start nor traps you on a slow one.

### How it is put together

All the decision-making lives in coverage-included modules; `main.jsx` (which is coverage-excluded) keeps only composition:

| File | Role |
|---|---|
| `utils/splashCss.js` | Pure `splashCss(theme)` → CSS string. Nine namespaced `siq-splash-*` keyframes. |
| `hooks/useSplashGate.js` | The floor/ceiling/auth-fail state machine. Booleans in, boolean out — no react-query, no DOM. |
| `hooks/useInitialDataReady.js` | Self-unsubscribing react-query cache subscription; latches once and tears down. |
| `hooks/usePrefersReducedMotion.js` | Guarded `matchMedia`. |
| `components/mobile/SplashScreen.jsx` | The visual. No props. |

Three decisions worth flagging for review:

- **It overlays `MobileApp` rather than replacing it.** The tabs' fetches only start once `MobileApp` mounts, so it has to be mounted and fetching underneath — otherwise nothing would ever fetch and the splash would ride to the ceiling every time.
- **Readiness is a cache subscription, not `useIsFetching()`.** `useIsFetching` re-renders its host on every fetch start/stop for the process lifetime; hosted in `AuthGate` that means re-rendering the whole tree on every background refetch, forever. The subscription unsubscribes permanently once it latches. **Zero edits to `MobileApp` or any tab.**
- **`AuthGate` returns one flat shape across all three branches.** Returning a differently-shaped fragment per branch remounted the splash the moment the session resolved — React reconciles fragment children by index, so index 0 went `SplashScreen` → `SignOutButton`, tearing it down and replaying every entrance animation mid-flight. Measured 2 mounts before, 1 after.

## How to test manually

Open the app on a mobile viewport (or throttle the network). The splash should cover the boot, clear no sooner than 700 ms and no later than 5 s, and never re-appear when switching tabs. With OS-level reduced motion on, it should render fully-formed and still.

## Screenshots

Captured in Chromium at a Pixel 7 viewport against the production build — mid-loop, and the `prefers-reduced-motion` static end state.

| Animated (mid-loop) | Reduced motion (static end state) |
|---|---|
| Stroke drawn, head dot tracking the curve, glow pulsing, progress track scanning | Stroke complete, head dot and halo hidden, subtitle at rest, track empty |

## Notes for the reviewer

- **One new colour token.** `surfaceDeep: '#12121f'` — the tile gradient's second stop, which had no existing token (it sits between `bg` and `surfaceAlt` on the same ramp). Purely additive: renames nothing, no existing component reads it. `.design-sync/base.css` regenerated via `gen-css.mjs`, not hand-edited.
- **Two permitted colour literals** in `splashCss.js`: `rgba(0, 0, 0, .55)` and `rgba(255, 255, 255, .05)` on the tile's box-shadow. Neutral shadow/highlight alphas with no `THEME` token; inventing one would be worse. Every other colour, including the translucent cyans, derives from `THEME` through a module-private `alpha()` helper — proven by substitution tests rather than a hex grep.
- **`e2e/visual.spec.js` gains a one-line wait.** `toBeVisible()` ignores occlusion, so without it the three `mobile shell` baselines would capture the splash. No baselines should need regenerating — the `visual` project already sets `reducedMotion: 'reduce'` and `animations: 'disabled'`, and the splash unmounts atomically with no exit transition.
- **The head dot deliberately has no `cx`/`cy`.** `offset-path` composes as a pure translation, so setting them would double the offset and park the dot outside the viewBox — verified in Chromium (`cx=30 cy=88` → renders at `(60, 176)`). An `@supports not (offset-path: …)` block hides it on engines without motion-path support instead.
- **`setDismissed` during render** in `useSplashGate` is React's documented "adjust state during render" pattern, not a workaround — the `useEffect` form is a hard error under this repo's `react-hooks/set-state-in-effect`.
- **Known gap, pre-existing:** the five lines of prop wiring in `AuthGate` are untested, because `main.jsx` is coverage-excluded and not importable in jsdom (importing it runs `initSentry()` and `createRoot().render()` at module scope). An inverted flag there would show a bounded 5-second splash, and no test would catch it. Worth a follow-up to extract `AuthGate` into its own file and off the exclude list — deliberately not done here, as it would widen this PR into a refactor.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — 41 new tests; the `main.jsx` wiring gap is noted above
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser
- [x] Visual change: screenshots attached above
- [x] Stays inside the property boundary: colour hexes = #183 · box metrics = S6 · type = S-1 (see DESIGN.md)

On the property boundary: the boundary governs edits to existing styled lines, so three concurrent workstreams do not collide in the same lines. Every style here is on lines that did not exist before. Every colour reads from `THEME`, so #183's rename moves the splash mechanically like any other component; the one `theme.js` edit is additive; spacing and type live entirely inside the two new files for S6 and S-1 to retro-fit; and no existing styled line in any other file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6Px2NPhrf3bk21X4mYnYU

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6Px2NPhrf3bk21X4mYnYU)_