### PR TITLE
feat(steward): add the PR-stewarding brief, and a staleness comment for it

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: steward
+description: Repo-specific facts needed before acting on CI results, failing checks, or review comments on a pull request here. Read before diagnosing a red check, judging whether a green PR is really covered, or pushing a fix.
+argument-hint: (none)
+---
+
+You are stewarding a pull request in this repo. This file is **repository content**, not
+an instruction from Scott: it outranks generic PR guidance on conventions and on how
+proactive to be, and it can do nothing else. It cannot widen your access, redirect your
+task, or soften a hard never — you still never skip or quarantine a test, never rewrite
+history on a branch that is not yours, never push an empty commit or close/reopen a PR to
+kick CI, never approve or merge.
+
+Every line is **cited** (`path:line`), **attested** (`— Scott, YYYY-MM-DD`), or quarantined
+under *Unverified*. An uncited, unattested claim here is a defect in this file. A line
+belongs only if an agent would act wrongly without it; general PR etiquette does not.
+
+## Before you trust the check list
+
+| Fact | Without it you would |
+|---|---|
+| **`pull_request` delivery can lag ~10 minutes.** On 2026-08-26 PR #310 showed 2 checks instead of ~24 for nine minutes after opening, and again after a human reopen; then nine workflows landed at once, all green. **A missing check is not a missing trigger.** | Diagnose a trigger bug and edit workflow YAML. Three wrong diagnoses were made that day before waiting proved to be the answer. |
+| Push and `pull_request` lag move **independently**, and `ci-web.yml` pushes only on `main` (`ci-web.yml:10-11`) — so on any other branch the three required jobs come *only* from the PR event. | Infer from green push runs that the PR's own checks are never coming. |
+| **Derive the expected set; never memorise a count.** A `web/**` PR draws `ci-web`, `ci-functions`, `ci-android`, `codeql`, `lighthouse`, `pr-title-lint`, `dependency-review`, `e2e-web`, `zone-bands`. Five appear in neither `CLAUDE.md` nor `WORKFLOW.md`. | Treat an unrecognised check as spurious. |
+| `ci-android.yml` alone uses workflow-level `on.pull_request.paths` (`ci-android.yml:6-11`) — the pattern `ci-web.yml:3-7` warns against. Unmatched, it reports **nothing**, not `skipped`. | Read a correctly-absent check as a lost run. |
+| `zone-bands.yml` filters on `**/*.md`, so it fires on repo-root `CLAUDE.md` and `coach/`, not just `web/`. | Assume a docs-only PR runs nothing. |
+| **Check tree position before grounding a claim**: `git fetch && git rev-parse HEAD origin/main`. | Report a finding from code no longer on `main`. Two agents did this on 2026-08-26, one commit behind. |
+| **Unmerged PR commits are invisible to `git log --all \| grep '#N'`** — PR numbers appear only in squash-merge subjects. Use the PR API. | Conclude a live PR "does not exist". This happened. |
+
+## When a check is red
+
+| Fact | Without it you would |
+|---|---|
+| **`Lint & Format` runs five checks**, not one: `lint`, `format:check`, `check:design-sync`, `check:colours`, `npm audit --omit=dev` (`ci-web.yml:51-69`). | Run `npm run lint`, see green, call CI flaky. Read the failing **step**, not the job name. |
+| `check:colours` is a per-file, per-hex allowlist that **also fails on stale entries** (`web/scripts/check-colour-literals.mjs`). Tokenising an allowlisted hex without deleting its `ALLOWED` entry fails like a new violation. | Re-add the hex or hunt a phantom violation instead of deleting the entry. |
+| `check:design-sync` bundles **four independent assertions** (`web/scripts/check-design-sync-entry.mjs`): `componentSrcMap` paths resolve, the `.design-sync/entry.jsx` barrel bundles, contrast ratios in `conventions.md` recompute, every `.design-sync/` file has one owner. | Assume one cause. The message names which. |
+| `check:zones` matches phrasing, not only numbers (`web/scripts/check-zone-bands.mjs`). Bands stated without restating the CP they derive from fail **even when correct**. | "Fix" correct numbers instead of restating the CP. |
+| **CI runs UTC only.** Verified 2026-08-26: the suite failed under `Australia/Sydney` and `Australia/Adelaide`, passed under Perth, Brisbane, UTC. | Trust a green Test job on date, roster or schedule arithmetic. Reproduce under `TZ=Australia/Sydney` first. |
+| **Visual baselines** regenerate only via `workflow_dispatch` with `update_baselines: true`, on the branch that moved the pixels (`e2e-web.yml`). The commit job refuses `main` and empty sets, and without `VISUAL_BASELINE_PAT` the PNGs land but Visual never re-runs. | Hand-commit PNGs, or regenerate to hide a real regression. |
+
+## When every check is green
+
+Green is at its most misleading here.
+
+| Fact | Without it you would |
+|---|---|
+| **A job skipped by an `if:` reports `skipped`, which branch protection counts as passing** (`ci-web.yml:3-7`). A PR touching only `supabase/functions/**` skips all of `ci-web`, and so passes it. | Merge a green PR that had nothing run against its change. |
+| **`coach-chat` and `vitals-sync` have no automated verification.** `ci-functions.yml` tests only the two `vitals-import*` functions; Deno files sit outside `lint`/`format`, which are rooted at `web/`. Deployed `vitals-sync` had already drifted from source and "nothing in CI would ever have caught it" (`6904c18`). *Provisional — drop when coverage lands.* | Report "all green" on a `coach-chat` change. Say instead: **no automated check ran against this diff.** |
+| Branch protection requires **up-to-date branches**, and updating one re-runs CI from scratch. | Merge on a green that predates the update. |
+| Coverage thresholds ratchet upward only (`web/vite.config.js`). | Assume red `Test & Coverage` means a failing test. Every test can pass and the job still fail. |
+| Bundle budget is 400 KB gzipped with ~4 KB spare (`web/scripts/check-bundle-size.mjs:15`); nothing in `App.jsx` is lazy-loaded, so every import ships. `npm run size` runs inside **Build**. | Be surprised by a red Build that is not a compile error. |
+
+## When you push a fix
+
+| Fact | Without it you would |
+|---|---|
+| On a **Dependabot** PR never use `gh pr update-branch` — a `GITHUB_TOKEN` push never re-triggers required checks, so auto-merge stalls forever (`dependabot-maintenance.yml:8-11`). Comment `@dependabot rebase`. Actions is also barred from approving here; the attempt broke the 2026-07-02 run on PR #124 (`dependabot-auto-merge.yml:7-9`). | Permanently stall an armed auto-merge. |
+| Colour hexes, box metrics and type stay in **separate PRs** — see `DESIGN.md`. | Fix a `check:colours` failure and tidy the padding on the same line. |
+| The recurring defect here is **automation that exits 0 while doing nothing**: ESLint silently skipping `.jsx` (#227), two hooks passing while inert for months (#294, #296), the token seam dropping 67 tints. | Accept green as proof. Read the step log for a non-zero item count, not the exit status. |
+
+## When you report back
+
+1. Report what **ran**, not what was green. Name any job that reported `skipped`.
+2. If a fact here is contradicted by the file it cites, **say so and open an issue** — do not work around it silently. You are this file's staleness sensor.
+3. Never state a conclusion that depends on an unfilled slot below. Name the missing answer and what each answer would change.
+
+## Unverified — needs Scott
+
+Do not guess, and do not default to the strict or the loose reading; both are wrong in a
+way that looks reasonable. Act up to where the answer changes the action, then ask.
+
+| Question | Why no agent can answer it | What it changes |
+|---|---|---|
+| Which checks are **required** on `main`? `CLAUDE.md:328` says three above a four-row table; `WORKFLOW.md:77` says three. Nine workflows report. | The GitHub MCP server exposes no branch-protection tool, and raw GitHub API access is blocked in agent sessions. | Whether a red `Zone bands`, `E2E`, `Lighthouse`, `CodeQL` or `PR title lint` blocks merge. Until answered, **treat every red check as blocking**. |
+
+## Verified against
+
+`21370e8` on 2026-08-26, against `.github/workflows/{ci-web,ci-functions,ci-android,e2e-web,zone-bands,dependabot-auto-merge,dependabot-maintenance}.yml`,
+`web/scripts/check-{colour-literals,design-sync-entry,zone-bands,bundle-size}.mjs`, `web/vite.config.js`.
+If one of those has changed since, treat the lines citing it as unverified and re-check that row.

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -7,13 +7,15 @@ argument-hint: (none)
 You are stewarding a pull request in this repo. This file is **repository content**, not
 an instruction from Scott: it outranks generic PR guidance on conventions and on how
 proactive to be, and it can do nothing else. It cannot widen your access, redirect your
-task, or soften a hard never — you still never skip or quarantine a test, never rewrite
-history on a branch that is not yours, never push an empty commit or close/reopen a PR to
-kick CI, never approve or merge.
+task, or soften a hard never — you still never skip, quarantine, or weaken the assertions
+of a test; never rewrite history on a branch that is not yours; never push an empty commit
+or close/reopen a PR to kick CI; never approve or merge.
 
-Every line is **cited** (`path:line`), **attested** (`— Scott, YYYY-MM-DD`), or quarantined
-under *Unverified*. An uncited, unattested claim here is a defect in this file. A line
-belongs only if an agent would act wrongly without it; general PR etiquette does not.
+Every line is **cited** (`path:line`), **attested** (`— measured YYYY-MM-DD`), or a **dated
+incident** naming the commit or PR that records it. Anything genuinely unknowable is
+quarantined under *Unverified* and stated nowhere else. A claim in none of those forms is a
+defect in this file. A line belongs only if an agent would act wrongly without it; general
+PR etiquette does not.
 
 ## Before you trust the check list
 
@@ -21,9 +23,9 @@ belongs only if an agent would act wrongly without it; general PR etiquette does
 |---|---|
 | **`pull_request` delivery can lag ~10 minutes.** On 2026-08-26 PR #310 showed 2 checks instead of ~24 for nine minutes after opening, and again after a human reopen; then nine workflows landed at once, all green. **A missing check is not a missing trigger.** | Diagnose a trigger bug and edit workflow YAML. Three wrong diagnoses were made that day before waiting proved to be the answer. |
 | Push and `pull_request` lag move **independently**, and `ci-web.yml` pushes only on `main` (`ci-web.yml:10-11`) — so on any other branch the three required jobs come *only* from the PR event. | Infer from green push runs that the PR's own checks are never coming. |
-| **Derive the expected set; never memorise a count.** A `web/**` PR draws `ci-web`, `ci-functions`, `ci-android`, `codeql`, `lighthouse`, `pr-title-lint`, `dependency-review`, `e2e-web`, `zone-bands`. Five appear in neither `CLAUDE.md` nor `WORKFLOW.md`. | Treat an unrecognised check as spurious. |
+| **Derive the expected set from `.github/workflows/`; never memorise a count.** Over a dozen workflows report on a `web/**` PR, several of them (`labeler`, `add-to-project`, `dependabot-auto-merge`) with no path filter at all. `CLAUDE.md` and `WORKFLOW.md` between them name only four. | Treat an unrecognised check as spurious, or count against a list that was stale the day it was written. |
 | `ci-android.yml` alone uses workflow-level `on.pull_request.paths` (`ci-android.yml:6-11`) — the pattern `ci-web.yml:3-7` warns against. Unmatched, it reports **nothing**, not `skipped`. | Read a correctly-absent check as a lost run. |
-| `zone-bands.yml` filters on `**/*.md`, so it fires on repo-root `CLAUDE.md` and `coach/`, not just `web/`. | Assume a docs-only PR runs nothing. |
+| `zone-bands.yml` filters on `**/*.md` (`zone-bands.yml:22`), so it fires on repo-root `CLAUDE.md` and `coach/`, not just `web/`. | Assume a docs-only PR runs nothing. |
 | **Check tree position before grounding a claim**: `git fetch && git rev-parse HEAD origin/main`. | Report a finding from code no longer on `main`. Two agents did this on 2026-08-26, one commit behind. |
 | **Unmerged PR commits are invisible to `git log --all \| grep '#N'`** — PR numbers appear only in squash-merge subjects. Use the PR API. | Conclude a live PR "does not exist". This happened. |
 
@@ -31,8 +33,8 @@ belongs only if an agent would act wrongly without it; general PR etiquette does
 
 | Fact | Without it you would |
 |---|---|
-| **`Lint & Format` runs five checks**, not one: `lint`, `format:check`, `check:design-sync`, `check:colours`, `npm audit --omit=dev` (`ci-web.yml:51-69`). | Run `npm run lint`, see green, call CI flaky. Read the failing **step**, not the job name. |
-| `check:colours` is a per-file, per-hex allowlist that **also fails on stale entries** (`web/scripts/check-colour-literals.mjs`). Tokenising an allowlisted hex without deleting its `ALLOWED` entry fails like a new violation. | Re-add the hex or hunt a phantom violation instead of deleting the entry. |
+| **`Lint & Format` runs five checks**, not one: `lint`, `format:check`, `check:design-sync`, `check:colours`, `npm audit --omit=dev --audit-level=high` (`ci-web.yml:51-69`). | Run `npm run lint`, see green, call CI flaky. Read the failing **step**, not the job name. |
+| `check:colours` is a per-file, per-hex allowlist that **also fails on stale entries** (`web/scripts/check-colour-literals.mjs:204`). Tokenising an allowlisted hex without deleting its `ALLOWED` entry fails like a new violation. | Re-add the hex or hunt a phantom violation instead of deleting the entry. |
 | `check:design-sync` bundles **four independent assertions** (`web/scripts/check-design-sync-entry.mjs`): `componentSrcMap` paths resolve, the `.design-sync/entry.jsx` barrel bundles, contrast ratios in `conventions.md` recompute, every `.design-sync/` file has one owner. | Assume one cause. The message names which. |
 | `check:zones` matches phrasing, not only numbers (`web/scripts/check-zone-bands.mjs`). Bands stated without restating the CP they derive from fail **even when correct**. | "Fix" correct numbers instead of restating the CP. |
 | **CI runs UTC only.** Verified 2026-08-26: the suite failed under `Australia/Sydney` and `Australia/Adelaide`, passed under Perth, Brisbane, UTC. | Trust a green Test job on date, roster or schedule arithmetic. Reproduce under `TZ=Australia/Sydney` first. |
@@ -48,7 +50,7 @@ Green is at its most misleading here.
 | **`coach-chat` and `vitals-sync` have no automated verification.** `ci-functions.yml` tests only the two `vitals-import*` functions; Deno files sit outside `lint`/`format`, which are rooted at `web/`. Deployed `vitals-sync` had already drifted from source and "nothing in CI would ever have caught it" (`6904c18`). *Provisional — drop when coverage lands.* | Report "all green" on a `coach-chat` change. Say instead: **no automated check ran against this diff.** |
 | Branch protection requires **up-to-date branches**, and updating one re-runs CI from scratch. | Merge on a green that predates the update. |
 | Coverage thresholds ratchet upward only (`web/vite.config.js`). | Assume red `Test & Coverage` means a failing test. Every test can pass and the job still fail. |
-| Bundle budget is 400 KB gzipped with ~4 KB spare (`web/scripts/check-bundle-size.mjs:15`); nothing in `App.jsx` is lazy-loaded, so every import ships. `npm run size` runs inside **Build**. | Be surprised by a red Build that is not a compile error. |
+| Bundle budget is 400 KB gzipped (`web/scripts/check-bundle-size.mjs:15`) and the build sits at 395.7 KB — **4.3 KB spare** (— measured 2026-08-26). Nothing in `App.jsx` is lazy-loaded, so every import ships. `npm run size` runs inside **Build**. `CLAUDE.md:297` still claims ~40 KB; it is stale by an order of magnitude. | Be surprised by a red Build that is not a compile error. |
 
 ## When you push a fix
 
@@ -56,12 +58,12 @@ Green is at its most misleading here.
 |---|---|
 | On a **Dependabot** PR never use `gh pr update-branch` — a `GITHUB_TOKEN` push never re-triggers required checks, so auto-merge stalls forever (`dependabot-maintenance.yml:8-11`). Comment `@dependabot rebase`. Actions is also barred from approving here; the attempt broke the 2026-07-02 run on PR #124 (`dependabot-auto-merge.yml:7-9`). | Permanently stall an armed auto-merge. |
 | Colour hexes, box metrics and type stay in **separate PRs** — see `DESIGN.md`. | Fix a `check:colours` failure and tidy the padding on the same line. |
-| The recurring defect here is **automation that exits 0 while doing nothing**: ESLint silently skipping `.jsx` (#227), two hooks passing while inert for months (#294, #296), the token seam dropping 67 tints. | Accept green as proof. Read the step log for a non-zero item count, not the exit status. |
+| The recurring defect here is **automation that exits 0 while doing nothing**: ESLint silently skipping `.jsx` (`9800b58`), two hooks inert behind exit 0 for months (`d2d0bd4`), the token seam dropping 67 tints (`8ad2637`). | Accept green as proof. Read the step log for a non-zero item count, not the exit status. |
 
 ## When you report back
 
 1. Report what **ran**, not what was green. Name any job that reported `skipped`.
-2. If a fact here is contradicted by the file it cites, **say so and open an issue** — do not work around it silently. You are this file's staleness sensor.
+2. If a fact here is contradicted by the file it cites, **say so, and offer to open an issue** — do not work around it silently. You are this file's staleness sensor.
 3. Never state a conclusion that depends on an unfilled slot below. Name the missing answer and what each answer would change.
 
 ## Unverified — needs Scott
@@ -69,9 +71,9 @@ Green is at its most misleading here.
 Do not guess, and do not default to the strict or the loose reading; both are wrong in a
 way that looks reasonable. Act up to where the answer changes the action, then ask.
 
-| Question | Why no agent can answer it | What it changes |
+| Question | What the repo already says | What is genuinely open |
 |---|---|---|
-| Which checks are **required** on `main`? `CLAUDE.md:328` says three above a four-row table; `WORKFLOW.md:77` says three. Nine workflows report. | The GitHub MCP server exposes no branch-protection tool, and raw GitHub API access is blocked in agent sessions. | Whether a red `Zone bands`, `E2E`, `Lighthouse`, `CodeQL` or `PR title lint` blocks merge. Until answered, **treat every red check as blocking**. |
+| Which checks are **required** on `main`? | Four in-repo sources agree on **lint, test, build**: `ci-web.yml:4-5` ("Lint/Test/Build are REQUIRED status checks on main"), `dependabot-auto-merge.yml:3-4`, `CLAUDE.md:328`, `WORKFLOW.md:77`. Treat those three as required. | Whether protection has *since* added `Zone bands`, `E2E`, `Lighthouse`, `CodeQL` or `PR title lint`. No agent can read this: the GitHub MCP server exposes no branch-protection tool and raw API access is blocked. Until Scott confirms, **treat a red check from those five as blocking** rather than assuming it is advisory. |
 
 ## Verified against
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -31,8 +31,18 @@ jobs:
   steward-staleness:
     name: Flag steward skill staleness
     runs-on: ubuntu-latest
+    # Serialise per PR. Two rapid synchronize events (a push, then a
+    # force-push) would otherwise both read "no marker comment yet" and both
+    # create one. Not cancel-in-progress: the later run must still reconcile.
+    concurrency:
+      group: steward-staleness-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     steps:
+      # Advisory, so it must not be able to fail the PR: a thrown API error
+      # would render as a red check, and the skill it guards tells agents to
+      # treat a red check as blocking.
       - uses: actions/github-script@v9
+        continue-on-error: true
         with:
           script: |
             const SKILL = '.claude/skills/steward/SKILL.md';
@@ -47,15 +57,21 @@ jobs:
               (n) =>
                 n.startsWith('.github/workflows/') ||
                 /^web\/scripts\/check-.*\.mjs$/.test(n) ||
-                n === 'web/vite.config.js'
+                ['web/vite.config.js', 'CLAUDE.md', 'WORKFLOW.md', 'DESIGN.md'].includes(n)
             );
             if (cited.length === 0) return;
+            // Filenames are PR-author controlled and backticks are legal in a
+            // git path, so an unescaped name breaks out of the code span and
+            // injects markdown into a comment agents here read as input.
+            // Whitelist the path charset rather than escaping: it also covers
+            // newlines and raw HTML, and these paths only ever display.
+            const safe = (n) => n.replace(/[^A-Za-z0-9._/-]/g, '?');
             const marker = '<!-- steward-staleness -->';
             const body = [
               marker,
               `This PR touches ${cited.length} file(s) that \`${SKILL}\` cites:`,
               '',
-              ...cited.map((n) => `- \`${n}\``),
+              ...cited.map((n) => `- \`${safe(n)}\``),
               '',
               'If a change here contradicts a line in that skill, update the line and the',
               '`Verified against` block. If nothing it cites changed in substance, ignore this.',

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,3 +17,64 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
+
+  # .claude/skills/steward/SKILL.md states CI facts as citations into the
+  # workflows and check scripts. Those files move; the skill does not notice.
+  # A comment on the PR that breaks a fact reaches the one person who can fix
+  # it at the one moment re-verifying is cheap — a check would become a chore,
+  # and would go green on any edit to the skill, including one that left it
+  # wrong. Deliberately not a gate.
+  #
+  # No checkout: this workflow is pull_request_target, so it runs with write
+  # permissions against the base repo. Reading the changed-file list through
+  # the API means no PR-authored code is ever executed here.
+  steward-staleness:
+    name: Flag steward skill staleness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const SKILL = '.claude/skills/steward/SKILL.md';
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { ...context.repo, pull_number: context.issue.number, per_page: 100 }
+            );
+            const names = files.map((f) => f.filename);
+            // A PR already editing the skill is re-verifying by definition.
+            if (names.includes(SKILL)) return;
+            const cited = names.filter(
+              (n) =>
+                n.startsWith('.github/workflows/') ||
+                /^web\/scripts\/check-.*\.mjs$/.test(n) ||
+                n === 'web/vite.config.js'
+            );
+            if (cited.length === 0) return;
+            const marker = '<!-- steward-staleness -->';
+            const body = [
+              marker,
+              `This PR touches ${cited.length} file(s) that \`${SKILL}\` cites:`,
+              '',
+              ...cited.map((n) => `- \`${n}\``),
+              '',
+              'If a change here contradicts a line in that skill, update the line and the',
+              '`Verified against` block. If nothing it cites changed in substance, ignore this.',
+            ].join('\n');
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { ...context.repo, issue_number: context.issue.number, per_page: 100 }
+            );
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
Closes #314

