### PR TITLE
fix(steward): correct the required set, and the guard bug that correcting it exposed

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -64,26 +64,46 @@ Green is at its most misleading here.
 
 1. Report what **ran**, not what was green. Name any job that reported `skipped`.
 2. If a fact here is contradicted by the file it cites, **say so, and offer to open an issue** — do not work around it silently. You are this file's staleness sensor.
-3. Name a **required** check by name when you say a PR is blocked. Nine are required — see *What protects `main`* — so "CI is red" and "this cannot merge" are different claims. Use the **check-run name**, which is the job's `name:`, not the workflow's: the ruleset binds to `Zone bands match derivePaceZones`, and nothing reports under `Zone bands`.
+3. Name a **required** check by name when you say a PR is blocked. Ten are required — see *What protects `main`*, and read the ruleset rather than trusting that number — so "CI is red" and "this cannot merge" are different claims. Use the **check-run name**, which is the job's `name:`, not the workflow's: the ruleset binds to `Zone bands match derivePaceZones`, and nothing reports under `Zone bands`.
 
 ## What protects `main`
 
-Read from the `main` ruleset — Rulesets, **not** classic branch protection, which is
-unconfigured (— confirmed by Scott 2026-08-28 from the ruleset page itself; required set expanded
-from seven to nine later the same day). Active, targeting the default branch, with
-an **empty bypass list**, so it applies to everyone including the repo owner. No agent can
-read this: the GitHub MCP server exposes no branch-protection tool and raw API access is
-blocked from agent sessions. Re-confirm with Scott rather than inferring it from a doc.
+**Read it yourself — do not trust the table below, this file included.**
+
+```bash
+gh api repos/skizzy1986/erg-dashboard/rulesets/18063518 \
+  --jq '{updated_at, bypass: .bypass_actors, required: [.rules[]
+    | select(.type=="required_status_checks")
+    | .parameters.required_status_checks[].context]}'
+```
+
+Rulesets, **not** classic branch protection: `GET /branches/main/protection` returns 404.
+Active, targeting the default branch, `bypass_actors: []`, so it applies to everyone
+including the repo owner.
+
+**This section was wrong for three PRs, and the reason it survived is a warning about
+the whole file.** It claimed seven required checks (#316), then nine (#321) — each with a
+dated attestation citing "the ruleset page as Scott showed it". Neither was ever true: the
+ruleset had required exactly `Lint & Format`, `Test & Coverage`, `Build` since 2026-06-24
+and had not been edited since. What protected the error was a line *in this file* asserting
+that no agent could read the ruleset because raw API access is blocked from agent sessions.
+That is false in a local session — the command above works — and it told every agent not to
+look, so two concurrent sessions corroborated the assumption instead of the source
+(`CLAUDE.md`'s CI table was the only doc that matched reality). The six missing checks plus
+`Context7 rule reaches every workflow` were actually added on 2026-08-28 at 12:22 +08:00,
+which is when the table below first became true. **When this file tells you a capability is
+unavailable, test the capability before believing it: that instruction is itself the thing
+most likely to be stale.**
 
 | | |
 |---|---|
-| Required status checks | **`Lint & Format`, `Test & Coverage`, `Build`, `CodeQL`, `Validate PR title (Conventional Commits)`, `Review dependency changes`, `Deno Tests`, `Zone bands match derivePaceZones`, `Build Debug APK`** — those nine, and nothing else. |
+| Required status checks | **`Lint & Format`, `Test & Coverage`, `Build`, `CodeQL`, `Validate PR title (Conventional Commits)`, `Review dependency changes`, `Deno Tests`, `Zone bands match derivePaceZones`, `Build Debug APK`, `Context7 rule reaches every workflow`** — those ten, and nothing else. `CodeQL` is emitted by the GitHub Advanced Security app and is a **different check-run** from `codeql.yml`'s job `Analyze (JavaScript/TypeScript)`; the ruleset binds the former. |
 | Advisory — red does **not** block merge | `Lighthouse`, `Playwright Smoke`, `Playwright Visual`. Still fix them; just do not report them as blocking. |
 | Reports but is not required | `Build Web Assets`, `Seer Code Review`, `Vercel Preview Comments`, `Analyze (JavaScript/TypeScript)`, `Label by changed paths`, `add-to-project`, `Flag steward skill staleness`, `Enable auto-merge`, and every `Detect …` filter job. Red here does not block either — but see the `Build Web Assets` trap below. |
 | Also enforced | a PR before merging · branches up to date before merging · force pushes blocked **on `main` only**, so `--force-with-lease` on your own feature branch is fine |
 | Not enforced | linear history. Squash with `(#N)` is convention, not a gate. |
 
-**A required check can be satisfied by `skipped`** (`ci-web.yml:3-7`), so all nine can be
+**A required check can be satisfied by `skipped`** (`ci-web.yml:3-7`), so all ten can be
 green having run nothing — see *When every check is green*. That applies hardest to
 `Deno Tests`: it is required, but `ci-functions.yml` tests only the two `vitals-import*`
 functions, so on a `coach-chat` change it **runs, passes, and verifies nothing** (#312).
@@ -108,14 +128,30 @@ a matched path passes and the next one hangs. Both now gate a `changes` job and 
 `skipped` instead (#316, #317). Confirmed twice on 2026-08-28: PR #319, a docs-only change,
 reported `skipped` for `Build Debug APK` and `Build Web Assets` rather than nothing.
 
-`CLAUDE.md:328` still says **three** gated jobs and its table omits six of the nine; the
-`Zone bands` row it does carry is now correctly a gate (#311).
+`Context7 rule reaches every workflow` reached requirability the same way, by the same
+deliberate choice: it is its own workflow rather than a sixth step in `Lint & Format`,
+because `ci-web.yml`'s `changes` job filters on `web/**` (`ci-web.yml:33-36`) and the files
+it guards live in `.claude/skills/**` and the repo-root `CLAUDE.md` (#325). Verified running
+— not skipping — on that PR.
+
+`CLAUDE.md`'s CI table still opens by saying **three** gated jobs, and lists fewer rows than
+the required set; the `Zone bands` row it does carry is now correctly a gate (#311).
 
 ## Verified against
 
 `21370e8` on 2026-08-26, against `.github/workflows/{ci-web,ci-functions,ci-android,e2e-web,zone-bands,dependabot-auto-merge,dependabot-maintenance}.yml`,
 `web/scripts/check-{colour-literals,design-sync-entry,zone-bands,bundle-size}.mjs`, `web/vite.config.js`.
 
-*What protects `main`* re-verified on 2026-08-28 at `5479e21`, against `ci-android.yml` as
-converted by #317 and against the ruleset page as Scott showed it after adding the two checks.
-If one of those has changed since, treat the lines citing it as unverified and re-check that row.
+*What protects `main`* re-verified on 2026-08-28 at `6ac5188`, against `ci-android.yml` as
+converted by #317, `.github/workflows/context7-rule.yml` as added by #325, and — for the
+required set — **the ruleset API itself**, not a screenshot and not a person's recollection:
+
+```
+GET /repos/skizzy1986/erg-dashboard/rulesets/18063518
+  → updated_at 2026-08-28T12:22:08.154+08:00, bypass_actors [], enforcement active
+  → 10 required contexts, as listed above
+```
+
+That distinction is the point of this revision: the previous two attestations here cited the
+ruleset *page* and were both wrong. Re-run the command rather than trusting the timestamp —
+the ruleset is edited outside this repo, so nothing in git can tell you it moved.

--- a/web/scripts/check-context7.mjs
+++ b/web/scripts/check-context7.mjs
@@ -16,7 +16,7 @@
 //
 //   canonical  .claude/skills/erg-context.md holds the wording
 //   inherits   the skill prepends erg-context.md to its spawns
-//   direct     the skill names Context7 itself (skills that spawn no agents)
+//   direct     the skill names the lookup itself (skills that spawn no agents)
 //   delegates  the skill points at another SKILL.md that is covered
 //   exempt     listed below with a reason, and fails if it becomes covered
 //
@@ -95,9 +95,15 @@ try {
 const texts = new Map(skills.map((rel) => [rel, read(rel)]));
 const routes = new Map();
 
+// `direct` requires the lookup tool, NOT the bare word "Context7". The word
+// alone is not coverage: steward/SKILL.md names the required check-run
+// `Context7 rule reaches every workflow` without stating the rule, and a
+// substring test on the word scored that as covered — turning a valid
+// exemption into a false stale-exemption failure on #328. A skill carries the
+// rule only if it tells you what to actually call.
 for (const [rel, text] of texts) {
   if (text.includes('erg-context.md')) routes.set(rel, 'inherits');
-  else if (text.includes('Context7')) routes.set(rel, 'direct');
+  else if (text.includes(TOOLS[0])) routes.set(rel, 'direct');
 }
 
 // Resolve delegation to a fixpoint so a chain of aliases still counts, and so a
@@ -126,8 +132,9 @@ for (const rel of skills) {
   } else if (!exemption && !routes.has(rel)) {
     failures.push(
       `${rel} is not reached by the Context7-first rule. Prepend ` +
-        `${CANONICAL} to its spawns, name Context7 in the file itself, or ` +
-        'add a reasoned EXEMPT entry in web/scripts/check-context7.mjs'
+        `${CANONICAL} to its spawns, name \`${TOOLS[0]}\` in the file ` +
+        'itself, or add a reasoned EXEMPT entry in ' +
+        'web/scripts/check-context7.mjs'
     );
   }
 }


### PR DESCRIPTION
Follow-up to #325 (now merged). No issue — surfaced while stewarding that PR,
which is exactly what rule 2 of *When you report back* asks an agent to do.

> **Update after rebase onto merged #325.** This PR now carries a second commit:
> the Context7 guard flagged *this very change*, and it was right to look but
> wrong about why. Details in **Second commit** below.

## First commit — `docs(steward): correct the required set — read the ruleset API, not the page`

**The required-check set in `steward/SKILL.md` was wrong, and had been for three
PRs.** It claimed seven (#316), then nine (#321), each with a dated attestation
citing "the ruleset page as Scott showed it". Neither was ever true — the ruleset
had required exactly three checks since 2026-06-24 and had not been edited since:

```
GET /repos/skizzy1986/erg-dashboard/rulesets/18063518
  → ["Lint & Format", "Test & Coverage", "Build"]
  → updated_at 2026-06-24T16:35:12   (read twice, ten minutes apart)
```

The interesting part is **why it survived**. This same file said:

> No agent can read this: the GitHub MCP server exposes no branch-protection tool
> and raw API access is blocked from agent sessions.

That is false in a local session — `gh api …/rulesets/18063518` works — and it
told every agent not to look. So sessions corroborated each other's assumption
instead of checking the source. `CLAUDE.md`'s CI table was the only doc that
matched reality.

This commit:

1. **Replaces the unreadable-by-agents claim with the command that reads it**, and
   leads the section with *"read it yourself — do not trust the table below, this
   file included."*
2. **Records the incident.** A file whose entire contract is that every line is
   cited, attested, or a dated incident should carry its own worst failure — and
   the generalisable lesson is sharp: *when this file tells you a capability is
   unavailable, test the capability before believing it; that instruction is
   itself the thing most likely to be stale.*
3. **Corrects the set to ten.** Scott added the six missing checks plus
   `Context7 rule reaches every workflow` on 2026-08-28 at 12:22 +08:00 — which is
   when the table first became true. Also notes that `CodeQL` is emitted by the
   GitHub Advanced Security app and is a **different check-run** from `codeql.yml`'s
   job `Analyze (JavaScript/TypeScript)`; the ruleset binds the former.
4. **Re-attests against the API response** — `updated_at`, `bypass_actors`,
   `enforcement` — not a screenshot, and says to re-run rather than trust the
   timestamp: the ruleset is edited outside this repo, so nothing in git can tell
   you it moved.
5. Notes why `Context7 rule reaches every workflow` is its own workflow rather
   than a step in `Lint & Format`.

## Second commit — `fix(ci): match the Context7 rule by its lookup tool, not the bare word`

Correcting the required set necessarily made `steward/SKILL.md` mention
`Context7 rule reaches every workflow` — the **name of the required check-run**.
The guard's `direct` coverage route tested `text.includes('Context7')`, scored the
file as covered, collided that with its `EXEMPT` entry, and failed as a stale
exemption:

```
✗ .claude/skills/steward/SKILL.md is listed as exempt but is now covered (direct)
  — delete its EXEMPT entry in web/scripts/check-context7.mjs
```

**The exemption was not stale.** `steward` still does not carry the rule and
should not — it names a check, not a lookup. The defect was the predicate: a bare
substring on the word "Context7" is not coverage, it is a word.

`direct` is now keyed on the lookup tool. A skill carries the rule only if it
tells you what to actually call:

| skill | says `Context7` | says `resolve-library-id` | route |
|---|---|---|---|
| `daily`, `audit` | yes | yes | `direct` |
| `steward` | yes | **no** | `exempt`, correctly |

Routing is unchanged — `1 delegates, 2 direct, 3 inherits, 1 exempt` — and the
failure message now names the tool to add rather than the word. Re-sabotaged:
stripping `resolve-library-id` from `daily` still fails with

```
✗ … is not reached by the Context7-first rule. Prepend …/erg-context.md to its
  spawns, name `resolve-library-id` in the file itself, or add a reasoned EXEMPT entry
```

Worth saying plainly: the guard caught a real ambiguity in its own definition of
coverage on the second change it ever saw. That is the check working, not
misfiring.

## How to test manually

```bash
gh api repos/skizzy1986/erg-dashboard/rulesets/18063518 --jq '{updated_at, bypass: .bypass_actors, required: [.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context]}'
```

Should return ten contexts, `bypass_actors: []`, `updated_at` 2026-08-28T12:22:08.
If it does not, this file is stale again — and the whole point of the change is
that you find that out by running the command rather than by reading the table.

```bash
node web/scripts/check-context7.mjs
```

## Checklist

- [x] CI is green (lint, test, build)
- [x] Tests cover the change, or I've noted why they don't — the doc claims are
      verified against the live ruleset API, quoted above; the guard change is
      sabotage-tested rather than unit-tested and is outside the coverage scope
      (`include: ['src/**']`)
- [x] `npm run build` passes locally — pre-push hook ran the full Vitest suite
- [x] No unexpected console errors in the browser — no runtime code touched
- [x] Visual change: none
- [x] Stays inside the property boundary — no colour, box-metric or type
      properties touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
