### PR TITLE
ci: have Update Visual Baselines commit the PNGs to the branch

### DIFF
--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -19,9 +19,29 @@ name: E2E — Web
 # For the visual suite that pinning is load-bearing in a second way: glyph
 # rasterisation differs between images, so a baseline generated anywhere other
 # than this exact image fails forever. That is what the `Update Visual
-# Baselines` job is for — run it from the Actions tab when a design change is
-# meant to move pixels, download the artifact, commit the PNGs. A bump of
-# @playwright/test can also require it.
+# Baselines` job is for — dispatch it from the Actions tab on the branch whose
+# design change is meant to move pixels, and it regenerates the PNGs and commits
+# them to that branch (#288). A bump of @playwright/test can also require it.
+#
+# Regenerating and committing are deliberately two jobs. The PNGs can only be
+# produced inside the container, but pushing from inside it is fragile —
+# actions/checkout silently falls back to a REST tarball when it cannot use git,
+# leaving no .git to commit into — so `Commit Visual Baselines` runs on a plain
+# runner and consumes the artifact. The artifact upload is therefore load-bearing
+# now, and is still the escape hatch if the push is refused.
+#
+# `contents: write` is scoped to that one job; everything else here is read-only,
+# and it refuses to push to main. It pushes with VISUAL_BASELINE_PAT (a
+# fine-grained PAT, this repo only, Contents: read+write) so that the push
+# retriggers this workflow and Playwright Visual re-runs against the new
+# baselines. Without that secret it falls back to GITHUB_TOKEN, which still
+# commits but never retriggers a workflow (see the note in
+# dependabot-maintenance.yml): the PNGs land, but the Visual check keeps showing
+# the previous run until something else pushes.
+#
+# What this does NOT do is decide whether the new screenshots are RIGHT. That
+# judgement belongs on the PR, reading the committed PNG diff — the job only
+# removes the clerical step of moving files.
 #
 # Path filtering is job-level (`changes` job + `if:`), not workflow-level
 # `on.paths` — see the note in ci-web.yml for why (required-check safety).
@@ -33,9 +53,14 @@ on:
   workflow_dispatch:
     inputs:
       update_baselines:
-        description: 'Regenerate the visual baselines and upload them as an artifact'
+        description: 'Regenerate the visual baselines and commit them to this branch'
         type: boolean
         default: false
+
+# Read-only floor for the whole workflow, so the one `contents: write` below is
+# an explicit, auditable exception rather than an inherited repo default.
+permissions:
+  contents: read
 
 concurrency:
   group: e2e-web-${{ github.ref }}
@@ -141,13 +166,63 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - run: npm ci
       # Rewriting a baseline reports the test as failed, which is not a failure
-      # of this job — the regenerated PNGs still have to be uploaded.
+      # of this job — the regenerated PNGs still have to leave the container.
       - run: npm run test:visual:update
         continue-on-error: true
         env:
           HOME: /root
+      # Both the handoff to `Commit Visual Baselines` and the manual fallback:
+      # if the push is ever refused, the zip is still downloadable from the run.
       - uses: actions/upload-artifact@v7
         with:
           name: visual-baselines
           path: web/e2e/visual.spec.js-snapshots/
           retention-days: 7
+
+  commit-baselines:
+    name: Commit Visual Baselines
+    # Deliberately NOT the Playwright container: this job only moves files, and a
+    # plain runner has a real git checkout with push credentials attached.
+    runs-on: ubuntu-latest
+    needs: visual-baselines
+    # A baseline commit must never land unreviewed on the default branch. The
+    # regeneration job above still runs and still uploads the artifact when
+    # dispatched on main — only the push is refused.
+    if: github.ref != 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Land on the branch itself, not the detached SHA, so there is
+          # something to push to.
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.VISUAL_BASELINE_PAT || secrets.GITHUB_TOKEN }}
+      # Overwrites in place; it does not delete. Retiring a baseline after its
+      # test is removed stays a manual edit.
+      - uses: actions/download-artifact@v8
+        with:
+          name: visual-baselines
+          path: web/e2e/visual.spec.js-snapshots/
+      - name: Commit and push the regenerated baselines
+        run: |
+          set -euo pipefail
+          snapshots=e2e/visual.spec.js-snapshots
+          # The regeneration step is continue-on-error, so refuse to commit an
+          # empty set rather than silently wiping the baselines.
+          if [ -z "$(find "$snapshots" -name '*.png' -print -quit)" ]; then
+            echo "::error::no baseline PNGs were produced — refusing to commit"
+            exit 1
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add "$snapshots"
+          if git diff --cached --quiet; then
+            echo "Baselines unchanged — nothing to commit."
+            exit 0
+          fi
+          git commit -m "test: regenerate visual baselines (run ${{ github.run_id }})" \
+                     -m "Generated by .github/workflows/e2e-web.yml from ${{ github.sha }}."
+          # Fast-forward only. If the branch moved while the container job ran,
+          # this fails loudly and the artifact remains the fallback. Never --force.
+          git push origin "HEAD:${{ github.ref_name }}"

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -39,6 +39,11 @@ name: E2E — Web
 # dependabot-maintenance.yml): the PNGs land, but the Visual check keeps showing
 # the previous run until something else pushes.
 #
