### PR TITLE
docs(steward): record what protects main, and make Zone bands requirable

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -13,7 +13,7 @@ or close/reopen a PR to kick CI; never approve or merge.
 
 Every line is **cited** (`path:line`), **attested** (`— measured YYYY-MM-DD`), or a **dated
 incident** naming the commit or PR that records it. Anything genuinely unknowable is
-quarantined under *Unverified* and stated nowhere else. A claim in none of those forms is a
+quarantined and marked as such rather than stated flat. A claim in none of those forms is a
 defect in this file. A line belongs only if an agent would act wrongly without it; general
 PR etiquette does not.
 
@@ -64,16 +64,26 @@ Green is at its most misleading here.
 
 1. Report what **ran**, not what was green. Name any job that reported `skipped`.
 2. If a fact here is contradicted by the file it cites, **say so, and offer to open an issue** — do not work around it silently. You are this file's staleness sensor.
-3. Never state a conclusion that depends on an unfilled slot below. Name the missing answer and what each answer would change.
+3. Name a **required** check by name when you say a PR is blocked. Three are required and the rest are advisory — see *What protects `main`* — so "CI is red" and "this cannot merge" are different claims.
 
-## Unverified — needs Scott
+## What protects `main`
 
-Do not guess, and do not default to the strict or the loose reading; both are wrong in a
-way that looks reasonable. Act up to where the answer changes the action, then ask.
+Read from the `main` ruleset — Rulesets, **not** classic branch protection, which is
+unconfigured (— confirmed by Scott 2026-08-28). Active, targeting the default branch, with
+an **empty bypass list**, so it applies to everyone including the repo owner. No agent can
+read this: the GitHub MCP server exposes no branch-protection tool and raw API access is
+blocked from agent sessions. Re-confirm with Scott rather than inferring it from a doc.
 
-| Question | What the repo already says | What is genuinely open |
-|---|---|---|
-| Which checks are **required** on `main`? | Four in-repo sources agree on **lint, test, build**: `ci-web.yml:4-5` ("Lint/Test/Build are REQUIRED status checks on main"), `dependabot-auto-merge.yml:3-4`, `CLAUDE.md:328`, `WORKFLOW.md:77`. Treat those three as required. | Whether protection has *since* added `Zone bands`, `E2E`, `Lighthouse`, `CodeQL` or `PR title lint`. No agent can read this: the GitHub MCP server exposes no branch-protection tool and raw API access is blocked. Until Scott confirms, **treat a red check from those five as blocking** rather than assuming it is advisory. |
+| | |
+|---|---|
+| Required status checks | **`Lint & Format`, `Test & Coverage`, `Build`** — those three, any source. Nothing else. |
+| Advisory — red does **not** block merge | `Zone bands`, `CodeQL`, `Lighthouse`, `Validate PR title`, `E2E`, `dependency review`, `Build Debug APK`. Still fix them; just do not report them as blocking. |
+| Also enforced | a PR before merging · branches up to date before merging · force pushes blocked **on `main` only**, so `--force-with-lease` on your own feature branch is fine |
+| Not enforced | linear history. Squash with `(#N)` is convention, not a gate. |
+
+**A required check can be satisfied by `skipped`** (`ci-web.yml:3-7`), so all three can be
+green having run nothing — see *When every check is green*. `CLAUDE.md:328`'s "three jobs"
+is correct; the four-row table under it wrongly lists `Zone bands` as a gate.
 
 ## Verified against
 

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -25,7 +25,7 @@ PR etiquette does not.
 | Push and `pull_request` lag move **independently**, and `ci-web.yml` pushes only on `main` (`ci-web.yml:10-11`) — so on any other branch ci-web's three required jobs come *only* from the PR event. | Infer from green push runs that the PR's own checks are never coming. |
 | **Derive the expected set from `.github/workflows/`; never memorise a count.** Over a dozen workflows report on a `web/**` PR, several of them (`labeler`, `add-to-project`, `dependabot-auto-merge`) with no path filter at all. `CLAUDE.md` and `WORKFLOW.md` between them name only four. | Treat an unrecognised check as spurious, or count against a list that was stale the day it was written. |
 | `ci-android.yml` alone uses workflow-level `on.pull_request.paths` (`ci-android.yml:6-11`) — the pattern `ci-web.yml:3-7` warns against. Unmatched, it reports **nothing**, not `skipped`. | Read a correctly-absent check as a lost run. |