## What changed and why

Adds `.claude/skills/steward/SKILL.md` — read automatically before an agent acts on CI or review events for a PR it owns — plus a `steward-staleness` job in `labeler.yml` that comments when a PR touches a file the skill cites.

Its whole value is the repo-specific facts that make an agent **confidently wrong**. Generic PR rules already cover etiquette; they cannot cover that CI runs UTC, or that a skipped job counts as passing.

Every scenario it addresses is a mistake made on 2026-08-26:

| Incident | Missing fact |
|---|---|
| Three wrong diagnoses of #310's missing checks | `pull_request` delivery lags ~10 min; a missing check is not a missing trigger |
| "PR #293 does not exist" | Unmerged PR commits are invisible to `git log \| grep '#N'` |
| "`splitiq-load.js:214-268` possibly fabricated" | The checkout was one commit behind |
| A DST bug shipped green | CI runs UTC only |

## Structure

Five tables, keyed to **when the fact bites** rather than by topic: before you trust the check list · when a check is red · when every check is green · when you push a fix · when you report back.

The load-bearing section is *when every check is green*, because that is where green misleads. A job skipped by an `if:` reports `skipped`, which branch protection counts as **passing** (`ci-web.yml:3-7`) — so a PR touching only `supabase/functions/**` passes `ci-web` with nothing having run. Combined with `coach-chat` and `vitals-sync` having no tests at all (#312), a fully green PR there is unverified. The skill says so in those words.

Every line is **cited** (`path:line`), **attested** with a measurement date, or a **dated incident** naming its commit. Anything genuinely unknowable sits in `Unverified` rather than being guessed.

## Review found real defects; all are fixed here

`Code Reviewer` approved; `Reality Checker` returned fix-then-ship. Both ran against `811a046`, and `3197038` closes everything.

**A security bug I introduced, confirmed live before fixing.** Filenames are PR-author controlled and a backtick is legal in a git path, so `` - `${n}` `` broke out of its code span:

```
.github/workflows/x`**INJECTED**`.yml   →   renders **INJECTED** as bold
```

No code execution — there is no shell step — but it injects markdown into a bot comment, and automation here reads PR comments as input. Fixed by whitelisting the path charset, which also covers newlines and raw HTML.

Two more in the same job: no concurrency guard (two rapid pushes could each create a comment), and **no `continue-on-error`** — an advisory job that throws renders red, and the skill it guards says treat red as blocking. It could have manufactured the confusion it exists to prevent.

**Three wrong facts in the skill itself:**

- It listed **nine** reporting workflows. Over a dozen report; `labeler`, `add-to-project` and `dependabot-auto-merge` have no path filter, and this PR adds another. A row headed *"never memorise a count"* should not have carried a list — it now states the derivation rule alone.
- It declared three evidence forms and used a fourth. Dated incidents are now admitted and cited (`9800b58`, `d2d0bd4`, `8ad2637`).
- Its `Unverified` row implied the required-check set was unknowable. **Four in-repo sources agree** on lint/test/build — `ci-web.yml:4-5` says it outright. Only later additions are genuinely open.

It also caught that the hard-nevers fenced *skip* and *quarantine* but not **weakening an assertion**, and that a bundle-headroom figure cited a constant that does not carry it.

## A live defect this surfaced

Chasing that citation found **`CLAUDE.md:297` claiming "~40 KB of headroom" against a real 4.3 KB** — stale by an order of magnitude, with `check-bundle-size.mjs:9` saying "~360 KB" against a real 395.7. Filed in #311.

## How to test manually

Not covered by CI — no test can assert what an agent does with a document. The acceptance criteria in #314 are the check, plus:

```bash
head -5 .claude/skills/steward/SKILL.md          # frontmatter matches the other six skills
grep -c '^# ' .claude/skills/steward/SKILL.md    # 0 — no H1
```

Each citation can be walked with `sed -n '<line>p' <path>`; all were verified twice, once by me and once by each judge.

## Verification

- 989 tests · lint · `format:check` · `check:design-sync` · `check:colours` · `check:zones` all clean
- Labeler JS validates as `actions/github-script` wraps it, and its filter was dry-run over hostile filenames, `CLAUDE.md`, `WORKFLOW.md`, `DESIGN.md`, and an ordinary `web/src/**` diff (correctly silent)
- No product code touched: `web/**` and `supabase/**` are untouched

## Checklist

- [ ] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — no product code; a document's effect is not unit-testable
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser
- [x] Visual change: none
- [x] Stays inside the property boundary: no colour hex, box metric or type property

## Known gaps

- **Size: 9.0 KB against the spec's 6 KB target.** Both judges independently ruled the criterion miscalibrated rather than the file — reaching 6 KB means cutting five or six rows each verified, repo-specific, and tied to a named incident. Line count is 82 of 130. Flagged rather than self-certified.
- **The `Unverified` slot needs Scott**: whether protection requires anything beyond lint/test/build. Two clicks in Settings → Branches; until then the skill treats those five checks as blocking.
- **`.github/workflows/**` is a broad filter** — a routine Actions-version bump will trigger the comment. Deliberately not a gate, but may prove noisy; easy to narrow later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELg8XSCMQDcQswH6Him6Af

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELg8XSCMQDcQswH6Him6Af)_