+# The retrigger reaches this workflow through `pull_request`, not `push` — `on.push`
+# above is main-only — so the branch must have an open PR for the re-run to happen.
+# That is the normal case (baselines are regenerated on a branch already under
+# review), but a branch with no PR gets the commit and no re-run.
+#
 # What this does NOT do is decide whether the new screenshots are RIGHT. That
 # judgement belongs on the PR, reading the committed PNG diff — the job only
 # removes the clerical step of moving files.

--- a/web/e2e/visual.spec.js
+++ b/web/e2e/visual.spec.js
@@ -29,7 +29,10 @@
 //
 // BASELINES ARE GENERATED IN THE CI PLAYWRIGHT CONTAINER, never on a dev
 // machine — glyph rasterisation differs and a locally-generated baseline fails
-// forever. See the `visual-baselines` job in .github/workflows/e2e-web.yml, or:
+// forever. Dispatch `E2E — Web` on your branch with `update_baselines: true` and
+// it regenerates them and commits them to that branch (#288); reviewing the
+// resulting PNG diff on the PR is where "is this right?" gets decided. The
+// equivalent by hand, if you have a Docker daemon:
 //   docker run --rm -v "$PWD":/repo -w /repo/web -e HOME=/root -e CI=1 \
 //     mcr.microsoft.com/playwright:v1.62.1-noble \
 //     sh -c "npm ci && npm run test:visual:update"


### PR DESCRIPTION
Closes #288

## What changed and why

`Update Visual Baselines` now commits the regenerated screenshot baselines to the dispatched branch instead of stopping at an artifact — removing the manual download-unzip-commit step that #287 ran straight into. A *remote* agent session can't close that loop: the GitHub MCP tools expose no artifact-download call and there's no Docker daemon in the sandbox. (A local machine with Docker Desktop **can** reproduce the pinned image — verified during this PR, byte-for-byte against CI — so the constraint is on remote sessions specifically. The stronger argument stands regardless: it's the step most likely to be skipped, because Visual isn't a required check and a design PR is already green by the time you get there.)

### How it's built

Regeneration and the commit are **two jobs on purpose**. The PNGs can only be produced inside the pinned `mcr.microsoft.com/playwright:vX.Y.Z-noble` image, but pushing from inside it is fragile — `actions/checkout` falls back to a REST tarball when it can't use git, leaving no `.git` to commit into. This was a prediction when the PR was written; it is now **measured**: `git rev-parse HEAD` prints nothing usable inside that container. So the container job is unchanged, and a new `Commit Visual Baselines` job on a plain runner consumes the artifact — which stops being vestigial and becomes the handoff, while remaining the escape hatch if a push is ever refused.

Other guard rails: sanity-gates on at least one PNG before committing (the regeneration step is `continue-on-error`, so a broken upstream run must not wipe the baselines), no-ops cleanly when nothing moved, `git add` scoped to the snapshots dir, fast-forward push only — never `--force`.

This deliberately does **not** decide whether the new screenshots are *right*. That judgement stays on the PR, reading the committed PNG diff.

## ✅ Verified end-to-end

Run on a throwaway branch with a deliberate geometry change (extra copy on the login screen). The full loop:

1. **Reject** — `Playwright Visual` *fails* against the old baselines ([run 369](https://github.com/skizzy1986/erg-dashboard/actions/runs/32808546989))
2. **Regenerate + commit** — dispatch produces commit `e818b63` ([run 370](https://github.com/skizzy1986/erg-dashboard/actions/runs/32808552925))
3. **Accept** — the push retriggers CI and `Playwright Visual` *passes* against the new baselines ([run 371](https://github.com/skizzy1986/erg-dashboard/actions/runs/32808657559))

| DoD | Evidence |
|---|---|
| Commits and pushes to the dispatched branch | `e818b63` |
| Authored by the bot | `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` |
| Commit message names run id + head SHA | `test: regenerate visual baselines (run 32808552925)`, body cites `2f8432808d7d…` |
| Touches only snapshot PNGs | **exactly one file** — `login-visual-linux.png`, 10631 → 11823 bytes |
| Push retriggers the workflow | run 371 spawned 4s after the push; a `GITHUB_TOKEN` push spawns nothing |
| `contents: write` scoped to one job | container job's log shows `GITHUB_TOKEN Permissions: Contents: read` |
| Refuses `main` | both baseline jobs report *skipped* on every `pull_request` event |
| Artifact upload retained | attached to every dispatch run |

**No feedback loop:** on the retriggered run both baseline jobs report *skipped*, so the bot's own push cannot re-enter the commit job.

## Prerequisite (already done)

The job pushes with `VISUAL_BASELINE_PAT` — a fine-grained PAT, this repo only, Contents: read+write — so the push retriggers `e2e-web.yml`. A `GITHUB_TOKEN` push never retriggers a workflow (see `dependabot-maintenance.yml`). The workflow falls back to `GITHUB_TOKEN`, so it stays correct without the secret; it just wouldn't re-run CI.

One caveat now documented in the workflow header: the retrigger arrives via `pull_request`, not `push` (`on.push` is main-only), so the branch needs an **open PR** for the re-run. That's the normal case — baselines get regenerated on a branch already under review.

## Checklist

- [x] CI is green (lint, test, build) — plus 832 tests locally
- [x] Tests cover the change, or I've noted why they don't — **workflow YAML has no unit-test surface**; validated by YAML parse, `bash -n` on the push script, and the end-to-end run above
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no application code touched
- [x] Visual change: none — baselines untouched by this PR
- [x] Stays inside the property boundary — CI config and comments only