### PR TITLE
fix(schedule): teach getRosterMode the real roster — 8/6 regime, off-roster stretch, DST-safe arithmetic

### DIFF
--- a/web/src/constants/schedule.js
+++ b/web/src/constants/schedule.js
@@ -1,4 +1,24 @@
 import { THEME } from './theme.js';
+
+// ── ROSTER REGIMES — the swing geometry, in effect from a date ──
+// Each regime starts on its `from` date with the AWAY (FIFO) block,
+// then alternates away→home every cycle. Ordered oldest→newest; the
+// LATEST regime whose `from` is on or before a date governs it.
+// Dates before the first regime are deliberately NOT extrapolated
+// backward (see getRosterMode) — Scott had an extra home week for
+// family before the original anchor.
+export const ROSTER_REGIMES = [
+  { from: '2026-06-23', awayDays: 7, homeDays: 7 }, // Tue 23 Jun — 7-on/7-off
+  { from: '2026-09-03', awayDays: 8, homeDays: 6 }, // Thu 3 Sep — fly Thu am, return Thu pm
+];
+
+// ── ROSTER OVERRIDES — one-off roster changes on top of the regime ─
+// The roster is not concrete; work and home demands move it. A keyed
+// date forces the mode for that ONE day, leaving the regime untouched.
+// Key = "YYYY-MM-DD", value = 'home' | 'fifo'. Mirrors SESSION_OVERRIDES.
+// e.g. '2026-09-08': 'home'  // came home early, family
+export const ROSTER_OVERRIDES = {};
+
 export const MICROCYCLE = {
   home: {
     label: 'HOME WEEK — Loading (PUSH)',

--- a/web/src/constants/schedule.js
+++ b/web/src/constants/schedule.js
@@ -7,8 +7,12 @@ import { THEME } from './theme.js';
 // Dates before the first regime are deliberately NOT extrapolated
 // backward (see getRosterMode) — Scott had an extra home week for
 // family before the original anchor.
+// A regime with a fixed `mode` is not a swing at all — it pins every day to
+// that mode until the next regime starts. Use it for off-roster stretches,
+// which a cycle cannot express without pretending they alternate.
 export const ROSTER_REGIMES = [
   { from: '2026-06-23', awayDays: 7, homeDays: 7 }, // Tue 23 Jun — 7-on/7-off
+  { from: '2026-08-07', mode: 'home' }, // Fri 7 Aug — off roster, home continuously
   { from: '2026-09-03', awayDays: 8, homeDays: 6 }, // Thu 3 Sep — fly Thu am, return Thu pm
 ];
 

--- a/web/src/utils/__tests__/schedule.test.js
+++ b/web/src/utils/__tests__/schedule.test.js
@@ -141,6 +141,32 @@ describe('getRosterMode — ROSTER_OVERRIDES', () => {
   });
 });
 
