### PR TITLE
ci(skills): guard the Context7-first rule on every workflow path

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -69,6 +69,11 @@ Then **read the named file**. An issue is a report, not a diagnosis.
 - `analyze_issue_with_seer` is available for root-cause analysis. It is slow and
   may be metered, so run it only on findings that survive the read, and say when
   you are about to.
+- The **Context7 first** rule binds the verification itself. If the cause turns
+  on how a library behaves — a react-query cache eviction, a Recharts prop, a
+  `supabase-js` error shape — resolve it through `resolve-library-id` →
+  `query-docs` before naming it as the cause. A diagnosis from memory is the
+  same guess as a diagnosis from the Sentry title, one level down.
 
 Drop anything you cannot locate in the code. A finding you cannot point at is a
 guess.

--- a/.claude/skills/daily/SKILL.md
+++ b/.claude/skills/daily/SKILL.md
@@ -68,5 +68,9 @@ These are the difference between a useful brief and a harmful one.
 - Never invent an estimate. An unsized task says "needs a look first".
 - If `web/node_modules` is missing, state that `cd web && npm install` is step
   zero on every code task — don't assume it.
+- **Context7 first** whenever sizing a task turns on a library fact — whether a
+  Vitest option exists, what a react-query upgrade changes. Resolve it
+  (`resolve-library-id` → `query-docs`) or say "needs a look first". A
+  remembered API is exactly how a 30-minute task becomes a two-hour one.
 - Re-rank from scratch every run. Never carry a previous list forward.
 - Six items is the ceiling, not the target. Three good ones beat six padded.

--- a/.claude/skills/erg-context.md
+++ b/.claude/skills/erg-context.md
@@ -45,6 +45,25 @@ Testing Library. Full briefing: `CLAUDE.md`.
 - Read back every write. Destructive changes require Scott's explicit approval.
 - Deeper patterns: `.claude/skills/supabase-patterns.md`.
 
+## Library documentation — Context7 first
+
+The Context7 MCP connector is live in every session. **Never answer a library
+question from memory, and never reach for WebSearch first.** Look it up:
+
+1. `resolve-library-id` (`libraryName`, `query`) → a `/org/repo` id
+2. `query-docs` (`libraryId`, `query`, optional `tokens`) → the docs
+
+This binds on any API surface, config key, or version-specific behaviour in
+React, Vite, Vitest, `@supabase/supabase-js`, `@testing-library/react`,
+Recharts, `@tanstack/react-query`, ESLint and Prettier. Fall back to WebSearch
+only when `resolve-library-id` returns nothing, or for tooling unlikely to be
+indexed (Husky, lint-staged, mathjs, vite-plugin-pwa).
+
+**Name the source for every library claim you make** — "Context7" or the URL —
+so a reader can tell a looked-up fact from a remembered one. An unsourced API
+claim is a guess, and this repo has already shipped bugs from confident guesses
+about library behaviour.
+
 ## Quality gates
 
 - `npm run build`, `npm test`, `npm run lint`, `npm run format:check` must pass.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -22,6 +22,10 @@ and wait for Scott.
 3. Pin the stage model via the Agent tool's per-call `model` parameter.
 4. For READ-ONLY stages: run `git status --short` before and after the spawn.
    Any new diff is a stage failure — report and stop.
+5. That preamble carries the **Context7 first** rule, so every subagent inherits
+   it automatically — no per-stage repetition needed. It binds you too, in the
+   stages you run yourself (5 and 7): resolve library facts through
+   `resolve-library-id` → `query-docs` before WebSearch, and name the source.
 
 ## Routing — classify the request first
 
@@ -41,6 +45,8 @@ focused question.
    Task: map the relevant files and functions, existing patterns to follow, the
    Supabase data surface involved, and risks/gotchas. Cite exact paths and line
    numbers. Do not propose a solution — that is the Spec stage's job.
+   Where the map touches a library boundary, settle the library's actual
+   behaviour with Context7 rather than asserting it — WebSearch is the fallback.
 
 2. **Story** — spawn `Product Manager` (model: sonnet, READ-ONLY).
    Task: one-screen user story — "As Scott, I want <capability>, so that
