### PR TITLE
ci(android): filter at the job level so Build Debug APK can be required

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -24,7 +24,7 @@ PR etiquette does not.
 | **`pull_request` delivery can lag ~10 minutes.** On 2026-08-26 PR #310 showed 2 checks instead of ~24 for nine minutes after opening, and again after a human reopen; then nine workflows landed at once, all green. **A missing check is not a missing trigger.** | Diagnose a trigger bug and edit workflow YAML. Three wrong diagnoses were made that day before waiting proved to be the answer. |
 | Push and `pull_request` lag move **independently**, and `ci-web.yml` pushes only on `main` (`ci-web.yml:10-11`) — so on any other branch ci-web's three required jobs come *only* from the PR event. | Infer from green push runs that the PR's own checks are never coming. |
 | **Derive the expected set from `.github/workflows/`; never memorise a count.** Over a dozen workflows report on a `web/**` PR, several of them (`labeler`, `add-to-project`, `dependabot-auto-merge`) with no path filter at all. `CLAUDE.md` and `WORKFLOW.md` between them name only four. | Treat an unrecognised check as spurious, or count against a list that was stale the day it was written. |
-| `ci-android.yml` alone uses workflow-level `on.pull_request.paths` (`ci-android.yml:6-11`) — the pattern `ci-web.yml:3-7` warns against. Unmatched, it reports **nothing**, not `skipped`. | Read a correctly-absent check as a lost run. |
+| **No workflow filters at the `on.pull_request.paths` level any more** — every one gates a `changes` job with a job-level `if:`, so an unmatched check reports `skipped`, never nothing (`ci-web.yml:3-7` explains why). If you ever see a check that simply is not there, suspect a reverted filter or an event that never arrived, not a skip. | Read a genuinely absent check as a skip, or a skip as absence. |
 | `zone-bands.yml` filters on `**/*.md` (`zone-bands.yml:50`), so it fires on repo-root `CLAUDE.md` and `coach/`, not just `web/`. It reports `skipped` when unmatched. | Assume a docs-only PR runs nothing. |
 | **Check tree position before grounding a claim**: `git fetch && git rev-parse HEAD origin/main`. | Report a finding from code no longer on `main`. Two agents did this on 2026-08-26, one commit behind. |
 | **Unmerged PR commits are invisible to `git log --all \| grep '#N'`** — PR numbers appear only in squash-merge subjects. Use the PR API. | Conclude a live PR "does not exist". This happened. |
