### PR TITLE
chore(sessions): give every Claude Code session its own worktree

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 ﻿{
+  "worktree": { "baseRef": "fresh" },
   "hooks": {
     "SessionStart": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ web/.design-sync/node_modules
 # written by whatever Deno happens to be on a dev machine is noise, not a
 # reproducibility guarantee.
 deno.lock
+
+# Per-session git worktrees (EnterWorktree). Concurrent Claude Code sessions each
+# get their own checkout here, so two sessions cannot race on one working tree.
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,10 +515,41 @@ Rebase early and often; a branch that tracks `main` closely rarely conflicts. Ne
 to `#build` in Slack. Check `#build` to confirm a change landed correctly
 without needing to prompt Coach.
 
+### Concurrent sessions: one worktree each
+
+**Every Claude Code session works in its own git worktree.** Call `EnterWorktree`
+before the first edit — not as a rescue once a conflict appears.
+
+Sessions launched in the same directory share one working tree and one `HEAD`.
+There is no isolation between them: a `git checkout` in one session yanks the
+files out from under another mid-edit, and two sessions editing one file race on
+every write. This is not hypothetical. On **2026-08-25** three concurrent
+sessions — one on #279, one on #287, one on #291 — collided here. The tree
+changed branches four times in forty minutes, and one session's uncommitted work
+surfaced in another session's `git status` while a subagent was reading it.
+
+- **Start with `EnterWorktree`.** It cuts a new branch from a freshly-fetched
+  `origin/main` (`worktree.baseRef: "fresh"` in `.claude/settings.json`) — the
+  same rule as step 1 above.
+- **Continuing an open PR?** `EnterWorktree` always makes a *new* branch, so for
+  existing work use `git worktree add <path> <branch>` and then `EnterWorktree`
+  with `path`.
+- **Commit or stash before you switch.** A worktree switch does not carry
+  uncommitted changes across; they stay in the tree you left.
+- **One branch, one worktree** — git refuses to check the same branch out twice,
+  and that refusal is the constraint doing the real work.
+- **Run `npm install` in `web/` first.** A worktree is a fresh checkout with no
+  `node_modules`, so `npm test` / `lint` / `build` cannot run until you do.
+- Worktrees live in `.claude/worktrees/` and are gitignored.
+
+Check for company before assuming the tree is yours: the Claude Code session
+list shows which other sessions are running in this directory.
+
 ## Safety Constraints
 
 - Never push directly to main — always use feature branches; branch protection enforces this
 - Branch from a freshly-fetched `origin/main`; keep branches short-lived and rebase (not merge) to stay current — `--force-with-lease` only, never `--force`
+- Work in your own worktree (`EnterWorktree`) — never share a working tree with another running session
 - Never hardcode credentials — use `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
 - Never delete Supabase rows without confirming with the user first
 - Always run `npm run build` before marking a feature complete


### PR DESCRIPTION
## Why

Sessions launched in the same directory share one working tree and one `HEAD`, with no isolation between them.

On **2026-08-25** three concurrent sessions — one on #279, one on #287, one on #291 — collided in this repo. In forty minutes the tree changed branches four times (`fix/residual-theme-hexes` → `main` → `claude/mobile-app-design-adoption-92zgfw` → `fix/291-visual-comparator-threshold`), and one session's uncommitted work surfaced in another session's `git status` while a subagent was mid-read. Two of those sessions were writing to the same files. Nothing was lost, but that was luck rather than design.

`EnterWorktree` activates on **project instructions**, so writing the convention into `CLAUDE.md` is what makes future sessions self-isolate instead of discovering the collision the hard way.

## What changed

| File | Change |
|---|---|
| `CLAUDE.md` | New "Concurrent sessions: one worktree each" subsection under Change Procedure, plus a Safety Constraints bullet |
| `.claude/settings.json` | `worktree.baseRef: "fresh"` — a new worktree branches from `origin/main`, matching step 1 of the Change Procedure |
| `.gitignore` | Ignore `.claude/worktrees/` so per-session checkouts aren't untracked noise |

The doc covers the four traps that actually bite, each hit while writing this PR:

- **`EnterWorktree` always cuts a _new_ branch.** Continuing an open PR needs `git worktree add <path> <branch>` then `EnterWorktree` with `path`.
- **A switch doesn't carry uncommitted changes across** — they stay in the tree you left. Commit or stash first.
- **One branch, one worktree.** Git refuses to check the same branch out twice, and that refusal is the constraint doing the real work.
- **`npm install` in `web/` comes first.** A worktree is a fresh checkout with no `node_modules`, and `.husky/pre-push` runs the full vitest suite — so without it you cannot push at all.

## Verification

- `npx vitest run` — **832 passed, 67 files** (run in the worktree, via the pre-push hook; not bypassed)
- `settings.json` parses and all four hook groups are intact
- `.claude/worktrees/` confirmed matched by the new rule (`.gitignore:30`)
- Working tree clean after install + test run, so `node_modules/` and `test-results/` are already ignored

Docs and config only — no source touched, so `lint` / `format:check` / `test` scope (`web/src`, `web/scripts`) is unaffected.

## Note for review

`.claude/settings.json` has two hooks pinned to `/home/user/erg-dashboard`, a Linux path that doesn't exist on this machine — the `PostToolUse` eslint hook and the `Stop` uncommitted-changes warning. Both are silently dead here. The `Stop` one is the warning that would have flagged the uncommitted work left sitting in the shared tree. Out of scope for this PR; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
