### PR TITLE
docs: correct the bundle headroom figure — 4.3 KB, not ~40 KB

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -50,7 +50,7 @@ Green is at its most misleading here.
 | **`coach-chat` and `vitals-sync` have no automated verification.** `ci-functions.yml` tests only the two `vitals-import*` functions; Deno files sit outside `lint`/`format`, which are rooted at `web/`. Deployed `vitals-sync` had already drifted from source and "nothing in CI would ever have caught it" (`6904c18`). *Provisional — drop when coverage lands.* | Report "all green" on a `coach-chat` change. Say instead: **no automated check ran against this diff.** |
 | Branch protection requires **up-to-date branches**, and updating one re-runs CI from scratch. | Merge on a green that predates the update. |
 | Coverage thresholds ratchet upward only (`web/vite.config.js`). | Assume red `Test & Coverage` means a failing test. Every test can pass and the job still fail. |
-| Bundle budget is 400 KB gzipped (`web/scripts/check-bundle-size.mjs:15`) and the build sits at 395.7 KB — **4.3 KB spare** (— measured 2026-08-26). Nothing in `App.jsx` is lazy-loaded, so every import ships. `npm run size` runs inside **Build**. `CLAUDE.md:297` still claims ~40 KB; it is stale by an order of magnitude. | Be surprised by a red Build that is not a compile error. |
+| Bundle budget is 400 KB gzipped (`web/scripts/check-bundle-size.mjs:15`) and the build sits at 395.7 KB — **4.3 KB spare** (— re-measured 2026-08-28, unchanged). Nothing in `App.jsx` is lazy-loaded, so every import ships. `npm run size` runs inside **Build**. `CLAUDE.md:296-301` now states this figure; the two agree as of that date. | Be surprised by a red Build that is not a compile error. |
 
 ## When you push a fix
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,8 +293,12 @@ request headers and is unaffected, but **every hand-rolled edge-function
 never sends the request — a bare `TypeError: Failed to fetch` on the client with only
 the OPTIONS in the edge logs. This silently killed the Coach tab (#301).
 
-Session Replay is deliberately **not** enabled — it costs ~35-50 KB gzip against
-~40 KB of headroom under the 400 KB budget in `web/scripts/check-bundle-size.mjs`.
+Session Replay is deliberately **not** enabled — it costs ~35-50 KB gzip, and there
+is nothing like that much room. The build sits at **395.7 KB against the 400 KB budget**
+in `web/scripts/check-bundle-size.mjs`, leaving **4.3 KB** of headroom (— measured
+2026-08-28). That is an order of magnitude less than Replay needs, so enabling it is a
+code-splitting job rather than a config flag: nothing in `App.jsx` is lazy-loaded, so
+every import ships on first paint. `npm run size` enforces this inside the **Build** job.
 
 Env vars are documented in `web/.env.example`. Runtime (`VITE_SENTRY_DSN`) and
 build-time (`SENTRY_ORG`/`SENTRY_PROJECT`/`SENTRY_URL`/`SENTRY_AUTH_TOKEN`) are set in


### PR DESCRIPTION
Related to #311 (the "check the fast-moving sections claim-by-claim" item), but fixed directly rather than folded in — it is a single verified number, not part of the CI-gate rewrite that issue is about.

## What changed and why

`CLAUDE.md:296` claimed **~40 KB** of headroom under the 400 KB gzip budget. The real figure is **4.3 KB** — stale by an order of magnitude, and stale in the direction that invites someone to spend room that is not there.

Re-measured on this branch via `npm run size`:

```
    391.7 KB  index-B7Lm0UPw.js
      1.5 KB  web-B-UxAMWU.js
      1.3 KB  web-D0ZZATOk.js
      0.5 KB  web-CVoKHV0s.js
      0.4 KB  web-DSxpgqtr.js
      0.3 KB  index-AgTDnBZY.css
  ──────────
    395.7 KB  total  (budget 400 KB)

✓ Within budget (4.3 KB headroom).
```

Unchanged from the 2026-08-26 reading already attested in the steward skill, so the two now agree on a measured number rather than one contradicting the other.

## Why it is not just a number swap

The sentence was making an argument, and the wrong number weakened it. Session Replay at ~35–50 KB read as a close call against ~40 KB of room — the kind of trade-off someone might reasonably revisit. Against 4.3 KB it is not close, and the actual blocker is structural: nothing in `App.jsx` is lazy-loaded, so every import ships on first paint. Enabling Replay is a code-splitting job, not a config flag. The rewrite says that, so the next person to consider it starts from the real constraint.

## Second file: the staleness sensor was itself stale

`.claude/skills/steward/SKILL.md:53` carried the clause that flagged this very defect:

> `CLAUDE.md:297` still claims ~40 KB; it is stale by an order of magnitude.

Once `CLAUDE.md` is fixed, that clause describes a state that no longer exists. Leaving it would make the file that exists to catch stale claims the stale claim — and its own rule 2 says a fact contradicted by the file it cites is a defect in that file. Updated to record that the two now agree, with the re-measurement date.

## How to test manually

```bash
cd web && npm run build && npm run size
```

Confirm the reported total and headroom match the figures now in `CLAUDE.md`.

## Verification

Ran the full `Lint & Format` gate — all five commands, not just `lint`:

| Check | Result |
|---|---|
| `lint` | clean |
| `format:check` | all matched files use Prettier style |
| `check:design-sync` | barrel bundles · all `componentSrcMap` paths resolve · 1 contrast claim recomputes · 49 files owned |
| `check:zones` | 4 published bands across 286 tracked markdown files match `derivePaceZones` |
| `npm run build` + `npm run size` | exit 0, within budget |

`check:zones` and `check:design-sync` are reported with their item counts rather than their exit status, per the standing note that the recurring defect here is automation that exits 0 while doing nothing.

## Expected CI shape

Docs-only, no `web/**` paths touched — so `Lint & Format`, `Test & Coverage`, `Build` and `Deno Tests` should all report **`skipped`**, which branch protection counts as passing. `Zone bands` **should run**, since `zone-bands.yml` filters on `**/*.md` and this PR edits two. Treat a green here as "nothing ran against the diff except the zone check", not as coverage.

## Note on the doctrine SHA

This edits `CLAUDE.md`, which is canonical doctrine, so `doctrine-sha-guard.yml` will open a tracking issue on merge and the nightly Routine will supersede `anchors.doctrine_sha` at 01:00 UTC and close it. Expected and self-maintaining — no action needed.

## Checklist

- [ ] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — prose only; the number it asserts is enforced by `npm run size` in the **Build** job
- [x] `npm run build` passes locally
- [x] No unexpected console errors in the browser — no runtime code touched
- [x] Visual change: none
- [x] Stays inside the property boundary: no colour hex, box metric or type property

---
_Generated by [Claude Code](https://claude.ai/code/session_019xQnrk6PEW6FZDBCtiexQT)_