@@ -87,12 +87,12 @@ green having run nothing — see *When every check is green*. That applies harde
 functions, so on a `coach-chat` change it **runs, passes, and verifies nothing** (#312).
 Requiring it did not close that hole.
 
-**`Build Debug APK` cannot safely be required.** `ci-android.yml` still uses workflow-level
-`on.pull_request.paths`, so on an unmatched PR it reports *nothing* rather than `skipped` —
-and a required check that never reports leaves the PR at "Expected — waiting for status"
-forever. Converting it to the `changes`-job pattern is what would make it requirable;
-`zone-bands.yml` was converted that way for exactly this reason, so `Zone bands` is now
-safe to require even though it is still only advisory.
+**Every reporting check is now safe to require.** `zone-bands.yml` and `ci-android.yml` both
+used workflow-level `on.pull_request.paths`, which reports *nothing* on an unmatched PR — and
+a required check that never reports strands the PR on "Expected — waiting for status". Worse,
+it would have failed *intermittently*: a PR touching a matched path passes, the next one
+hangs. Both now gate a `changes` job, so they report `skipped` instead. Adding either to the
+ruleset is a settings change with no code consequence.
 
 `CLAUDE.md:328`'s four-row table lists `Zone bands` as a gate; it is advisory.
 

--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -1,23 +1,44 @@
 name: CI — Android
 
+# Path filtering is at the JOB level, never workflow-level `on.paths`, for the
+# reason ci-web.yml:3-7 gives: a workflow that never triggers reports NOTHING,
+# so as a required check it strands the PR on "Expected — waiting for status",
+# whereas a job skipped by an `if:` reports "skipped", which branch protection
+# counts as passing. zone-bands.yml was converted for the same reason.
+
 on:
   push:
     branches: [main, 'claude/**', 'feature/**', 'fix/**']
   pull_request:
-    paths:
-      - 'web/android/**'
-      - 'web/capacitor.config.json'
-      - 'web/src/**'
-      - 'supabase/**'
 
 concurrency:
-  group: ci-android-${{ github.ref }}
+  group: ci-android-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Android inputs
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            android:
+              - 'web/android/**'
+              - 'web/capacitor.config.json'
+              - 'web/src/**'
+              - 'supabase/**'
+              - '.github/workflows/ci-android.yml'
+
   build-web:
     name: Build Web Assets
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v7
@@ -43,7 +64,8 @@ jobs:
   build-apk:
     name: Build Debug APK
     runs-on: ubuntu-latest
-    needs: build-web
+    needs: [changes, build-web]
+    if: needs.changes.outputs.android == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v7


### PR DESCRIPTION
Follow-up to #316, which did the same for `zone-bands.yml`. `ci-android.yml` was the last workflow using workflow-level `on.pull_request.paths`.

## The problem

On a PR touching none of its inputs, `ci-android.yml` reported **nothing** — not `skipped`. A required check that never reports strands the PR on *"Expected — waiting for status"*, so `Build Debug APK` could not be added to the ruleset.

**The failure would have been intermittent, which is worse than broken.** A PR touching `web/src/**` passes; the next docs-only PR hangs. The PR that breaks doesn't look like the cause — you'd be debugging the wrong change. Consistent failures get fixed; intermittent ones get lived with.

## The change

Adopts the pattern `ci-web.yml:3-7` documents and `ci-functions.yml` / `zone-bands.yml` already use. Path list moves verbatim into a `dorny/paths-filter` job; both jobs gain `if: needs.changes.outputs.android == 'true'`.

| | Before | After |
|---|---|---|
| `pull_request` | workflow-level `paths` | bare — job-level `if:` |
| `concurrency` | `github.ref` | `head_ref \|\| ref_name` |
| `changes` job | — | `Detect Android inputs` |
| `build-apk` `needs` | `build-web` | `[changes, build-web]` |

**`build-apk` needed `changes` in its `needs`, not just an `if:`.** A condition can only reference `needs.X` when `X` is an actual dependency — otherwise the expression evaluates empty and the job runs when it shouldn't. That reviews cleanly and misbehaves in CI, so it's worth stating rather than leaving as a silent detail.

**Both job names are unchanged.** `Build Web Assets` and `Build Debug APK` are the strings a ruleset entry binds to; renaming one would silently detach a requirement added later.

The concurrency change matters more here than in #316: this workflow has **both** a `push` and a `pull_request` trigger, so under `github.ref` it ran the whole suite twice per commit on agent branches instead of collapsing it.

Also adds `.github/workflows/ci-android.yml` to its own filter, matching the others, so a change to the workflow triggers the workflow.

## Skill updates

Two claims went stale with the change:

- The row naming `ci-android.yml` as the last workflow-level filterer now says **none** filter that way, and keeps the underlying trap as a diagnostic — an absent check is not a skipped one, and confusing the two is how you chase a phantom trigger bug.
- The requirability paragraph no longer excludes `Build Debug APK`.

## Why require it at all

You said you plan to use the APK regularly. That's the test: a check earns a gate when its failure costs something. A broken Android build previously cost nothing because nothing enforced it — that changes if the APK is a real artifact.

## How to test manually

```bash
# no workflow-level pull_request paths remain anywhere
for f in .github/workflows/*.yml; do
  python3 -c "
import yaml
d=yaml.safe_load(open('$f')); t=d.get(True) or d.get('on')
pr=t.get('pull_request') if isinstance(t,dict) else None
if isinstance(pr,dict) and 'paths' in pr: print('STILL HAS: $f')"
done
```

On **this** PR both Android jobs should run — the diff touches `.github/workflows/ci-android.yml`, which is now in its own filter. The conversion's real proof is the next docs-only PR, where they should report `skipped` rather than vanishing.

## Verification

- 990 tests · lint · `format:check` · `check:zones` clean
- `ci-android.yml` parses; both job names byte-identical; filter list moved verbatim
- Confirmed zero workflow-level `pull_request.paths` remain across all 16 workflows
- Patch was dry-run against a copy before being applied, and fails loudly rather than half-applying if anchors move

## Checklist

- [ ] CI is green
- [x] Tests cover the change, or I've noted why they don't — workflow trigger shape; only observable in CI
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser
- [x] Visual change: none
- [x] Stays inside the property boundary: no colour hex, box metric or type property

## Known gaps

- **`Build Debug APK` is still advisory.** This makes it *safe* to require; adding it — alongside `Zone bands` — is a ruleset edit I can't make.
- Both Android jobs now run on this PR and on any `.github/workflows/ci-android.yml` change, which is intentional but slightly noisier than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELg8XSCMQDcQswH6Him6Af

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELg8XSCMQDcQswH6Him6Af)_