@@ -69,12 +75,16 @@ focused question.
      idempotent upsert on a natural key. Edge functions are Deno under
      `supabase/functions/<name>/` with a pure, separately-testable parser.
      Run the Supabase security/perf advisors after DDL. Patterns:
-     `.claude/skills/supabase-patterns.md`. Do not touch frontend.
+     `.claude/skills/supabase-patterns.md`. Check any `@supabase/supabase-js`
+     or Deno API you are not certain of against Context7 before writing against
+     it. Do not touch frontend.
    - *Frontend addendum:* match inline-style theming, the nav-tab structure,
      `supabaseClient` for data, the single `formatDate` helper. After editing
      any large file, run `npm run build` as a truncation check. Never hardcode
      the user; respect RLS. No new heavy deps unless the spec names them.
-     Layer rules: `.claude/skills/architecture.md`. Do not touch backend/migrations.
+     Layer rules: `.claude/skills/architecture.md`. Check any React, Recharts or
+     `@tanstack/react-query` API you are not certain of against Context7 before
+     writing against it. Do not touch backend/migrations.
 
 5. **Test verification** — YOU run `npm test` and the coverage report, then
    spawn `Test Results Analyzer` (model: sonnet, READ-ONLY) with the output and
@@ -85,7 +95,9 @@ focused question.
    - `Code Reviewer` (model: sonnet): judge the diff — correctness vs the spec,
      layer compliance, security (no hardcoded credentials, RLS considered, no
      unsanitised `dangerouslySetInnerHTML`), style (inline styles, no
-     TypeScript, no leftover `console.log`), tests present.
+     TypeScript, no leftover `console.log`), tests present. Flag any library
+     API the diff relies on that was asserted from memory where Context7 would
+     have settled it.
      Verdict: **APPROVE / REQUEST CHANGES** with numbered findings.
    - `Reality Checker` (model: opus): judge built-vs-story/spec. Evidence =
      test output, build logs, git diff — no screenshots required. Findings by

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -36,6 +36,11 @@ Current extraction targets: the `web/src/App.jsx` shell remainder,
    - Tests for the extracted module land in the SAME change, and the new file
      is covered by the coverage gate in `web/vite.config.js` (the ratchet only
      goes up).
+   - The move is verbatim, so a library lookup should rarely be needed. When one
+     is — a Vitest config key, a react-query import path the new file now needs —
+     the **Context7 first** rule in the preamble applies: look it up, don't
+     recall it. Guessing here silently changes behaviour a verbatim move promised
+     not to touch.
 
 3. Report: new file path, lines removed from the source file, build PASS/FAIL,
    tests PASS/FAIL. If the build fails, stop — never commit red.

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -26,10 +26,10 @@ Examples:
    the persona:
 
    > You are doing TECHNICAL research, not market intelligence. Investigate the
-   > topic against official documentation. Check Context7 first for stack
-   > libraries (React, Vite, Vitest, @supabase/supabase-js,
-   > @testing-library/react, Recharts): `resolve-library-id` then `query-docs`;
-   > fall back to WebSearch for anything unindexed. For APIs report: auth
+   > topic against official documentation. The **Context7 first** rule in the
+   > preamble above is the hard floor for this stage: `resolve-library-id` then
+   > `query-docs` for every stack library, WebSearch only for what Context7
+   > cannot resolve, and every claim carries its source. For APIs report: auth
    > method, the specific endpoints this project needs, rate limits, data
    > formats, and whether a Supabase Edge Function or client-side fetch fits.
    > For libraries report: React 18 + Vite compatibility, bundle-size impact,

