### PR TITLE
docs(e2e): document the Windows/Git Bash form of the baseline docker recipe

### DIFF
--- a/web/e2e/visual.spec.js
+++ b/web/e2e/visual.spec.js
@@ -36,6 +36,16 @@
 //   docker run --rm -v "$PWD":/repo -w /repo/web -e HOME=/root -e CI=1 \
 //     mcr.microsoft.com/playwright:v1.62.1-noble \
 //     sh -c "npm ci && npm run test:visual:update"
+//
+// That form is POSIX-shell only. Under Git Bash on Windows, MSYS rewrites the
+// container-side `/repo` into a Windows path before Docker ever sees it, so the
+// mount lands somewhere unintended — and `$PWD` compounds it when the checkout
+// path contains a space. Turn the rewriting off and pass a native path, quoting
+// the whole -v argument so the space survives:
+//   MSYS_NO_PATHCONV=1 docker run --rm -v "C:\path\to\erg-dashboard:/repo" \
+//     -w /repo/web -e HOME=/root -e CI=1 \
+//     mcr.microsoft.com/playwright:v1.62.1-noble \
+//     sh -c "npm ci && npm run test:visual:update"
 
 import { test, expect } from '@playwright/test';
 import { installAppFixtures, stubSupabase, seedSession } from './fixtures.js';


### PR DESCRIPTION
## What changed and why

The `docker run` recipe in `web/e2e/visual.spec.js` is the escape hatch for regenerating visual baselines outside CI — but it only works in a POSIX shell. Under Git Bash on Windows, MSYS rewrites the container-side `/repo` path before Docker ever sees it, and `$PWD` compounds the problem when the checkout path contains a space. So the one documented fallback fails on the platform most likely to need it.

This adds the working invocation **alongside** the original rather than replacing it, since the POSIX form is still correct on macOS/Linux:

```
MSYS_NO_PATHCONV=1 docker run --rm -v "C:\path\to\erg-dashboard:/repo" \
  -w /repo/web -e HOME=/root -e CI=1 \
  mcr.microsoft.com/playwright:v1.62.1-noble \
  sh -c "npm ci && npm run test:visual:update"
```

`MSYS_NO_PATHCONV=1` disables the path rewriting; the whole `-v` argument is quoted so a space in the path survives.

Found while verifying #288 — a Docker Desktop run on Windows reproduced CI's baselines byte-for-byte, but only after working out this invocation. Verified against a checkout whose path contains a space.

## How to test manually

On Windows/Git Bash, from the repo root, run the documented command with a real path. It should complete `npm ci` and the visual suite inside the container. On a clean checkout the nine PNGs under `web/e2e/visual.spec.js-snapshots/` must come back **unchanged** — that's the signal the local container matches CI and can be trusted to generate baselines.

## Note for whoever merges second

This touches the same comment block as **#289**, on lines immediately adjacent to the prose that PR rewrites. The two don't overlap, but they're close enough that git may flag a conflict depending on merge order. Whichever lands second may need a rebase — it's a comment, so resolution is trivial. Happy to rebase this one after #289 merges if that's easier.

## Checklist

- [ ] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — **comment-only change; no behaviour to test.** Prettier and ESLint pass on the file
- [x] `npm run build` passes locally — unaffected, no code touched
- [x] No unexpected console errors in the browser — no application code touched
- [x] Visual change: none — baselines untouched
- [x] Stays inside the property boundary — a comment; no colour, box-metric, or type changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01KscPrQ1EiuepxRbM9TWie3)_