### PR TITLE
fix(e2e): make the visual comparator able to see a colour change

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -112,4 +112,16 @@ export default [
       },
     },
   },
+  {
+    // Vitest globals for the script tests. Flat config merges, so console and
+    // process still come from the block above.
+    files: ['scripts/**/__tests__/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        describe: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+      },
+    },
+  },
 ];

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { SCREENSHOT_COMPARE } from './scripts/visual-tolerance.mjs';
 
 // E2E smoke tests build the app with a stub Supabase config and serve it via
 // `vite preview`. The auth gate is satisfied by seeding a fake session into
@@ -20,10 +21,18 @@ export default defineConfig({
   timeout: 30_000,
   expect: {
     timeout: 10_000,
-    // maxDiffPixels: 0 with the default per-pixel threshold — no tolerance for
-    // geometry drift (a padding nudge moves hundreds of pixels), some tolerance
-    // for anti-aliasing noise.
-    toHaveScreenshot: { animations: 'disabled', maxDiffPixels: 0 },
+    // Two knobs, not one. `threshold` is a per-pixel YIQ colour distance
+    // (Playwright default 0.2, allowance 35215 x threshold^2 = 1408.6) and
+    // decides whether a pixel counts as different at all; `maxDiffPixels`
+    // bounds how many flagged pixels are allowed. So maxDiffPixels: 0 at the
+    // default threshold is not strict — nothing ever gets flagged. #291 is the
+    // proof: repainting the whole viewport #08080d -> #3d0812 is a delta of
+    // 436.7, three times under the allowance, and updated zero baseline bytes.
+    // threshold: 0 is affordable because baselines are generated and compared
+    // in the same pinned container — at threshold 0 the stable baselines differ
+    // by zero pixels, not few. maxDiffPixels: 0 now equals Playwright's default
+    // and is kept as a statement of intent.
+    toHaveScreenshot: { animations: 'disabled', ...SCREENSHOT_COMPARE },
   },
   use: {
     baseURL: `http://localhost:${PORT}`,

--- a/web/scripts/__tests__/visual-tolerance.test.mjs
+++ b/web/scripts/__tests__/visual-tolerance.test.mjs
@@ -1,0 +1,80 @@
+import {
+  SCREENSHOT_COMPARE,
+  ONE_CHANNEL_LEVEL,
+  maxAdmittedDelta,
+  yiqDelta,
+} from '../visual-tolerance.mjs';
+
+describe('visual comparator tolerance', () => {
+  // Guards the pure-JS replica of pixelmatch's colorDelta against a
+  // transcription error in the YIQ coefficients. Every expected value here was
+  // measured in the pinned Playwright container, so a drifted formula shows up
+  // as a number mismatch rather than as a silently-passing visual suite.
+  it('reproduces the measured YIQ deltas', () => {
+    expect(yiqDelta('#08080d', '#3d0812')).toBeCloseTo(436.7, 1);
+    expect(yiqDelta('#08080d', '#6b6b8f')).toBeCloseTo(5361.8, 1);
+    expect(yiqDelta('#08080d', '#ffffff')).toBeCloseTo(30686.4, 1);
+    expect(yiqDelta('#0a0a0f', '#08080d')).toBeCloseTo(2.02, 2);
+    expect(yiqDelta('#000000', '#010101')).toBeCloseTo(0.5053, 4);
+    expect(yiqDelta('#000000', '#000001')).toBeCloseTo(0.0565, 4);
+  });
+
+  // #291 in executable form. At Playwright's default threshold of 0.2 the
+  // allowance is 35215 * 0.2^2 = 1408.6, which swallows the 436.7 delta of a
+  // whole-viewport repaint from #08080d to #3d0812 — so no pixel was ever
+  // flagged, maxDiffPixels: 0 never fired, and the run updated zero baseline
+  // bytes. Anyone restoring the default should read this first.
+  it('shows the default threshold admits the #291 repaint', () => {
+    expect(maxAdmittedDelta(0.2)).toBeGreaterThan(
+      yiqDelta('#08080d', '#3d0812')
+    );
+  });
+
+  // The actual guard, stated as a ceiling rather than a magic number: the
+  // configured threshold must not admit a delta as large as a one-level change
+  // in a single channel. This fails for 0.2, 0.05 and 0.01 alike. Asserting
+  // `threshold === 0` instead would be circular — it would restate the config
+  // rather than test what the config buys.
+  it('configures a threshold that admits less than one channel level', () => {
+    expect(maxAdmittedDelta(SCREENSHOT_COMPARE.threshold)).toBeLessThan(
+      ONE_CHANNEL_LEVEL
+    );
+  });
+
+  // A colour-token change that should move pixels cannot silently move none.
+  // Scoped deliberately to the allowance: pixelmatch also drops anti-aliased
+  // pixels from the count (includeAA: false), so clearing the allowance is
+  // necessary but not sufficient for an edge pixel. Flat grounds are unaffected.
+  // Literal hex on purpose: reading THEME here would couple this guard to
+  // web/src/constants/theme.js, which is being rewritten to var(--color-*)
+  // strings on a separate branch.
+  it('puts every colour change that should move pixels over the allowance', () => {
+    const shouldMovePixels = [
+      ['#08080d', '#3d0812'], // the #291 sentinel repaint
+      ['#0a0a0f', '#08080d'], // the MobileApp background drift already in the repo
+      ['#000000', '#000001'], // the smallest representable colour edit
+      ['#08080d', '#1a1a2e'], // a bg -> surface token swap
+    ];
+    for (const [a, b] of shouldMovePixels) {
+      expect(yiqDelta(a, b)).toBeGreaterThan(
+        maxAdmittedDelta(SCREENSHOT_COMPARE.threshold)
+      );
+    }
+  });
+
+  // The assertions above guard the constant; this one guards the wiring. A
+  // config that imported SCREENSHOT_COMPARE and then ignored it, or a project
+  // that overrode toHaveScreenshot downstream, would leave every other test in
+  // this file green while the real suite ran blind again. Dynamic import so the
+  // @playwright/test load is paid only here.
+  it('applies the shared options to the real Playwright config', async () => {
+    const { default: config } = await import('../../playwright.config.js');
+    expect(config.expect.toHaveScreenshot).toMatchObject(SCREENSHOT_COMPARE);
+  });
+
+  // The count bound is half the contract; a relaxed maxDiffPixels would let
+  // flagged pixels through even at threshold 0.
+  it('allows no differing pixels', () => {
+    expect(SCREENSHOT_COMPARE.maxDiffPixels).toBe(0);
+  });
+});

--- a/web/scripts/visual-tolerance.mjs
+++ b/web/scripts/visual-tolerance.mjs
@@ -1,0 +1,59 @@
+// Comparator options for the Playwright visual suite, plus the colour-distance
+// maths they are chosen against. Kept out of playwright.config.js so the
+// reasoning is testable: scripts/__tests__/visual-tolerance.test.mjs asserts the
+// configured threshold cannot admit a visible colour change (#291).
+//
+// The constants below are pixelmatch's. pixelmatch is vendored inside
+// playwright-core and is what toHaveScreenshot compares with. It is deliberately
+// NOT imported here (it is a transitive dep, not a declared one); the formula is
+// replicated instead, and the test pins the replica against deltas measured in
+// the pinned container. The pixelmatch version in play is fixed by
+// web/package-lock.json.
+
+// There is a THIRD knob, and it is not settable from playwright.config.js.
+// pixelmatch defaults to includeAA: false and Playwright does not override it, so
+// a pixel that exceeds the allowance is still dropped from the diff count when
+// pixelmatch's antialiased() heuristic classifies it as an edge pixel. Exceeding
+// the threshold is necessary, not sufficient. It does not affect the flat fills
+// this suite's grounds are made of - a solid region has no edge neighbours to
+// trip the heuristic - but assuming one knob where there were two is precisely
+// how #291 happened, so: there are three.
+
+export const SCREENSHOT_COMPARE = { threshold: 0, maxDiffPixels: 0 };
+
+function channels(hex) {
+  const h = hex.startsWith('#') ? hex.slice(1) : hex;
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+  ];
+}
+
+// pixelmatch's colorDelta for two fully opaque pixels: squared YIQ distance.
+export function yiqDelta(hexA, hexB) {
+  const [r1, g1, b1] = channels(hexA);
+  const [r2, g2, b2] = channels(hexB);
+  const y =
+    0.29889531 * (r1 - r2) + 0.58662247 * (g1 - g2) + 0.11448223 * (b1 - b2);
+  const i =
+    0.59597799 * (r1 - r2) - 0.2741761 * (g1 - g2) - 0.32180189 * (b1 - b2);
+  const q =
+    0.21147017 * (r1 - r2) - 0.52261711 * (g1 - g2) + 0.31114694 * (b1 - b2);
+  return 0.5053 * y * y + 0.299 * i * i + 0.1957 * q * q;
+}
+
+// The largest squared YIQ distance a given threshold still calls "identical".
+export function maxAdmittedDelta(threshold) {
+  return 35215 * threshold ** 2;
+}
+
+// The smallest colour edit that can be represented at all: a one-level change in
+// the single least-weighted channel. Blue wins at 0.0565, nine times smaller
+// than the 0.5053 of a one-level change in all three channels, so taking the
+// minimum is what makes the ceiling in the test mean what it says.
+export const ONE_CHANNEL_LEVEL = Math.min(
+  yiqDelta('#000000', '#010000'),
+  yiqDelta('#000000', '#000100'),
+  yiqDelta('#000000', '#000001')
+);


### PR DESCRIPTION
Closes #291.

## The bug

Changing `THEME.bg` to a visibly different colour and regenerating the baselines produced **nine byte-identical PNGs and a green run**.

`web/playwright.config.js` set `toHaveScreenshot: { animations: 'disabled', maxDiffPixels: 0 }`. That reads as maximally strict and isn't — there are two knobs:

- **`threshold`** (Playwright default **0.2**) is a *per-pixel* YIQ colour distance. It decides whether a pixel counts as different **at all**. pixelmatch's allowance is `35215 × threshold²` = **1408.6**.
- **`maxDiffPixels`** bounds **how many** flagged pixels are allowed.

Repainting the whole viewport `#08080d` → `#3d0812` is a delta of **436.7** — 3.2× *under* the allowance. No pixel was ever flagged, so `maxDiffPixels: 0` never fired. The suite was blind to exactly the class of change #183 will make.

The comment on that line claimed it gave "some tolerance for anti-aliasing noise". It tolerated a 52-grey-level repaint of every pixel on screen.

## Evidence

Reproduced four times in the pinned `mcr.microsoft.com/playwright:v1.62.1-noble` image, from a clean export of `main`.

**Before the fix**, with `THEME.bg = '#3d0812'`:

| Check | Result |
|---|---|
| `npm run test:visual:update` | 9 passed, all nine PNGs byte-identical (md5 unchanged) |
| DOM at screenshot time | `[role=alert]` present, `rgb(61, 8, 18)`, box 1280×848 |
| Live screenshot, decoded | **99.3% `#3d0812`** |
| Committed baseline, decoded | **99.3% `#08080d`** |

So the render was always correct; the *comparison* was at fault.

**After the fix:**

| Run | Result |
|---|---|
| Real `THEME.bg` | **9 passed** — the committed baselines still describe `main`, so none are regenerated here |
| Sentinel `THEME.bg` | **4 failed** — `error-fallback` (ratio 1.00), `login` (0.90), `mobile-log` (0.92), `mobile-recovery` (0.93) |

## The fix

Comparator options move into `web/scripts/visual-tolerance.mjs` so the reasoning is testable, guarded by a unit test in the **required** `Test & Coverage` job. (`Playwright Visual` is deliberately not a required check, so a guard living only there would enforce nothing.)

Two assertions carry the weight:

- **The ceiling** — `maxAdmittedDelta(threshold) < ONE_CHANNEL_LEVEL`. Stated as a *property*, not `threshold === 0`, which would be circular: whoever raised the threshold would update the assertion in the same edit and CI would stay green. `ONE_CHANNEL_LEVEL` is a one-level change in the least-weighted channel (blue, **0.0565**), so the guard fails for 0.2, 0.05, 0.01 **and 0.002**.
- **The wiring** — reads the *resolved* Playwright config. Without it, `{ ...SCREENSHOT_COMPARE, threshold: 0.2 }` would re-open this bug with every other test green. Verified it fails on exactly that bypass while the other five pass.

`web/scripts/` rather than `web/e2e/` because `npm run lint` and `npm run format:check` are both `src/ scripts/` — neither reaches `e2e/`, and a gate that is itself ungated is how this broke in the first place.

## Why `threshold: 0` is affordable

Baselines are generated and compared in the same pinned container. At `threshold: 0` the stable baselines differ by **zero** pixels — not few. There is no anti-aliasing noise to tolerate. `includeAA: false` (pixelmatch's default, which Playwright does not override) further excludes AA-classified edge pixels from the count, which blunts the glyph-rasterisation risk from a future `@playwright/test` bump; the remedy for that is the existing `Update Visual Baselines` dispatch job.

## Reported to #183, not fixed here

Five of the nine baselines still don't move when `THEME.bg` does, because the surface that dominates them is a hardcoded literal — `App.jsx:227` `'#08080d'`, `MobileApp.jsx:48` `'#0a0a0f'` (**already drifted** from the token; delta 2.02 against an allowance of 1408.6, so nothing could see it). Those are #183's lane per the property boundary and are written up there.

This PR touches no colour hex, no spacing, no font property, no baseline PNG, no workflow, and adds no dependency.

## Verification

- `npm test` — 68 files, 838 tests pass
- `npm run lint` — exit 0
- `npm run build` — exit 0
- Coverage unchanged (`web/scripts/**` is outside `coverage.include: ['src/**']`, consistent with the other CI-enforcement modules there)
- Guard falsified at `threshold` 0.002 / 0.01 / 0.2 — fails at each, passes at 0
- Wiring assertion falsified by breaking the spread — fails alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