--- a/.github/workflows/context7-rule.yml
+++ b/.github/workflows/context7-rule.yml
@@ -1,0 +1,63 @@
+name: Context7 rule
+
+# The Context7-first rule is what stops agents answering library questions from
+# memory. No CI runner can verify an agent actually called the connector — MCP
+# is invisible from here — so this guards the only thing that IS checkable and
+# does rot: whether the rule is still written down on every path into the repo.
+#
+# This is a separate workflow rather than another step in ci-web.yml's lint job,
+# and that is the whole point. ci-web.yml's `changes` filter is scoped to
+# 'web/**' (ci-web.yml:33-36), so a PR touching only .claude/skills/** or the
+# repo-root CLAUDE.md skips the entire lint job — the guard would never fire on
+# the files it exists to protect. That is exactly how the zone-band check missed
+# its third copy (zone-bands.yml:10-14): it lived in a web-scoped job. Repeating
+# the mistake for a second guard is not a trade worth making for one fewer file.
+#
+# The script imports nothing outside node builtins, so this needs a checkout and
+# node — no npm ci.
+#
+# Path filtering is at the JOB level, never workflow-level `on.paths`, for the
+# reason ci-web.yml:3-7 gives: a workflow that never triggers reports NOTHING,
+# so as a required check it strands the PR on "Expected — waiting for status",
+# whereas a job skipped by an `if:` reports "skipped", which branch protection
+# counts as passing.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: context7-rule-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect Context7 rule inputs
+    runs-on: ubuntu-latest
+    outputs:
+      rule: ${{ steps.filter.outputs.rule }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            rule:
+              - '.claude/skills/**'
+              - 'CLAUDE.md'
+              - 'web/scripts/check-context7.mjs'
+              - '.github/workflows/context7-rule.yml'
+
+  check:
+    name: Context7 rule reaches every workflow
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.rule == 'true'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - run: node web/scripts/check-context7.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,6 +337,7 @@ Every PR is gated by three GitHub Actions jobs that must pass before merge:
 | `Test & Coverage` | All Vitest tests pass; coverage meets the ratcheting thresholds in `web/vite.config.js` (`test.coverage.thresholds` — the **only** source of truth for the numbers), raised as extractions add tests |
 | `Build` | `npm run build` exits 0 (runs only after Test passes) |
 | `Zone bands` | Every rowing zone band published in any tracked `.md` recomputes against `derivePaceZones()` (`npm run check:zones`). **Path-filtered on `**/*.md`, not `web/**`** — the earlier version lived in the design-sync guard and so never fired on `coach/` or the repo-root `CLAUDE.md`, which is how the same wrong AT ceiling reached three documents (#266, #268, #275). |
+| `Context7 rule` | Every `.claude/skills/*/SKILL.md` is still reached by the Context7-first rule — directly, by inheriting `erg-context.md`, by delegating to a covered skill, or by a reasoned exemption (`npm run check:context7`). **Path-filtered on `.claude/skills/**` + `CLAUDE.md`, not `web/**`**, for the same reason `Zone bands` is: a guard scoped to `web/**` never fires on the files it protects. It cannot check that an agent obeyed the rule — MCP calls are invisible to a runner — only that the instruction still exists. |
 
 Coverage thresholds live in `web/vite.config.js` (`test.coverage.thresholds`) and
 **ratchet upward**. Scope is explicit — `coverage.all` + `include: ['src/**']`
@@ -466,6 +467,27 @@ library documentation. Use it before WebSearch for any library in the stack.
 **Fall back to WebSearch when:** `resolve-library-id` returns no results, or the
 library is a tooling utility unlikely to be indexed (Husky, lint-staged, mathjs,
 vite-plugin-pwa).
+
+**Where this is enforced.** The rule is not left to habit. The canonical wording
+lives once in `.claude/skills/erg-context.md` (*Library documentation — Context7
+first*), which is prepended verbatim to **every** pipeline subagent spawn — so
+`/orchestrate`, `/feature`, `/research` and `/refactor` all inherit it without
+repeating it. `/daily` and `/audit` spawn no erg-context agents, so each states
+the rule itself at the point it bites (sizing a task; naming a root cause).
+`/orchestrate` additionally makes it a review criterion: the `Code Reviewer`
+stage flags any library API the diff relies on that was asserted from memory.
+**Name the source for every library claim** — an unsourced API claim is a guess.
+
+**The mechanical half.** `npm run check:context7`
+(`web/scripts/check-context7.mjs`, its own `Context7 rule` workflow) fails if any
+tracked `SKILL.md` stops being reached by the rule, if the canonical block or its
+two tool names vanish from `erg-context.md`, or if this `### Context7` heading is
+removed. Coverage is transitive, so the wording still lives in exactly one place;
+a new skill that carries the rule by no route fails the check on arrival. The
+exemption list is in the script and a **stale** entry fails too — the same
+discipline `check:colours` applies to its allowlist. What it cannot do is verify
+a lookup happened: MCP calls are invisible to a CI runner. It guards the
+instruction, not the obedience.
 
 ### Supabase (coaching data model)
 

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "check:zones": "node scripts/check-zone-bands.mjs",
     "check:design-sync": "node scripts/check-design-sync-entry.mjs",
     "check:colours": "node scripts/check-colour-literals.mjs",
+    "check:context7": "node scripts/check-context7.mjs",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/web/scripts/check-context7.mjs
+++ b/web/scripts/check-context7.mjs
@@ -1,0 +1,172 @@
+// Guards the Context7-first rule against silent deletion.
+//
+// Context7 is an MCP connector. Nothing in CI can observe whether an agent
+// actually called resolve-library-id before answering — that is unobservable
+// from a runner, and this script does not pretend otherwise. What IS checkable,
+// and what actually rots, is whether the rule is still WRITTEN DOWN on every
+// path an agent takes into this repo.
+//
+// The failure mode being closed is a workflow that quietly stops carrying the
+// rule: a new SKILL.md lands without it, or the canonical block is edited away
+// and every downstream skill silently loses the instruction it was inheriting.
+// Both are invisible in review — nothing breaks, agents just go back to
+// answering library questions from memory.
+//
+// Coverage is transitive on purpose, so the rule stays stated ONCE:
+//
+//   canonical  .claude/skills/erg-context.md holds the wording
+//   inherits   the skill prepends erg-context.md to its spawns
+//   direct     the skill names Context7 itself (skills that spawn no agents)
+//   delegates  the skill points at another SKILL.md that is covered
+//   exempt     listed below with a reason, and fails if it becomes covered
+//
+//   npm run check:context7
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(webRoot, '..');
+
+const CANONICAL = '.claude/skills/erg-context.md';
+const HEADING = '## Library documentation — Context7 first';
+const TOOLS = ['resolve-library-id', 'query-docs'];
+
+// A skill belongs here only when carrying the rule would be WRONG, not merely
+// unnecessary. Remove an entry the moment its file gains coverage — a stale
+// exemption fails this check, exactly as a stale entry fails check:colours.
+const EXEMPT = {
+  '.claude/skills/steward/SKILL.md':
+    'Contract-bound: every line must be cited, attested, or a dated incident, ' +
+    'and it states that general PR etiquette does not belong. An uncited ' +
+    'Context7 reminder would violate the file rather than improve it.',
+};
+
+const read = (rel) => readFileSync(join(repoRoot, rel), 'utf8');
+const failures = [];
+
+// --- 1. The canonical block still exists, and still names both tools. -------
+
+if (!existsSync(join(repoRoot, CANONICAL))) {
+  console.error(`check:context7: ${CANONICAL} is missing.`);
+  process.exit(1);
+}
+
+const canonical = read(CANONICAL);
+if (!canonical.includes(HEADING)) {
+  failures.push(
+    `${CANONICAL} no longer contains the section "${HEADING}" — every skill ` +
+      'that inherits the rule is now inheriting nothing'
+  );
+}
+for (const tool of TOOLS) {
+  if (!canonical.includes(tool)) {
+    failures.push(
+      `${CANONICAL} no longer names \`${tool}\`; the lookup is not actionable ` +
+        'without both step names'
+    );
+  }
+}
+
+// CLAUDE.md is the session-wide entry point — it is read before any skill runs.
+if (!read('CLAUDE.md').includes('### Context7')) {
+  failures.push(
+    'CLAUDE.md no longer documents Context7 under its own heading, so a ' +
+      'session that invokes no skill never sees the rule'
+  );
+}
+
+// --- 2. Every skill is reached by the rule, one route or another. -----------
+
+let skills;
+try {
+  skills = execFileSync('git', ['ls-files', '--', '.claude/skills'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .filter((f) => f.endsWith('/SKILL.md'));
+} catch (e) {
+  console.error(`check:context7: could not list skills — ${e.message}`);
+  process.exit(1);
+}
+
+const texts = new Map(skills.map((rel) => [rel, read(rel)]));
+const routes = new Map();
+
+for (const [rel, text] of texts) {
+  if (text.includes('erg-context.md')) routes.set(rel, 'inherits');
+  else if (text.includes('Context7')) routes.set(rel, 'direct');
+}
+
+// Resolve delegation to a fixpoint so a chain of aliases still counts, and so a
+// reference cycle terminates instead of recursing.
+for (let changed = true; changed;) {
+  changed = false;
+  for (const [rel, text] of texts) {
+    if (routes.has(rel)) continue;
+    const cited = [...text.matchAll(/[\w./-]*\.claude\/skills\/\S+?SKILL\.md/g)]
+      .map((m) => m[0].replace(/^[^.]*(?=\.claude)/, ''))
+      .filter((p) => p !== rel);
+    if (cited.some((p) => routes.has(p))) {
+      routes.set(rel, 'delegates');
+      changed = true;
+    }
+  }
+}
+
+for (const rel of skills) {
+  const exemption = EXEMPT[rel];
+  if (exemption && routes.has(rel)) {
+    failures.push(
+      `${rel} is listed as exempt but is now covered (${routes.get(rel)}) — ` +
+        'delete its EXEMPT entry in web/scripts/check-context7.mjs'
+    );
+  } else if (!exemption && !routes.has(rel)) {
+    failures.push(
+      `${rel} is not reached by the Context7-first rule. Prepend ` +
+        `${CANONICAL} to its spawns, name Context7 in the file itself, or ` +
+        'add a reasoned EXEMPT entry in web/scripts/check-context7.mjs'
+    );
+  }
+}
+
+for (const rel of Object.keys(EXEMPT)) {
+  if (!skills.includes(rel)) {
+    failures.push(
+      `EXEMPT names ${rel}, which is not a tracked skill — delete the entry`
+    );
+  }
+}
+
+// --- 3. Report. -------------------------------------------------------------
+
+if (failures.length) {
+  console.error('\nContext7 guard FAILED\n');
+  for (const f of failures) console.error(`  ✗ ${f}\n`);
+  console.error(
+    'A workflow has stopped carrying the Context7-first rule.\n\n' +
+      'This guard cannot check that an agent obeyed the rule — no CI runner\n' +
+      'can see an MCP call. It checks only that the instruction is still\n' +
+      'present on every path into the repo. Restore it rather than relaxing\n' +
+      'the check: the rule going missing is how agents drift back to\n' +
+      'answering library questions from memory.\n'
+  );
+  process.exit(1);
+}
+
+const tally = [...routes.values()].reduce(
+  (acc, r) => ({ ...acc, [r]: (acc[r] ?? 0) + 1 }),
+  {}
+);
+const summary = Object.entries(tally)
+  .sort()
+  .map(([r, n]) => `${n} ${r}`)
+  .join(', ');
+const exempt = Object.keys(EXEMPT).length;
+
+console.log(
+  `check:context7: canonical block intact; ${skills.length} skill(s) reached ` +
+    `(${summary}${exempt ? `, ${exempt} exempt` : ''}).`
+);


### PR DESCRIPTION
No issue — this came straight from a `/orchestrate` request. Happy to file one
retrospectively if the board wants the row.

## What changed and why

Context7 is connected in every session, but the *rule* to reach for it lived in
one skill's persona block — five of seven workflows never carried it, and that
copy had already drifted (no `@tanstack/react-query`, ESLint or Prettier). This
states the rule once and adds a guard so it cannot rot back out.

### The rule, stated once

`.claude/skills/erg-context.md` gains a canonical *Library documentation —
Context7 first* section. It is prepended verbatim to every pipeline spawn, so
`/orchestrate`, `/feature`, `/research` and `/refactor` inherit it without
repeating it. `/daily` and `/audit` spawn no erg-context agent, so each states it
where it bites — sizing a task, naming a root cause. `/orchestrate` additionally
makes it a `Code Reviewer` criterion: flag any library API the diff relies on
that was asserted from memory.

`/research`'s duplicated list is replaced by a pointer to the canonical block —
that duplicate is what drifted.

### The guard

`npm run check:context7` (`web/scripts/check-context7.mjs`) asserts every tracked
`SKILL.md` is reached by the rule via one of four routes:

```
check:context7: canonical block intact; 7 skill(s) reached (1 delegates, 2 direct, 3 inherits, 1 exempt).
```

Coverage is transitive, so the wording stays in exactly one place, and a new
skill carrying it by no route fails on arrival. `steward/SKILL.md` is exempt with
a written reason — its own contract requires every line to be cited, attested or
a dated incident, and says general PR etiquette does not belong. A **stale**
exemption fails too, the same discipline `check:colours` applies to its
allowlist.

### Why its own workflow, not a sixth step in `Lint & Format`

`ci-web.yml`'s `changes` job filters on `web/**` (`ci-web.yml:33-36`). A PR
touching only `.claude/skills/**` or the repo-root `CLAUDE.md` skips that job
entirely, so a guard living there would never fire on the files it exists to
protect. That is the same mistake `zone-bands.yml:10-14` was written to document.
Path filtering is at the job level, so it reports `skipped` rather than nothing
and **can be made required**.

### What it deliberately cannot do

It cannot verify an agent obeyed the rule — MCP calls are invisible to a CI
runner. It guards the *instruction*, not the *obedience*. That limit is stated in
the script header, the workflow comment and `CLAUDE.md`, so a green check is not
later mistaken for compliance.

## How to test manually

```bash
node web/scripts/check-context7.mjs
```

Sabotage-tested five ways — each exits 1 with a specific message, baseline exits 0:

| Sabotage | Caught |
|---|---|
| Canonical heading deleted from `erg-context.md` | yes |
| `daily` loses its direct mention | yes |
| A new uncovered skill lands | yes |
| An exempt file becomes covered (stale entry) | yes |
| `### Context7` removed from `CLAUDE.md` | yes |

## Follow-up for the repo owner

The check reports but does **not** block until it is added to the `main` ruleset.
The check-run name is **`Context7 rule reaches every workflow`**.

Read from the ruleset itself rather than from a doc
(`gh api repos/skizzy1986/erg-dashboard/rulesets/18063518`, `updated_at`
2026-06-24, `bypass_actors: []`), the required set is currently **three**:

```
Lint & Format · Test & Coverage · Build
```

So adding this one takes it from three to four. Note that `.claude/skills/steward/SKILL.md`
currently claims nine — that file is wrong, and separately from this PR the six it lists
(`CodeQL`, `Validate PR title (Conventional Commits)`, `Review dependency changes`,
`Deno Tests`, `Zone bands match derivePaceZones`, `Build Debug APK`) are still not
required. Worth its own issue; deliberately not folded in here.

## Checklist

- [x] CI is green (lint, test, build) — verified locally; see below
- [x] Tests cover the change, or I've noted why they don't — the guard is
      sabotage-tested above rather than unit-tested; it has no `src/**` surface
      and is outside the coverage scope (`include: ['src/**']`)
- [x] `npm run build` passes locally — bundle 395.7 KB / 400 KB, unchanged
- [x] No unexpected console errors in the browser — no runtime code touched
- [x] Visual change: none
- [x] Stays inside the property boundary — no colour, box-metric or type
      properties touched

Local gates: `lint` · `check:context7` · `check:zones` · `check:colours` ·
`check:design-sync` · **990 tests pass** · `build` · `size`. `format:check`
reports 182 files in this worktree, including untouched ones — that is a CRLF
checkout against Prettier's `endOfLine: lf`, not a real failure; the new script
was verified EOL-neutral against `check-zone-bands.mjs` as a control and is
Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

