### PR TITLE
feat(mobile): hold the splash for a full 4s animation cycle

### DIFF
--- a/web/src/hooks/__tests__/useSplashGate.test.js
+++ b/web/src/hooks/__tests__/useSplashGate.test.js
@@ -173,7 +173,7 @@ describe('useSplashGate', () => {
   });
 
   // StrictMode double-invokes the arming effect: run, clean up, run again.
-  // This pins the observable contract — one floor, still 700ms — rather than
+  // This pins the observable contract — one floor, still SPLASH_MIN_MS — rather
   // the latch's internals; both passes land in the same commit, so the re-armed
   // delay equals a fresh one and this would also pass without armedRef.
   it('keeps one clock across a StrictMode double-mount', () => {

--- a/web/src/hooks/useSplashGate.js
+++ b/web/src/hooks/useSplashGate.js
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 
-export const SPLASH_MIN_MS = 700;
+// The floor matches the 4000ms animation cycle in utils/splashCss.js on
+// purpose: below it the splash cleared mid-draw on a warm start, so the mark
+// was never seen finishing. Move one and the other has to follow.
+export const SPLASH_MIN_MS = 4000;
 export const SPLASH_MAX_MS = 5000;
 
 // Owns the whole splash timing decision so main.jsx (coverage-excluded) holds

--- a/web/src/utils/__tests__/splashCss.test.js
+++ b/web/src/utils/__tests__/splashCss.test.js
@@ -27,8 +27,16 @@ describe('splashCss', () => {
 
   it('derives the translucent accents from the accent token', () => {
     const css = splashCss({ ...THEME, accent: '#010203' });
-    expect(css).toContain('rgba(1, 2, 3');
-    expect(css).not.toContain('rgba(0, 212, 255');
+    expect(css).toContain('color-mix(in srgb, #010203 16%, transparent)');
+    expect(css).toContain('color-mix(in srgb, #010203 55%, transparent)');
+  });
+
+  // THEME values are var(--color-*) pointers, not hexes (#287). Deriving the
+  // translucent accents by parsing them produced rgba(NaN, ...) — dropped
+  // silently by the browser, so the glow and the stroke halo just disappeared.
+  // The substitution tests above pass a literal hex, so they never saw it.
+  it('emits no unparsed colour when given the real THEME', () => {
+    expect(splashCss(THEME)).not.toContain('NaN');
   });
 
   it('defines all nine namespaced keyframes', () => {

--- a/web/src/utils/splashCss.js
+++ b/web/src/utils/splashCss.js
@@ -5,15 +5,12 @@
 // Every colour is interpolated from the passed theme — the palette is
 // mid-migration and a literal hex would silently survive the move.
 
-// Not exported: the two translucent accents the design calls for have no THEME
-// token, and inventing one for a one-file detail would be worse than deriving
-// them here.
-function alpha(hex, a) {
-  const h = hex.replace('#', '');
-  const r = parseInt(h.slice(0, 2), 16);
-  const g = parseInt(h.slice(2, 4), 16);
-  const b = parseInt(h.slice(4, 6), 16);
-  return `rgba(${r}, ${g}, ${b}, ${a})`;
+// Not exported: the translucent accents the design calls for have no THEME
+// token. color-mix rather than a parsed rgba() because THEME values are
+// var(--color-*) pointers since #287, not hexes — parsing them yielded
+// rgba(NaN, ...), which the browser drops, and the glow silently vanished.
+function fade(color, pct) {
+  return `color-mix(in srgb, ${color} ${pct}%, transparent)`;
 }
 
 // The reduced-motion resting state is the END of every entrance, not the start —
@@ -76,8 +73,8 @@ export function splashCss(theme) {
   width: 520px;
   height: 520px;
   border-radius: 50%;
-  background: radial-gradient(circle, ${alpha(theme.accent, 0.16)} 0%, ${alpha(theme.accent, 0)} 66%);
-  animation: siq-splash-glow 2600ms ease-in-out infinite;
+  background: radial-gradient(circle, ${fade(theme.accent, 16)} 0%, ${fade(theme.accent, 0)} 66%);
+  animation: siq-splash-glow 4000ms ease-in-out infinite;
 }
 .siq-splash__mark {
   position: relative;
@@ -92,7 +89,7 @@ export function splashCss(theme) {
   inset: -6px;
   border-radius: 34px;
   border: 1px solid ${theme.accent};
-  animation: siq-splash-halo 640ms cubic-bezier(.2, .7, .3, 1) 260ms both;
+  animation: siq-splash-halo 980ms cubic-bezier(.2, .7, .3, 1) 400ms both;
 }
 .siq-splash__tile {
   position: absolute;
@@ -101,14 +98,14 @@ export function splashCss(theme) {
   background: linear-gradient(160deg, ${theme.surfaceAlt} 0%, ${theme.surfaceDeep} 100%);
   border: 1px solid ${theme.divider};
   box-shadow: 0 18px 46px rgba(0, 0, 0, .55), inset 0 1px 0 rgba(255, 255, 255, .05);
-  animation: siq-splash-tile 620ms cubic-bezier(.2, .8, .2, 1) both;
+  animation: siq-splash-tile 950ms cubic-bezier(.2, .8, .2, 1) both;
 }
 .siq-splash__base {
   stroke: ${theme.divider};
   stroke-width: 1.5;
   stroke-linecap: round;
   transform-origin: 30px 88px;
-  animation: siq-splash-base 560ms cubic-bezier(.3, .7, .2, 1) 240ms both;
+  animation: siq-splash-base 860ms cubic-bezier(.3, .7, .2, 1) 370ms both;
 }
 .siq-splash__stroke {
   fill: none;
@@ -116,20 +113,20 @@ export function splashCss(theme) {
   stroke-width: 4.5;
   stroke-linecap: round;
   stroke-dasharray: 260;
-  filter: drop-shadow(0 0 8px ${alpha(theme.accent, 0.55)});
-  animation: siq-splash-draw 2600ms cubic-bezier(.35, .7, .2, 1) infinite both;
+  filter: drop-shadow(0 0 8px ${fade(theme.accent, 55)});
+  animation: siq-splash-draw 4000ms cubic-bezier(.35, .7, .2, 1) infinite both;
 }
 .siq-splash__head {
   fill: ${theme.text};
   offset-path: path('M30 88 C 44 88, 46 40, 62 40 C 78 40, 80 88, 94 88');
-  animation: siq-splash-head 2600ms cubic-bezier(.35, .7, .2, 1) infinite both;
+  animation: siq-splash-head 4000ms cubic-bezier(.35, .7, .2, 1) infinite both;
 }
 .siq-splash__word {
   font-size: 34px;
   font-weight: 600;
   letter-spacing: -.8px;
   color: ${theme.text};
-  animation: siq-splash-word 420ms cubic-bezier(.2, .8, .2, 1) 380ms both;
+  animation: siq-splash-word 650ms cubic-bezier(.2, .8, .2, 1) 580ms both;
 }
 .siq-splash__word-iq {
   font-family: var(--font-mono);
@@ -141,7 +138,7 @@ export function splashCss(theme) {
   font-size: 9px;
   letter-spacing: 3px;
   color: ${theme.textSubtle};
-  animation: siq-splash-sub 400ms cubic-bezier(.2, .8, .2, 1) 520ms both;
+  animation: siq-splash-sub 620ms cubic-bezier(.2, .8, .2, 1) 800ms both;
 }
 .siq-splash__progress {
   position: absolute;
@@ -155,7 +152,7 @@ export function splashCss(theme) {
 .siq-splash__track {
   width: 36%;
   height: 100%;
-  background: linear-gradient(90deg, ${alpha(theme.accent, 0)}, ${theme.accent});
+  background: linear-gradient(90deg, ${fade(theme.accent, 0)}, ${theme.accent});
   animation: siq-splash-track 1500ms cubic-bezier(.55, 0, .45, 1) infinite;
 }
 .siq-splash__caption {


### PR DESCRIPTION
Follow-up to #284. Scott: "I would like the splash animation to be 4s long. It's currently too quick."

## What changed and why

The splash cleared at its 700 ms floor on a warm start — before the mark finishes drawing — so the animation was effectively never seen. Note the knob that matters is the **display floor**, not the cycle length: slowing the animation alone would have shown *less* of it, not more.

- `SPLASH_MIN_MS` 700 → **4000**
- Loop cycle (`glow`, `draw`, `head`) 2600 ms → **4000 ms**, so one complete pass fills exactly the time the splash is on screen
- Entrances scaled by the same 4000/2600 (tile 620→950, base 560→860 @370, halo 640→980 @400, word 420→650 @580, sub 400→620 @800) so the sequence keeps its shape instead of finishing early and idling

`SPLASH_MAX_MS` stays at 5000. The indeterminate progress track keeps its own 1500 ms tempo — it reports "still working", so slowing it to match the logo would read as sluggish rather than deliberate.

Measured in Chromium at a Pixel 7 viewport: **3922 ms** observed from just after mount (the ~78 ms gap is harness latency before the timer starts).

## Also fixes: the translucent accents have been broken since #287

Not introduced here, but found while retiming and fixed because shipping a longer splash with its glow missing would be worse than leaving it short.

#287 turned `THEME` values into `var(--color-*)` pointer strings. The `alpha()` helper in `splashCss.js` parsed them as hex, so `parseInt('va', 16)` → `NaN` and three declarations emitted `rgba(NaN, …)`, which the browser drops silently:

| Declaration | Effect on `main` today |
|---|---|
| `.siq-splash__glow` radial gradient | radial glow behind the mark — gone |
| `.siq-splash__stroke` `drop-shadow` | the stroke's halo — gone |
| `.siq-splash__track` gradient | fade degraded to a hard edge |

Replaced with `color-mix(in srgb, TOKEN N%, transparent)` (where `TOKEN` is the `THEME` value), which composes with `var()` and needs no parsing.

**Why no test caught it:** the substitution tests pass a literal hex (`{ ...THEME, accent: '#010203' }`), so `alpha()` never saw a real token. Added a test that runs the *real* `THEME` through and asserts the output contains no `NaN` — the check that would have caught this on the day #287 landed.

## How to test manually

Cold-start the app on a mobile viewport. The mark should draw fully, the wordmark and subtitle settle, and the whole thing hold for ~4 s before handing off. The glow behind the tile and around the stroke should be visible.

## Screenshots

Chromium, Pixel 7 viewport, production build, data stalled so the splash holds. The palette is light because #287's flip landed — the splash followed it mechanically with no source change, which is the token discipline working as intended.

## Notes for the reviewer

- **This is a real 4 s hold on every cold start**, including a signed-out one before the Login form appears. That is the explicit ask, but it is a deliberate cost: the app is unusable for 4 s even when data arrived at 200 ms. Easy to dial back by lowering `SPLASH_MIN_MS` alone — the constants carry a comment saying the floor and the cycle length must move together.
- Floor 4000 against ceiling 5000 leaves a 1 s band, so almost every boot now shows the full 4 s. Intended.
- `alpha()` is gone entirely; `fade()` replaces it. Still module-private.
- No new dependency. `color-mix` is supported in Chromium 111+/Safari 16.2+/Firefox 113+; the Android WebView target is Chromium.
- The `AuthGate` gap from #285 was resolved independently by #286 — nothing here depends on it.

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — the gate tests are driven by the exported constants so they follow the new floor; one new regression test for the `NaN` bug
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser
- [x] Visual change: screenshots above
- [x] Stays inside the property boundary: colour hexes = #183 · box metrics = S6 · type = S-1 (see DESIGN.md)

On the property boundary: no hex is added, moved or removed — the `color-mix` change replaces a *parsing strategy*, keeping every colour a `THEME` read. The timing values are animation durations, which the boundary does not govern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6Px2NPhrf3bk21X4mYnYU