+describe('getRosterMode — invariants a mutant would otherwise survive', () => {
+  afterEach(() => {
+    const extra = ROSTER_REGIMES.findIndex((r) => r.from === '2027-03-01');
+    if (extra !== -1) ROSTER_REGIMES.splice(extra, 1);
+  });
+
+  // 1 May 2026 is 53 days BEFORE the first regime. Extrapolating the 7/7 cycle
+  // backward lands on an away week and would answer 'fifo'; refusing to
+  // extrapolate answers 'home'. The other pre-regime assertions happen to be
+  // 'home' under both, so this is the one that pins the invariant.
+  it('refuses to extrapolate the cycle backward past the first regime', () => {
+    expect(getRosterMode(d(2026, 5, 1))).toBe('home');
+    expect(getRosterMode(d(2026, 5, 12))).toBe('home');
+  });
+
+  // A home-pinned regime returns 'home' even if the mode branch is deleted,
+  // because the arithmetic degrades to NaN and falls through. Only a
+  // fifo-pinned one proves the branch is load-bearing.
+  it('honours a fifo-pinned regime, proving the mode branch is real', () => {
+    ROSTER_REGIMES.push({ from: '2027-03-01', mode: 'fifo' });
+    expect(getRosterMode(d(2027, 3, 1))).toBe('fifo');
+    expect(getRosterMode(d(2027, 3, 15))).toBe('fifo');
+    expect(getRosterMode(d(2027, 4, 20))).toBe('fifo');
+  });
+});
+
 describe('ROSTER_ANCHOR', () => {
   it('is derived from the first regime, so the geometry has one source', () => {
     const [y, m, day] = ROSTER_REGIMES[0].from.split('-').map(Number);

--- a/web/src/utils/__tests__/schedule.test.js
+++ b/web/src/utils/__tests__/schedule.test.js
@@ -43,9 +43,34 @@ describe('getRosterMode', () => {
   });
 });
 
+// Scott came off roster on Fri 7 Aug 2026 and stayed home as a carer until
+// returning to work on 3 Sep. A cycle cannot express that — left to the 7/7
+// regime the app called 13 of those 27 days FIFO and prescribed deload
+// sessions for days he was at home.
+describe('getRosterMode — off-roster stretch from Fri 7 Aug 2026', () => {
+  it('pins every day home from the off-roster date to the next regime', () => {
+    for (let day = 7; day <= 31; day++) {
+      expect(getRosterMode(d(2026, 8, day))).toBe('home');
+    }
+    expect(getRosterMode(d(2026, 9, 1))).toBe('home');
+    expect(getRosterMode(d(2026, 9, 2))).toBe('home');
+  });
+
+  it('does not alter the 7/7 regime before it', () => {
+    expect(getRosterMode(d(2026, 8, 6))).toBe('fifo'); // last 7/7 day
+    expect(getRosterMode(d(2026, 7, 7))).toBe('fifo');
+    expect(getRosterMode(d(2026, 7, 14))).toBe('home');
+  });
+
+  it('yields to the 8/6 regime the day it starts', () => {
+    expect(getRosterMode(d(2026, 9, 2))).toBe('home'); // still off roster
+    expect(getRosterMode(d(2026, 9, 3))).toBe('fifo'); // 8/6 takes over
+  });
+});
+
 describe('getRosterMode — 8/6 regime from Thu 3 Sep 2026', () => {
   it('resolves the regime boundary from the correct regime', () => {
-    expect(getRosterMode(d(2026, 9, 2))).toBe('fifo'); // last day under 7/7
+    expect(getRosterMode(d(2026, 9, 2))).toBe('home'); // last off-roster day
     expect(getRosterMode(d(2026, 9, 3))).toBe('fifo'); // first away day of 8/6
   });
 

--- a/web/src/utils/__tests__/schedule.test.js
+++ b/web/src/utils/__tests__/schedule.test.js
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { MICROCYCLE } from '../../constants/schedule.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  MICROCYCLE,
+  ROSTER_REGIMES,
+  ROSTER_OVERRIDES,
+} from '../../constants/schedule.js';
 import {
   getRosterMode,
   resolveDay,
@@ -36,6 +40,88 @@ describe('getRosterMode', () => {
   it('ignores time-of-day (date components only)', () => {
     expect(getRosterMode(d(2026, 6, 23, 23))).toBe('fifo');
     expect(getRosterMode(d(2026, 6, 22, 1))).toBe('home');
+  });
+});
+
+describe('getRosterMode — 8/6 regime from Thu 3 Sep 2026', () => {
+  it('resolves the regime boundary from the correct regime', () => {
+    expect(getRosterMode(d(2026, 9, 2))).toBe('fifo'); // last day under 7/7
+    expect(getRosterMode(d(2026, 9, 3))).toBe('fifo'); // first away day of 8/6
+  });
+
+  it('runs 8 away days then 6 home days — cycle 1', () => {
+    expect(getRosterMode(d(2026, 9, 3))).toBe('fifo'); // first away
+    expect(getRosterMode(d(2026, 9, 10))).toBe('fifo'); // last away (8th)
+    expect(getRosterMode(d(2026, 9, 11))).toBe('home'); // first home
+    expect(getRosterMode(d(2026, 9, 16))).toBe('home'); // last home (6th)
+  });
+
+  it('repeats the 14-day cycle — cycle 2', () => {
+    expect(getRosterMode(d(2026, 9, 17))).toBe('fifo');
+    expect(getRosterMode(d(2026, 9, 24))).toBe('fifo');
+    expect(getRosterMode(d(2026, 9, 25))).toBe('home');
+    expect(getRosterMode(d(2026, 9, 30))).toBe('home');
+  });
+
+  it('repeats the 14-day cycle — cycle 3', () => {
+    expect(getRosterMode(d(2026, 10, 1))).toBe('fifo');
+    expect(getRosterMode(d(2026, 10, 8))).toBe('fifo');
+    expect(getRosterMode(d(2026, 10, 9))).toBe('home');
+    expect(getRosterMode(d(2026, 10, 14))).toBe('home');
+  });
+
+  it('fixes the four days the 7/7 alternation got wrong', () => {
+    expect(getRosterMode(d(2026, 9, 8))).toBe('fifo'); // was home
+    expect(getRosterMode(d(2026, 9, 15))).toBe('home'); // was fifo
+    expect(getRosterMode(d(2026, 9, 22))).toBe('fifo'); // was home
+    expect(getRosterMode(d(2026, 9, 29))).toBe('home'); // was fifo
+  });
+
+  it('still ignores time-of-day under the new regime', () => {
+    expect(getRosterMode(d(2026, 9, 10, 23))).toBe('fifo');
+    expect(getRosterMode(d(2026, 9, 11, 1))).toBe('home');
+  });
+});
+
+describe('getRosterMode — ROSTER_OVERRIDES', () => {
+  afterEach(() => {
+    for (const k of Object.keys(ROSTER_OVERRIDES)) delete ROSTER_OVERRIDES[k];
+  });
+
+  it('ships empty', () => {
+    expect(ROSTER_OVERRIDES).toEqual({});
+  });
+
+  it('forces home on a day the regime computes as fifo', () => {
+    expect(getRosterMode(d(2026, 9, 8))).toBe('fifo');
+    ROSTER_OVERRIDES['2026-09-08'] = 'home';
+    expect(getRosterMode(d(2026, 9, 8))).toBe('home');
+  });
+
+  it('forces fifo on a day the regime computes as home', () => {
+    expect(getRosterMode(d(2026, 9, 15))).toBe('home');
+    ROSTER_OVERRIDES['2026-09-15'] = 'fifo';
+    expect(getRosterMode(d(2026, 9, 15))).toBe('fifo');
+  });
+
+  it('applies to that ONE day only', () => {
+    ROSTER_OVERRIDES['2026-09-15'] = 'fifo';
+    expect(getRosterMode(d(2026, 9, 14))).toBe('home');
+    expect(getRosterMode(d(2026, 9, 16))).toBe('home');
+  });
+
+  it('wins before the first regime, where the fallback would say home', () => {
+    ROSTER_OVERRIDES['2026-01-01'] = 'fifo';
+    expect(getRosterMode(d(2026, 1, 1))).toBe('fifo');
+  });
+});
+
+describe('ROSTER_ANCHOR', () => {
+  it('is derived from the first regime, so the geometry has one source', () => {
+    const [y, m, day] = ROSTER_REGIMES[0].from.split('-').map(Number);
+    expect(ROSTER_ANCHOR.getFullYear()).toBe(y);
+    expect(ROSTER_ANCHOR.getMonth()).toBe(m - 1);
+    expect(ROSTER_ANCHOR.getDate()).toBe(day);
   });
 });
 

--- a/web/src/utils/schedule.js
+++ b/web/src/utils/schedule.js
@@ -20,6 +20,15 @@ const regimeStart = (from) => {
   return new Date(y, m - 1, d);
 };
 
+// Day arithmetic goes through UTC. Two LOCAL midnights either side of a DST
+// transition are 23h or 25h apart, so (a - b) / 86400000 floors to the wrong
+// whole day and the cycle slips permanently. Sydney and Adelaide reproduce it;
+// Perth, Brisbane and CI (UTC) do not, so CI cannot catch it.
+const utcDay = (date) =>
+  Math.floor(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / 86400000
+  );
+
 const localISO = (date) =>
   date.getFullYear() +
   '-' +
@@ -40,7 +49,7 @@ export function getRosterMode(date) {
   if (!regime) return 'home'; // before the first regime = current home week
   if (regime.mode) return regime.mode; // off-roster stretch, not a swing
   const cycle = regime.awayDays + regime.homeDays;
-  const pos = Math.floor((d - regimeStart(regime.from)) / 86400000) % cycle;
+  const pos = (utcDay(d) - utcDay(regimeStart(regime.from))) % cycle;
   return pos < regime.awayDays ? 'fifo' : 'home';
 }
 

--- a/web/src/utils/schedule.js
+++ b/web/src/utils/schedule.js
@@ -38,6 +38,7 @@ export function getRosterMode(date) {
     if (regimeStart(r.from) <= d) regime = r;
   }
   if (!regime) return 'home'; // before the first regime = current home week
+  if (regime.mode) return regime.mode; // off-roster stretch, not a swing
   const cycle = regime.awayDays + regime.homeDays;
   const pos = Math.floor((d - regimeStart(regime.from)) / 86400000) % cycle;
   return pos < regime.awayDays ? 'fifo' : 'home';

--- a/web/src/utils/schedule.js
+++ b/web/src/utils/schedule.js
@@ -1,25 +1,46 @@
-import { MICROCYCLE } from '../constants/schedule.js';
+import {
+  MICROCYCLE,
+  ROSTER_REGIMES,
+  ROSTER_OVERRIDES,
+} from '../constants/schedule.js';
 
 // ── ROSTER AUTO-SWITCH — home vs FIFO by date ─────────────────
-// FIFO is 1wk-on/1wk-off. Anchor on a KNOWN boundary: Scott flies
-// out Tue 2026-06-23 = FIFO week starts. From there, alternate every
-// 7 days. Weeks are computed as whole-week offsets from the anchor.
-// NOTE: Scott had an extra home week for family before this, so we
-// DON'T extrapolate backward past the anchor — only forward from it.
-// If the roster pattern changes, update ROSTER_ANCHOR.
-export const ROSTER_ANCHOR = new Date(2026, 5, 23); // Tue 23 Jun 2026 — FIFO begins (fly out)
+// The swing geometry lives in ROSTER_REGIMES (constants/schedule.js):
+// each regime starts on its `from` date with the AWAY block and then
+// alternates away→home on a (awayDays + homeDays) cycle. Resolution
+// order: a ROSTER_OVERRIDES hit wins outright, else the latest regime
+// starting on or before the date governs.
+// NOTE: Scott had an extra home week for family before the first
+// regime, so we DON'T extrapolate backward past it — only forward.
+const localDay = (date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+const regimeStart = (from) => {
+  const [y, m, d] = from.split('-').map(Number);
+  return new Date(y, m - 1, d);
+};
+
+const localISO = (date) =>
+  date.getFullYear() +
+  '-' +
+  String(date.getMonth() + 1).padStart(2, '0') +
+  '-' +
+  String(date.getDate()).padStart(2, '0');
+
+export const ROSTER_ANCHOR = regimeStart(ROSTER_REGIMES[0].from); // Tue 23 Jun 2026 — FIFO begins (fly out)
+
 export function getRosterMode(date) {
-  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  const anchor = new Date(
-    ROSTER_ANCHOR.getFullYear(),
-    ROSTER_ANCHOR.getMonth(),
-    ROSTER_ANCHOR.getDate()
-  );
-  const daysDiff = Math.floor((d - anchor) / 86400000);
-  if (daysDiff < 0) return 'home'; // before the anchor = current home week
-  // From anchor: week 0 = FIFO, week 1 = home, week 2 = FIFO, ...
-  const weekNum = Math.floor(daysDiff / 7);
-  return weekNum % 2 === 0 ? 'fifo' : 'home';
+  const d = localDay(date);
+  const override = ROSTER_OVERRIDES[localISO(d)];
+  if (override) return override;
+  let regime = null;
+  for (const r of ROSTER_REGIMES) {
+    if (regimeStart(r.from) <= d) regime = r;
+  }
+  if (!regime) return 'home'; // before the first regime = current home week
+  const cycle = regime.awayDays + regime.homeDays;
+  const pos = Math.floor((d - regimeStart(regime.from)) / 86400000) % cycle;
+  return pos < regime.awayDays ? 'fifo' : 'home';
 }
 
 // ── SESSION OVERRIDES — one-off changes on top of the template ─


### PR DESCRIPTION
Closes #309

## What changed and why

`getRosterMode` computed home/FIFO from one anchor on a strict 7-on/7-off alternation; it now resolves through an ordered list of roster regimes with a date-keyed override map, and does its day arithmetic in UTC so a DST transition cannot slip the cycle.

It feeds `CalendarView.jsx:69,74` and `OverviewView.jsx:78`, so every wrong day was a wrong prescribed session — shown with no signal that the answer was computed rather than known.

### Three defects, three commits

| Commit | Defect | Impact |
|---|---|---|
| `555ff7d` | Roster is **8/6 from Thu 3 Sep 2026**, not 7/7 | 15 of 42 days wrong (35%), permanently — both cycles are 14 days so it never self-corrects |
| `1e57dc8` | **7 Aug – 2 Sep is off roster**, not a swing | 13 of 27 days wrong (48%) — FIFO deload prescribed for days at home with a rack |
| `f3be964` | **DST slips the cycle** | 39 wrong days in Sydney over 15 months |

### The model

`ROSTER_REGIMES` in `constants/schedule.js` — the latest regime starting on or before a date governs it:

| From | Geometry |
|---|---|
| 2026-06-23 | 7 away / 7 home |
| 2026-08-07 | fixed `mode: 'home'` — off roster |
| 2026-09-03 | 8 away / 6 home |

A regime carrying a fixed `mode` is not a swing — it pins every day until the next regime starts. A cycle cannot express "no cycle" without pretending the days alternate.

The roster varies with work and home demands, so `ROSTER_OVERRIDES` ships empty alongside it: a date-keyed map forcing one day's mode and leaving the regime untouched, mirroring the existing `SESSION_OVERRIDES` precedent. Recording a future roster change is a data edit, not a code change.

`ROSTER_ANCHOR` is now derived from the first regime rather than separately hardcoded, so the geometry has one source of truth. Signature unchanged; all three consumers untouched.

### The DST defect is worth reading twice

Day offsets were `Math.floor((localMidnight − localMidnight) / 86400000)`. Across a DST transition those are 23 or 25 hours apart, so the floor lands on the wrong whole day and **every subsequent day slips by one, permanently**. The repo's own suite reproduces it:

| Timezone | Before | After |
|---|---|---|
| Australia/Perth | 42 passed | 44 passed |
| **Australia/Sydney** | **1 failed** | 44 passed |
| **Australia/Adelaide** | **1 failed** | 44 passed |
| Australia/Brisbane | 42 passed | 44 passed |
| UTC — what CI runs | 42 passed | 44 passed |

**Inherited, not introduced** — the single-anchor version had identical arithmetic. But this PR rewrites exactly those lines, and a change whose whole promise is a truth table should not hold only in half the country. `Date.UTC` has no offset transitions.

Two mutation gaps were closed in the same commit: deleting the no-backward-extrapolation guard survived the suite (every pre-regime assertion happened to read `home` either way — `2026-05-01` now discriminates), and the `mode` branch survived deletion because a home-pinned regime degrades to `NaN` and falls through — a **fifo**-pinned regime proves it is load-bearing.

## How to test manually

Covered by CI, but the timezone dimension is not:

```bash
cd web
TZ=Australia/Sydney   npx vitest run src/utils/__tests__/schedule.test.js
TZ=Australia/Adelaide npx vitest run src/utils/__tests__/schedule.test.js
```

Both fail on `1e57dc8` and pass on `f3be964`.

## Verification

- **989 tests pass**, 78 files · lint clean · `format:check` clean · build clean
- Bundle **395.7 KB** of the 400 KB budget (4.3 KB headroom, unchanged by this PR)
- 8 timezones — Perth, Sydney, Adelaide, Brisbane, Auckland, New York, London, UTC — **44/44 tests pass in each**
- Day-by-day sweep, 1 Jan 2026 – 31 Dec 2028: **1096/1096 correct** in Perth, Sydney, Adelaide, Auckland and New York
- Legacy window 23 Jun – 6 Aug: **byte-identical** to previous behaviour; the only intentional divergence is the off-roster stretch
- Reviewed by `Code Reviewer` (APPROVE) and `Reality Checker` (fix-then-ship — its DST blocker is fixed here)

## Checklist

- [ ] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser
- [x] Visual change: none — pure date logic, no rendering touched
- [x] Stays inside the property boundary: no colour hex, no box metric, no type property

## Known gaps

- **CI runs UTC only, so it cannot fail on the DST defect.** No test was added that is structurally incapable of failing; the real guard is a DST timezone in the CI matrix, which is a workflow change outside this PR's scope. Tracked in #309.
- **`App.jsx:37-38` still describes the single-anchor model** ("anchored to `ROSTER_ANCHOR` (Tue 23 Jun 2026 = FIFO out)"). Left untouched deliberately — the scope boundary kept this PR out of `App.jsx`. Worth a docs follow-up.
- **The `2026-08-07` off-roster date is Scott's stated fact**, not something derivable from the repo. It rewrites 15 past days from `fifo` to `home`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELg8XSCMQDcQswH6Him6Af

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELg8XSCMQDcQswH6Him6Af)_