-| `zone-bands.yml` filters on `**/*.md` (`zone-bands.yml:22`), so it fires on repo-root `CLAUDE.md` and `coach/`, not just `web/`. | Assume a docs-only PR runs nothing. |
+| `zone-bands.yml` filters on `**/*.md` (`zone-bands.yml:50`), so it fires on repo-root `CLAUDE.md` and `coach/`, not just `web/`. It reports `skipped` when unmatched. | Assume a docs-only PR runs nothing. |
 | **Check tree position before grounding a claim**: `git fetch && git rev-parse HEAD origin/main`. | Report a finding from code no longer on `main`. Two agents did this on 2026-08-26, one commit behind. |
 | **Unmerged PR commits are invisible to `git log --all \| grep '#N'`** — PR numbers appear only in squash-merge subjects. Use the PR API. | Conclude a live PR "does not exist". This happened. |
 
@@ -87,12 +87,12 @@ green having run nothing — see *When every check is green*. That applies harde
 functions, so on a `coach-chat` change it **runs, passes, and verifies nothing** (#312).
 Requiring it did not close that hole.
 
-**Two checks cannot safely be required** until they change shape. `zone-bands.yml` and
-`ci-android.yml` use workflow-level `on.pull_request.paths`, so on an unmatched PR they
-report *nothing* rather than `skipped` — and a required check that never reports leaves the
-PR at "Expected — waiting for status" forever. Requiring `Zone bands` would hang every
-code-only PR. Converting them to the `changes`-job pattern the other workflows use is what
-makes them requirable.
+**`Build Debug APK` cannot safely be required.** `ci-android.yml` still uses workflow-level
+`on.pull_request.paths`, so on an unmatched PR it reports *nothing* rather than `skipped` —
+and a required check that never reports leaves the PR at "Expected — waiting for status"
+forever. Converting it to the `changes`-job pattern is what would make it requirable;
+`zone-bands.yml` was converted that way for exactly this reason, so `Zone bands` is now
+safe to require even though it is still only advisory.
 
 `CLAUDE.md:328`'s four-row table lists `Zone bands` as a gate; it is advisory.
 

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -22,7 +22,7 @@ PR etiquette does not.
 | Fact | Without it you would |
 |---|---|
 | **`pull_request` delivery can lag ~10 minutes.** On 2026-08-26 PR #310 showed 2 checks instead of ~24 for nine minutes after opening, and again after a human reopen; then nine workflows landed at once, all green. **A missing check is not a missing trigger.** | Diagnose a trigger bug and edit workflow YAML. Three wrong diagnoses were made that day before waiting proved to be the answer. |
-| Push and `pull_request` lag move **independently**, and `ci-web.yml` pushes only on `main` (`ci-web.yml:10-11`) — so on any other branch the three required jobs come *only* from the PR event. | Infer from green push runs that the PR's own checks are never coming. |
+| Push and `pull_request` lag move **independently**, and `ci-web.yml` pushes only on `main` (`ci-web.yml:10-11`) — so on any other branch ci-web's three required jobs come *only* from the PR event. | Infer from green push runs that the PR's own checks are never coming. |
 | **Derive the expected set from `.github/workflows/`; never memorise a count.** Over a dozen workflows report on a `web/**` PR, several of them (`labeler`, `add-to-project`, `dependabot-auto-merge`) with no path filter at all. `CLAUDE.md` and `WORKFLOW.md` between them name only four. | Treat an unrecognised check as spurious, or count against a list that was stale the day it was written. |
 | `ci-android.yml` alone uses workflow-level `on.pull_request.paths` (`ci-android.yml:6-11`) — the pattern `ci-web.yml:3-7` warns against. Unmatched, it reports **nothing**, not `skipped`. | Read a correctly-absent check as a lost run. |
 | `zone-bands.yml` filters on `**/*.md` (`zone-bands.yml:22`), so it fires on repo-root `CLAUDE.md` and `coach/`, not just `web/`. | Assume a docs-only PR runs nothing. |
@@ -64,26 +64,37 @@ Green is at its most misleading here.
 
 1. Report what **ran**, not what was green. Name any job that reported `skipped`.
 2. If a fact here is contradicted by the file it cites, **say so, and offer to open an issue** — do not work around it silently. You are this file's staleness sensor.
-3. Name a **required** check by name when you say a PR is blocked. Three are required and the rest are advisory — see *What protects `main`* — so "CI is red" and "this cannot merge" are different claims.
+3. Name a **required** check by name when you say a PR is blocked. Seven are required and five are advisory — see *What protects `main`* — so "CI is red" and "this cannot merge" are different claims.
 
 ## What protects `main`
 
 Read from the `main` ruleset — Rulesets, **not** classic branch protection, which is
-unconfigured (— confirmed by Scott 2026-08-28). Active, targeting the default branch, with
+unconfigured (— confirmed by Scott 2026-08-28, required set expanded same day). Active, targeting the default branch, with
 an **empty bypass list**, so it applies to everyone including the repo owner. No agent can
 read this: the GitHub MCP server exposes no branch-protection tool and raw API access is
 blocked from agent sessions. Re-confirm with Scott rather than inferring it from a doc.
 
 | | |
 |---|---|
-| Required status checks | **`Lint & Format`, `Test & Coverage`, `Build`** — those three, any source. Nothing else. |
-| Advisory — red does **not** block merge | `Zone bands`, `CodeQL`, `Lighthouse`, `Validate PR title`, `E2E`, `dependency review`, `Build Debug APK`. Still fix them; just do not report them as blocking. |
+| Required status checks | **`Lint & Format`, `Test & Coverage`, `Build`, `CodeQL`, `Validate PR title (Conventional Commits)`, `Review dependency changes`, `Deno Tests`** — those seven, and nothing else. |
+| Advisory — red does **not** block merge | `Zone bands`, `Lighthouse`, `Playwright Smoke`, `Playwright Visual`, `Build Debug APK`. Still fix them; just do not report them as blocking. |
 | Also enforced | a PR before merging · branches up to date before merging · force pushes blocked **on `main` only**, so `--force-with-lease` on your own feature branch is fine |
 | Not enforced | linear history. Squash with `(#N)` is convention, not a gate. |
 
-**A required check can be satisfied by `skipped`** (`ci-web.yml:3-7`), so all three can be
-green having run nothing — see *When every check is green*. `CLAUDE.md:328`'s "three jobs"
-is correct; the four-row table under it wrongly lists `Zone bands` as a gate.
+**A required check can be satisfied by `skipped`** (`ci-web.yml:3-7`), so all seven can be
+green having run nothing — see *When every check is green*. That applies hardest to
+`Deno Tests`: it is required, but `ci-functions.yml` tests only the two `vitals-import*`
+functions, so on a `coach-chat` change it **runs, passes, and verifies nothing** (#312).
+Requiring it did not close that hole.
+
+**Two checks cannot safely be required** until they change shape. `zone-bands.yml` and
+`ci-android.yml` use workflow-level `on.pull_request.paths`, so on an unmatched PR they
+report *nothing* rather than `skipped` — and a required check that never reports leaves the
+PR at "Expected — waiting for status" forever. Requiring `Zone bands` would hang every
+code-only PR. Converting them to the `changes`-job pattern the other workflows use is what
+makes them requirable.
+
+`CLAUDE.md:328`'s four-row table lists `Zone bands` as a gate; it is advisory.
 
 ## Verified against
 

--- a/.github/workflows/zone-bands.yml
+++ b/.github/workflows/zone-bands.yml
@@ -15,27 +15,49 @@ name: Zone bands
 #
 # The script imports trainingConfig.js directly and has no third-party
 # dependencies, so this needs node and a checkout — no npm ci.
+#
+# Path filtering is at the JOB level, never workflow-level `on.paths`, for the
+# same reason ci-web.yml:3-7 gives: a workflow that never triggers reports
+# NOTHING, so as a required check it leaves the PR on "Expected — waiting for
+# status" forever, whereas a job skipped by an `if:` reports "skipped", which
+# branch protection counts as passing. Under the old `on.paths` form this check
+# could not be made required without hanging every PR that touched no markdown —
+# intermittently, since a PR carrying one .md would pass and the next would not.
 
 on:
   pull_request:
-    paths:
-      - '**/*.md'
-      - 'web/src/constants/trainingConfig.js'
-      - 'web/src/utils/pace.js'
-      - 'web/scripts/check-zone-bands.mjs'
-      - '.github/workflows/zone-bands.yml'
 
 permissions:
   contents: read
 
 concurrency:
-  group: zone-bands-${{ github.ref }}
+  group: zone-bands-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect zone-band inputs
+    runs-on: ubuntu-latest
+    outputs:
+      zones: ${{ steps.filter.outputs.zones }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            zones:
+              - '**/*.md'
+              - 'web/src/constants/trainingConfig.js'
+              - 'web/src/utils/pace.js'
+              - 'web/scripts/check-zone-bands.mjs'
+              - '.github/workflows/zone-bands.yml'
+
   check:
     name: Zone bands match derivePaceZones
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.zones == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7


### PR DESCRIPTION
Closes the `Unverified` slot #315 shipped with, and converts `zone-bands.yml` so the check it describes can actually be required.

**Scope note:** the conversion was originally deferred to a follow-up. It belongs here because it *invalidates a line this PR adds* — the skill would otherwise ship saying `Zone bands` cannot be required, and be wrong the moment the second PR merged. Landing them together keeps the file true at every commit.

## What protects `main`

Protection is a **Rulesets** entry named `main`, not classic branch protection — that page reads *"Classic branch protections have not been configured"*, which alone looks like `main` is unprotected. Active against the default branch with an **empty bypass list**, so it binds the repo owner too.

**Required — seven:** `Lint & Format` · `Test & Coverage` · `Build` · `CodeQL` · `Validate PR title` · `Review dependency changes` · `Deno Tests`

**Advisory:** `Zone bands` · `Lighthouse` · `Playwright Smoke` · `Playwright Visual` · `Build Debug APK`

Also on: a PR before merging, branches up to date, force pushes blocked **on `main` only**. **Linear history is not enforced** — squash is habit, not gate.

## The `zone-bands.yml` conversion

It used workflow-level `on.pull_request.paths`, so on a PR touching none of its inputs it reported **nothing** — not `skipped`. A required check that never reports leaves a PR on *"Expected — waiting for status"* indefinitely.

The failure would have been **intermittent, not obvious**: a PR carrying any `.md` passes, the next code-only PR hangs. The cause wouldn't have been visible from the PR that broke.

Now uses the `changes`-job pattern `ci-web.yml` and `ci-functions.yml` already use — path list moved verbatim into a `dorny/paths-filter` job, `check` gains `if: needs.changes.outputs.zones == 'true'`. Unmatched PRs report `skipped`, which branch protection counts as passing.

**The job name is deliberately unchanged.** `Zone bands match derivePaceZones` is the string that goes in the ruleset; renaming it would silently detach any requirement added later.

Concurrency also moves from `github.ref` to `head_ref || ref_name`, since `refs/pull/N/merge` and `refs/heads/<branch>` are different keys and wouldn't collapse if a push trigger is ever added.

`ci-android.yml` still has the old shape and is left alone — `Build Debug APK` remains unrequirable until it gets the same treatment.

## A nuance that looks like a fix and is not

`Deno Tests` is now required. But `ci-functions.yml` tests only the two `vitals-import*` functions, so on a `coach-chat` change it **runs, passes, and verifies nothing**. Requiring it did **not** close [#312](https://github.com/skizzy1986/erg-dashboard/issues/312).

Observed on this PR's own first run: **four of seven required checks were satisfied by `skipped`**. All correct — no web code, no edge functions — but it demonstrates that adding required checks raises the ceiling of what *can* block a merge, not the floor of what actually runs.

## The staleness rule fired inside the hour

`eb65fb9` recorded *"those three, any source. Nothing else."* True when written; wrong twelve minutes later when the ruleset was expanded. `5c19c75` corrects it. The mechanism working, and a fair warning about how fast that section rots.

One claim shipped in #315 becomes true rather than needing a fix: the skill says `ci-android.yml` *"alone"* uses workflow-level paths. That was **wrong when written** — `zone-bands.yml` did too. It is accurate now.

## A correction to #311

I filed [#311](https://github.com/skizzy1986/erg-dashboard/issues/311) claiming `CLAUDE.md:328`'s "three jobs" prose contradicted its four-row table, and proposed rewording **the prose**. Backwards: the prose was right; the table is wrong to list `Zone bands` as a gate. My proposed wording would have made the doc worse. Correcting separately on the issue.

## How to test manually

```bash
# the check still passes, script untouched
node web/scripts/check-zone-bands.mjs

# no workflow-level pull_request paths remain anywhere but ci-android
grep -A3 'pull_request:' .github/workflows/*.yml | grep -B1 paths
```

On this PR `Zone bands` should **run** (the diff has `.md`). The conversion's real proof is the next code-only PR, where it should report `skipped` rather than vanishing.

## Verification

- 990 tests · lint · `format:check` · `check:zones` clean; zone script passes over 286 markdown files
- `zone-bands.yml` parses; job name byte-identical to before; filter list moved verbatim
- `ci-android.yml` confirmed the only remaining workflow-level-`paths` user

## Checklist

- [ ] CI is green
- [x] Tests cover the change, or I've noted why they don't — docs plus a workflow trigger shape; the behaviour change is only observable in CI
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser
- [x] Visual change: none
- [x] Stays inside the property boundary: no colour hex, box metric or type property

## Known gaps

- **`ci-android.yml` not converted** — same one-line-shape change if you want `Build Debug APK` requirable.
- **`Zone bands` is still only advisory.** This makes it *safe* to require; adding it is a ruleset edit I can't make.
- **The protection section rots fastest of anything in the skill** — it describes settings no file in the repo carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELg8XSCMQDcQswH6Him6Af